### PR TITLE
AchievementManager: Always allow pausing if game not loaded

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -314,6 +314,8 @@ void AchievementManager::DoFrame()
 
 bool AchievementManager::CanPause()
 {
+  if (!IsGameLoaded())
+    return true;
   u32 frames_to_next_pause = 0;
   bool can_pause = rc_client_can_pause(m_client, &frames_to_next_pause);
   if (!can_pause)


### PR DESCRIPTION
In Achievement Manager, RetroAchievements disables pausing too frequently when running but there's no sense of doing this if RetroAchievements does not currently have a game running.