### PR TITLE
DiscIO: Make variables constexpr

### DIFF
--- a/Source/Core/DiscIO/CISOBlob.h
+++ b/Source/Core/DiscIO/CISOBlob.h
@@ -15,8 +15,8 @@ namespace DiscIO
 {
 static constexpr u32 CISO_MAGIC = 0x4F534943;  // "CISO" (byteswapped to little endian)
 
-static const u32 CISO_HEADER_SIZE = 0x8000;
-static const u32 CISO_MAP_SIZE = CISO_HEADER_SIZE - sizeof(u32) - sizeof(char) * 4;
+static constexpr u32 CISO_HEADER_SIZE = 0x8000;
+static constexpr u32 CISO_MAP_SIZE = CISO_HEADER_SIZE - sizeof(u32) - sizeof(char) * 4;
 
 struct CISOHeader
 {
@@ -53,7 +53,7 @@ private:
   CISOFileReader(File::IOFile file);
 
   typedef u16 MapType;
-  static const MapType UNUSED_BLOCK_ID = UINT16_MAX;
+  static constexpr MapType UNUSED_BLOCK_ID = UINT16_MAX;
 
   File::IOFile m_file;
   u64 m_size;

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -247,7 +247,7 @@ FileSystemGCWii::FileSystemGCWii(const VolumeDisc* volume, const Partition& part
 
   // 128 MiB is more than the total amount of RAM in a Wii.
   // No file system should use anywhere near that much.
-  static const u32 ARBITRARY_FILE_SYSTEM_SIZE_LIMIT = 128 * 1024 * 1024;
+  static constexpr u32 ARBITRARY_FILE_SYSTEM_SIZE_LIMIT = 128 * 1024 * 1024;
   if (*fst_size > ARBITRARY_FILE_SYSTEM_SIZE_LIMIT)
   {
     // Without this check, Dolphin can crash by trying to allocate too much

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -162,11 +162,11 @@ protected:
   virtual u32 GetOffsetShift() const { return 0; }
   static std::map<Language, std::string> ReadWiiNames(const std::vector<char16_t>& data);
 
-  static const size_t NUMBER_OF_LANGUAGES = 10;
-  static const size_t NAME_CHARS_LENGTH = 42;
-  static const size_t NAME_BYTES_LENGTH = NAME_CHARS_LENGTH * sizeof(char16_t);
-  static const size_t NAMES_TOTAL_CHARS = NAME_CHARS_LENGTH * NUMBER_OF_LANGUAGES;
-  static const size_t NAMES_TOTAL_BYTES = NAME_BYTES_LENGTH * NUMBER_OF_LANGUAGES;
+  static constexpr size_t NUMBER_OF_LANGUAGES = 10;
+  static constexpr size_t NAME_CHARS_LENGTH = 42;
+  static constexpr size_t NAME_BYTES_LENGTH = NAME_CHARS_LENGTH * sizeof(char16_t);
+  static constexpr size_t NAMES_TOTAL_CHARS = NAME_CHARS_LENGTH * NUMBER_OF_LANGUAGES;
+  static constexpr size_t NAMES_TOTAL_BYTES = NAME_BYTES_LENGTH * NUMBER_OF_LANGUAGES;
 
   static const IOS::ES::TicketReader INVALID_TICKET;
   static const IOS::ES::TMDReader INVALID_TMD;

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -53,8 +53,8 @@ public:
   std::array<u8, 20> GetSyncHash() const override;
 
 private:
-  static const u32 GC_BANNER_WIDTH = 96;
-  static const u32 GC_BANNER_HEIGHT = 32;
+  static constexpr u32 GC_BANNER_WIDTH = 96;
+  static constexpr u32 GC_BANNER_HEIGHT = 32;
 
   struct GCBannerInformation
   {
@@ -95,8 +95,8 @@ private:
   ConvertedGCBanner LoadBannerFile() const;
   ConvertedGCBanner ExtractBannerInformation(const GCBanner& banner_file, bool is_bnr1) const;
 
-  static const size_t BNR1_SIZE = sizeof(GCBanner) - sizeof(GCBannerInformation) * 5;
-  static const size_t BNR2_SIZE = sizeof(GCBanner);
+  static constexpr size_t BNR1_SIZE = sizeof(GCBanner) - sizeof(GCBannerInformation) * 5;
+  static constexpr size_t BNR2_SIZE = sizeof(GCBanner);
 
   Common::Lazy<ConvertedGCBanner> m_converted_banner;
 

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -20,9 +20,9 @@
 
 namespace DiscIO
 {
-static const u64 WII_SECTOR_SIZE = 0x8000;
-static const u64 WII_SECTOR_COUNT = 143432 * 2;
-static const u64 WII_DISC_HEADER_SIZE = 256;
+static constexpr u64 WII_SECTOR_SIZE = 0x8000;
+static constexpr u64 WII_SECTOR_COUNT = 143432 * 2;
+static constexpr u64 WII_DISC_HEADER_SIZE = 256;
 
 WbfsFileReader::WbfsFileReader(File::IOFile file, const std::string& path)
     : m_size(0), m_good(false)


### PR DESCRIPTION
This pull request updates several constants across the `DiscIO` module to use `constexpr` instead of `const`. This change ensures that these constants are evaluated at compile time, improving performance and aligning with modern C++ best practices. The changes are primarily focused on improving code consistency and maintainability.