### PR TITLE
Core, VideoCommon: Fix crash at shutdown due to destructor order

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -167,7 +167,7 @@ using StateChangedCallbackFunc = std::function<void(Core::State)>;
 int AddOnStateChangedCallback(StateChangedCallbackFunc callback);
 // Also invalidates the handle
 bool RemoveOnStateChangedCallback(int* handle);
-void CallOnStateChangedCallbacks(Core::State state);
+void NotifyStateChanged(Core::State state);
 
 // Run on the Host thread when the factors change. [NOT THREADSAFE]
 void UpdateWantDeterminism(Core::System& system, bool initial = false);

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -348,7 +348,7 @@ void CPUManager::Break()
 void CPUManager::Continue()
 {
   SetStepping(false);
-  Core::CallOnStateChangedCallbacks(Core::State::Running);
+  Core::NotifyStateChanged(Core::State::Running);
 }
 
 bool CPUManager::PauseAndLock(bool do_lock, bool unpause_on_unlock, bool control_adjacent)

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -868,7 +868,7 @@ static void Step()
 {
   auto& system = Core::System::GetInstance();
   system.GetCPU().SetStepping(true);
-  Core::CallOnStateChangedCallbacks(Core::State::Paused);
+  Core::NotifyStateChanged(Core::State::Paused);
 }
 
 static bool AddBreakpoint(BreakpointType type, u32 addr, u32 len)

--- a/Source/Core/VideoCommon/PerformanceMetrics.cpp
+++ b/Source/Core/VideoCommon/PerformanceMetrics.cpp
@@ -35,6 +35,12 @@ void PerformanceMetrics::CountVBlank()
   m_vps_counter.Count();
 }
 
+void PerformanceMetrics::OnEmulationStateChanged([[maybe_unused]] Core::State state)
+{
+  m_fps_counter.InvalidateLastTime();
+  m_vps_counter.InvalidateLastTime();
+}
+
 void PerformanceMetrics::CountThrottleSleep(DT sleep)
 {
   m_time_sleeping += sleep;

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -7,6 +7,7 @@
 #include <deque>
 
 #include "Common/CommonTypes.h"
+#include "Core/Core.h"
 #include "VideoCommon/PerformanceTracker.h"
 
 namespace Core
@@ -29,6 +30,7 @@ public:
 
   void CountFrame();
   void CountVBlank();
+  void OnEmulationStateChanged(Core::State state);
 
   // Call from CPU thread.
   void CountThrottleSleep(DT sleep);

--- a/Source/Core/VideoCommon/PerformanceTracker.cpp
+++ b/Source/Core/VideoCommon/PerformanceTracker.cpp
@@ -23,15 +23,7 @@ PerformanceTracker::PerformanceTracker(const std::optional<std::string> log_name
                                        const std::optional<DT> sample_window_duration)
     : m_log_name{log_name}, m_sample_window_duration{sample_window_duration}
 {
-  m_on_state_changed_handle =
-      Core::AddOnStateChangedCallback([this](Core::State state) { m_is_last_time_sane = false; });
-
   Reset();
-}
-
-PerformanceTracker::~PerformanceTracker()
-{
-  Core::RemoveOnStateChangedCallback(&m_on_state_changed_handle);
 }
 
 void PerformanceTracker::Reset()
@@ -133,6 +125,11 @@ DT PerformanceTracker::GetDtStd() const
 DT PerformanceTracker::GetLastRawDt() const
 {
   return m_last_raw_dt;
+}
+
+void PerformanceTracker::InvalidateLastTime()
+{
+  m_is_last_time_sane = false;
 }
 
 void PerformanceTracker::ImPlotPlotLines(const char* label) const

--- a/Source/Core/VideoCommon/PerformanceTracker.h
+++ b/Source/Core/VideoCommon/PerformanceTracker.h
@@ -16,7 +16,7 @@ class PerformanceTracker
 public:
   PerformanceTracker(const std::optional<std::string> log_name = std::nullopt,
                      const std::optional<DT> sample_window_duration = std::nullopt);
-  ~PerformanceTracker();
+  ~PerformanceTracker() = default;
 
   PerformanceTracker(const PerformanceTracker&) = delete;
   PerformanceTracker& operator=(const PerformanceTracker&) = delete;
@@ -39,6 +39,7 @@ public:
   DT GetDtAvg() const;
   DT GetDtStd() const;
   DT GetLastRawDt() const;
+  void InvalidateLastTime();
 
 private:
   void LogRenderTimeToFile(DT val);
@@ -46,8 +47,6 @@ private:
   void HandleRawDt(DT value);
   void PushFront(DT value);
   void PopBack();
-
-  int m_on_state_changed_handle;
 
   // Name of log file and file stream
   std::optional<std::string> m_log_name;


### PR DESCRIPTION
libvideocommon instantiates the g_perf_metrics variable, which contains PerformanceTracker objects.
The destructors for these objects modify the s_on_state_changed_callbacks vector, which lives in libcore.
This means libvideocommon must be torn down before libcore. However, libcore's functions need g_perf_metrics, so libcore needs libvideocommon to be loaded.
Break the dependency cycle by moving g_perf_metrics to libcore.
This fixes a segmentation fault with LTO enabled.