### PR TITLE
LibusbDevice: Send wakeup command to Santroller devices

### DIFF
--- a/Source/Core/Core/IOS/USB/USBScanner.h
+++ b/Source/Core/Core/IOS/USB/USBScanner.h
@@ -41,6 +41,7 @@ private:
 
   bool UpdateDevices();
   bool AddNewDevices(DeviceMap* new_devices) const;
+  static void WakeupSantrollerDevice(libusb_device* device);
   static void AddEmulatedDevices(DeviceMap* new_devices);
   static void AddDevice(std::unique_ptr<USB::Device> device, DeviceMap* new_devices);
 


### PR DESCRIPTION
I maintain a project for emulating various rhythm game controllers (https://santroller.com/)

Currently on consoles it automatically detects what console is in use and emulates the correct device for a given console, but the intrinsic it uses for that doesn't work for dolphin, so i've just added support for sending a control request to make these devices jump to the right mode.