### PR TITLE
Update imgui_demo.cpp

### DIFF
--- a/Externals/imgui/imgui_demo.cpp
+++ b/Externals/imgui/imgui_demo.cpp
@@ -3080,7 +3080,10 @@ struct ExampleDualListBox
     {
         const int* a = (const int*)lhs;
         const int* b = (const int*)rhs;
-        return (*a - *b) > 0 ? +1 : -1;
+        if (*a != *b){
+          return (*a - *b) > 0 ? +1 : -1;
+          }
+        return 0;
     }
     void SortItems(int n)
     {


### PR DESCRIPTION
Qsort callback CompareItemsByValue may return false result when input structs have all compared fields equal. This in turn may causes inconsistent order or even crashes in some qsort implementations.