### PR TITLE
LibusbDevice: Don't claim interfaces on windows or macOS

### DIFF
--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -438,6 +438,10 @@ static int DoForEachInterface(const Configs& configs, u8 config_num, Function ac
 
 int LibusbDevice::ClaimAllInterfaces(u8 config_num) const
 {
+  // On windows claiming fails for composite usb devices. Detaching also doesn't do anything on windows either.
+#ifdef _WIN32
+  return LIBUSB_SUCCESS;
+#endif
   const int ret = DoForEachInterface(m_config_descriptors, config_num, [this](u8 i) {
   // On macos detaching would fail without root or entitlement.
   // We assume user is using GCAdapterDriver and therefore don't want to detach anything


### PR DESCRIPTION
I was trying to use some composite usb devices with dolphin, and found that dolphin was having issues opening them. I was doing a comparison between dolphin and rpcs3, since my devices were working there and I realised that RPCS3 wasn't trying to claim the interfaces.

Detaching devices isn't necessary on windows either since that is what you are essentially doing when you use something like zadig.

Testing on macOS suggests the same issues are present there too, and we are already skipping detaching there.