### PR TITLE
BuildMacOSUniversalBinary: Explicitly specify CMAKE_OSX_DEPLOYMENT_TARGET in CMake flags

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -288,6 +288,7 @@ def build(config):
                 "-DCMAKE_PREFIX_PATH="+prefix_path,
                 "-DCMAKE_SYSTEM_PROCESSOR="+arch,
                 "-DCMAKE_IGNORE_PATH="+ignore_path,
+                "-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0.0",
                 "-DMACOS_CODE_SIGNING_IDENTITY="
                 + config["codesign_identity"],
                 '-DMACOS_CODE_SIGNING="ON"',


### PR DESCRIPTION
If the build folder is created from an older commit (i.e. PRs based on commits prior to when #13477 was merged) and this flag is not set, the last value set for this flag will be used instead. The last used value on our build machine is macOS 10.15, causing the deployment target to still be that version.