### PR TITLE
DiscIO: Use `= default` to define a trivial destructor

### DIFF
--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -78,9 +78,7 @@ void SectorReader::SetChunkSize(int block_cnt)
   SetSectorSize(m_block_size);
 }
 
-SectorReader::~SectorReader()
-{
-}
+SectorReader::~SectorReader() = default;
 
 const SectorReader::Cache* SectorReader::FindCacheLine(u64 block_num)
 {

--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -61,7 +61,7 @@ std::string GetName(BlobType blob_type, bool translate);
 class BlobReader
 {
 public:
-  virtual ~BlobReader() {}
+  virtual ~BlobReader() = default;
 
   virtual BlobType GetBlobType() const = 0;
   virtual std::unique_ptr<BlobReader> CopyReader() const = 0;

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -70,9 +70,7 @@ std::unique_ptr<CompressedBlobReader> CompressedBlobReader::Create(File::IOFile 
   return nullptr;
 }
 
-CompressedBlobReader::~CompressedBlobReader()
-{
-}
+CompressedBlobReader::~CompressedBlobReader() = default;
 
 std::unique_ptr<BlobReader> CompressedBlobReader::CopyReader() const
 {

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -41,9 +41,7 @@ VolumeGC::VolumeGC(std::unique_ptr<BlobReader> reader) : m_reader(std::move(read
   m_converted_banner = [this] { return LoadBannerFile(); };
 }
 
-VolumeGC::~VolumeGC()
-{
-}
+VolumeGC::~VolumeGC() = default;
 
 bool VolumeGC::Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const
 {

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -159,9 +159,7 @@ VolumeWii::VolumeWii(std::unique_ptr<BlobReader> reader)
   }
 }
 
-VolumeWii::~VolumeWii()
-{
-}
+VolumeWii::~VolumeWii() = default;
 
 bool VolumeWii::Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const
 {

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -44,9 +44,7 @@ WbfsFileReader::WbfsFileReader(File::IOFile file, const std::string& path)
     m_wlba_table[i] = Common::swap16(m_wlba_table[i]);
 }
 
-WbfsFileReader::~WbfsFileReader()
-{
-}
+WbfsFileReader::~WbfsFileReader() = default;
 
 std::unique_ptr<BlobReader> WbfsFileReader::CopyReader() const
 {


### PR DESCRIPTION
This pull request refactors multiple destructor definitions across classes in the DiscIO directory by replacing empty destructor implementations with `= default`. This change simplifies the codebase and improves maintainability without altering functionality.