### PR TITLE
[RFC] winupdater: workaround vcruntime version issues

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -333,7 +333,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 if(WIN32)
-  target_sources(common PRIVATE HRWrap.h HRWrap.cpp)
+  target_sources(common PRIVATE
+    VCRuntimeUpdater.h
+    VCRuntimeUpdater.cpp
+    HRWrap.h
+    HRWrap.cpp
+    PEVersion.h
+    PEVersion.cpp
+  )
 endif()
 
 if(USE_UPNP)

--- a/Source/Core/Common/HttpRequest.h
+++ b/Source/Core/Common/HttpRequest.h
@@ -48,6 +48,7 @@ public:
   s32 GetLastResponseCode() const;
   std::string EscapeComponent(const std::string& string);
   std::string GetHeaderValue(std::string_view name) const;
+  std::optional<std::chrono::system_clock::time_point> GetModifiedTime(const std::string& url);
   Response Get(const std::string& url, const Headers& headers = {},
                AllowedReturnCodes codes = AllowedReturnCodes::Ok_Only);
   Response Post(const std::string& url, const std::vector<u8>& payload, const Headers& headers = {},

--- a/Source/Core/Common/PEVersion.cpp
+++ b/Source/Core/Common/PEVersion.cpp
@@ -1,0 +1,60 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <Windows.h>
+
+#include <limits>
+
+#include "Common/PEVersion.h"
+#include "Common/StringUtil.h"
+
+#pragma comment(lib, "version.lib")
+
+std::optional<PEVersion> PEVersion::from_u32(u32 major, u32 minor, u32 build, u32 qfe)
+{
+  const auto max = std::numeric_limits<u16>::max();
+  if (major > max || minor > max || build > max || qfe > max)
+    return {};
+  return PEVersion{.major = static_cast<u16>(major),
+                   .minor = static_cast<u16>(minor),
+                   .build = static_cast<u16>(build),
+                   .qfe = static_cast<u16>(qfe)};
+}
+
+std::optional<PEVersion> PEVersion::from_string(const std::string& str)
+{
+  auto components = SplitString(str, '.');
+  // Allow variable number of components, but not empty.
+  if (components.size() == 0)
+    return {};
+  PEVersion version;
+  if (!TryParse(components[0], &version.major, 10))
+    return {};
+  if (components.size() > 1 && !TryParse(components[1], &version.minor, 10))
+    return {};
+  if (components.size() > 2 && !TryParse(components[2], &version.build, 10))
+    return {};
+  if (components.size() > 3 && !TryParse(components[3], &version.qfe, 10))
+    return {};
+  return version;
+}
+
+std::optional<PEVersion> PEVersion::from_file(const std::filesystem::path& path)
+{
+  DWORD handle;
+  DWORD data_len = GetFileVersionInfoSizeW(path.c_str(), &handle);
+  if (!data_len)
+    return {};
+  std::vector<u8> block(data_len);
+  if (!GetFileVersionInfoW(path.c_str(), 0, data_len, block.data()))
+    return {};
+  void* buf;
+  UINT buf_len;
+  if (!VerQueryValueW(block.data(), LR"(\)", &buf, &buf_len))
+    return {};
+  auto info = static_cast<VS_FIXEDFILEINFO*>(buf);
+  return PEVersion{.major = static_cast<u16>(info->dwFileVersionMS >> 16),
+                   .minor = static_cast<u16>(info->dwFileVersionMS),
+                   .build = static_cast<u16>(info->dwFileVersionLS >> 16),
+                   .qfe = static_cast<u16>(info->dwFileVersionLS)};
+}

--- a/Source/Core/Common/PEVersion.h
+++ b/Source/Core/Common/PEVersion.h
@@ -1,0 +1,37 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <filesystem>
+#include <fmt/format.h>
+#include <optional>
+#include <string>
+
+#include "Common/CommonTypes.h"
+
+struct PEVersion
+{
+  auto operator<=>(PEVersion const& rhs) const = default;
+
+  static std::optional<PEVersion> from_u32(u32 major, u32 minor, u32 build, u32 qfe = 0);
+  static std::optional<PEVersion> from_string(const std::string& str);
+  static std::optional<PEVersion> from_file(const std::filesystem::path& path);
+
+  u16 major;
+  u16 minor;
+  u16 build;
+  u16 qfe;
+};
+
+template <>
+struct fmt::formatter<PEVersion>
+{
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const PEVersion& version, FormatContext& ctx) const
+  {
+    return fmt::format_to(ctx.out(), "{}.{}.{}.{}", version.major, version.minor, version.build,
+                          version.qfe);
+  }
+};

--- a/Source/Core/Common/VCRuntimeUpdater.cpp
+++ b/Source/Core/Common/VCRuntimeUpdater.cpp
@@ -1,0 +1,158 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <Windows.h>
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+#include "Common/HttpRequest.h"
+#include "Common/IOFile.h"
+#include "Common/Logging/Log.h"
+#include "Common/PEVersion.h"
+#include "Common/StringUtil.h"
+#include "Common/VCRuntimeUpdater.h"
+#include "Common/WindowsRegistry.h"
+
+// This default value should be kept in sync with the value of VCToolsUpdateURL in
+// build_info.txt.in
+static const char* VCToolsUpdateURLDefault = "https://aka.ms/vs/17/release/vc_redist.x64.exe";
+
+#define VC_RUNTIME_REGKEY R"(SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\)"
+
+static const char* VCRuntimeRegistrySubkey()
+{
+  return VC_RUNTIME_REGKEY
+#ifdef _M_X86_64
+      "x64";
+#elif _M_ARM_64
+      "arm64";
+#else
+#error unsupported architecture
+#endif
+}
+
+static bool ReadVCRuntimeVersionField(u32* value, const char* name)
+{
+  return WindowsRegistry::ReadValue(value, VCRuntimeRegistrySubkey(), name);
+}
+
+VCRuntimeUpdater::VCRuntimeUpdater()
+{
+  // Cached installer is kept in current directory
+  redist_path = std::filesystem::current_path() / L"vc_redist.17.x64.exe";
+}
+
+std::optional<PEVersion> VCRuntimeUpdater::GetInstalledVersion()
+{
+  u32 installed;
+  if (!ReadVCRuntimeVersionField(&installed, "Installed") || !installed)
+    return {};
+
+  u32 major{};
+  u32 minor{};
+  u32 build{};
+  if (!ReadVCRuntimeVersionField(&major, "Major") || !ReadVCRuntimeVersionField(&minor, "Minor") ||
+      !ReadVCRuntimeVersionField(&build, "Bld"))
+  {
+    return {};
+  }
+  return PEVersion::from_u32(major, minor, build);
+}
+
+bool VCRuntimeUpdater::InstalledVersionIsOutdated()
+{
+  if (!CacheSync())
+  {
+    // If we can't download the file we won't be able to run it, so cause the exec to be skipped.
+    NOTICE_LOG_FMT(COMMON, "Failed to cache vcruntime installer. Bypass version check.");
+    return false;
+  }
+
+  auto installed_version = GetInstalledVersion();
+  if (!installed_version)
+    return true;
+
+  auto cache_version = PEVersion::from_file(redist_path);
+  if (!cache_version)
+    return true;
+  NOTICE_LOG_FMT(COMMON, "vcruntime version installed: {} cache: {}", *installed_version,
+                 *cache_version);
+  return installed_version < cache_version;
+}
+
+bool VCRuntimeUpdater::DownloadAndRun(const std::optional<std::string>& url, bool quiet)
+{
+  if (!CacheSync(url))
+    return false;
+  return Run(quiet);
+}
+
+bool VCRuntimeUpdater::CacheNeedsSync(const std::string& url)
+{
+  std::error_code ec;
+  auto cache_mtime = std::chrono::clock_cast<std::chrono::system_clock>(
+      std::filesystem::last_write_time(redist_path, ec));
+  if (ec)
+    return true;
+
+  Common::HttpRequest req;
+  req.FollowRedirects(10);
+  auto remote_mtime = req.GetModifiedTime(url);
+  if (!remote_mtime)
+    return false;
+
+  return cache_mtime < remote_mtime;
+}
+
+bool VCRuntimeUpdater::CacheSync(const std::optional<std::string>& url)
+{
+  auto redist_url = url.value_or(VCToolsUpdateURLDefault);
+  if (!CacheNeedsSync(redist_url))
+  {
+    return true;
+  }
+
+  Common::HttpRequest req;
+  req.FollowRedirects(10);
+  auto resp = req.Get(redist_url);
+  if (!resp)
+    return false;
+
+  auto redist_path_u8 = WStringToUTF8(redist_path.wstring());
+  File::IOFile redist_file;
+  redist_file.Open(redist_path_u8, "wb");
+  return redist_file.WriteBytes(resp->data(), resp->size());
+}
+
+bool VCRuntimeUpdater::Run(bool quiet)
+{
+  // The installer also supports /passive and /quiet. We normally pass neither (the
+  // exception being test automation) to allow the user to see and interact with the installer.
+  std::wstring cmdline = redist_path.filename().wstring() + L" /install /norestart";
+  if (quiet)
+    cmdline += L" /passive /quiet";
+
+  STARTUPINFOW startup_info{.cb = sizeof(startup_info)};
+  PROCESS_INFORMATION process_info;
+  if (!CreateProcessW(redist_path.c_str(), cmdline.data(), nullptr, nullptr, TRUE, 0, nullptr,
+                      nullptr, &startup_info, &process_info))
+  {
+    return false;
+  }
+  CloseHandle(process_info.hThread);
+
+  // Wait for it to run
+  WaitForSingleObject(process_info.hProcess, INFINITE);
+  DWORD exit_code;
+  bool has_exit_code = GetExitCodeProcess(process_info.hProcess, &exit_code);
+  CloseHandle(process_info.hProcess);
+  // NOTE: Some nonzero exit codes can still be considered success (e.g. if installation was
+  // bypassed because the same version already installed).
+  auto ok =
+      has_exit_code && (exit_code == ERROR_SUCCESS || exit_code == ERROR_SUCCESS_REBOOT_REQUIRED);
+  if (!ok && has_exit_code)
+    NOTICE_LOG_FMT(COMMON, "vcruntime installer returned:{}", exit_code);
+  return ok;
+}

--- a/Source/Core/Common/VCRuntimeUpdater.h
+++ b/Source/Core/Common/VCRuntimeUpdater.h
@@ -1,0 +1,25 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "Common/PEVersion.h"
+
+class VCRuntimeUpdater
+{
+public:
+  VCRuntimeUpdater();
+  static std::optional<PEVersion> GetInstalledVersion();
+  bool InstalledVersionIsOutdated();
+  bool DownloadAndRun(const std::optional<std::string>& url = {}, bool quiet = false);
+  bool Run(bool quiet = false);
+
+private:
+  bool CacheNeedsSync(const std::string& url);
+  bool CacheSync(const std::optional<std::string>& url = {});
+
+  std::filesystem::path redist_path;
+};

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -142,6 +142,7 @@
     <ClInclude Include="Common\NandPaths.h" />
     <ClInclude Include="Common\Network.h" />
     <ClInclude Include="Common\PcapFile.h" />
+    <ClInclude Include="Common\PEVersion.h" />
     <ClInclude Include="Common\Profiler.h" />
     <ClInclude Include="Common\Projection.h" />
     <ClInclude Include="Common\QoSSession.h" />
@@ -170,6 +171,7 @@
     <ClInclude Include="Common\Unreachable.h" />
     <ClInclude Include="Common\UPnP.h" />
     <ClInclude Include="Common\VariantUtil.h" />
+    <ClInclude Include="Common\VCRuntimeUpdater.h" />
     <ClInclude Include="Common\Version.h" />
     <ClInclude Include="Common\WindowsRegistry.h" />
     <ClInclude Include="Common\WindowSystemInfo.h" />
@@ -827,6 +829,7 @@
     <ClCompile Include="Common\NandPaths.cpp" />
     <ClCompile Include="Common\Network.cpp" />
     <ClCompile Include="Common\PcapFile.cpp" />
+    <ClCompile Include="Common\PEVersion.cpp" />
     <ClCompile Include="Common\Profiler.cpp" />
     <ClCompile Include="Common\QoSSession.cpp" />
     <ClCompile Include="Common\Random.cpp" />
@@ -842,6 +845,7 @@
     <ClCompile Include="Common\TraversalClient.cpp" />
     <ClCompile Include="Common\UPnP.cpp" />
     <ClCompile Include="Common\WindowsRegistry.cpp" />
+    <ClCompile Include="Common\VCRuntimeUpdater.cpp" />
     <ClCompile Include="Common\Version.cpp" />
     <ClCompile Include="Core\AchievementManager.cpp" />
     <ClCompile Include="Core\ActionReplay.cpp" />

--- a/Tools/test-updater.py
+++ b/Tools/test-updater.py
@@ -137,6 +137,13 @@ if __name__ == "__main__":
                 "AutoUpdate": {"UpdateTrack": "updater-test"},
             },
         )
+        create_entries_in_ini(
+            tmp_dolphin.joinpath("User/Config/Logger.ini"),
+            {
+                "Logs": {"COMMON": "True"},
+                "Options": {"Verbosity": "2", "WriteToFile": "True"},
+            },
+        )
 
         tmp_dolphin_next = tmp_dir.joinpath("dolphin_next")
         print(f"install next to {tmp_dolphin_next}")
@@ -162,7 +169,7 @@ if __name__ == "__main__":
         tmp_env = os.environ
         tmp_env.update({"DOLPHIN_UPDATE_SERVER_URL": DOLPHIN_UPDATE_SERVER_URL})
         tmp_dolphin_bin = tmp_dolphin.joinpath(dolphin_bin_path.name)
-        result = subprocess.run(tmp_dolphin_bin, env=tmp_env)
+        result = subprocess.run(tmp_dolphin_bin, env=tmp_env, cwd=tmp_dolphin)
         assert result.returncode == 0
 
         assert HTTPRequestHandler.done.wait(60 * 2)
@@ -197,5 +204,6 @@ if __name__ == "__main__":
                 continue
         assert not failed
 
-        print(tmp_dolphin.joinpath("User/Logs/Updater.log").read_text())
+        print(tmp_dolphin.joinpath("User/Logs/dolphin.log").read_text(encoding='utf-8'))
+        print(tmp_dolphin.joinpath("User/Logs/Updater.log").read_text(encoding='utf-8'))
         # while True: time.sleep(1)


### PR DESCRIPTION
Dolphin will now try to update vcruntime before Updater runs. This ensures even if "next" Updater relies on binary-incompatible version of vcruntime (compared to "current" Dolphin), it will still work.

Dolphin keeps cached copy of the vcruntime installer and compares mtime against the MS-hosted file to determine if there's an update to download.