### PR TITLE
DolphinQt: Remove unused variables from `AdvancedPane.h`

### DIFF
--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -38,7 +38,6 @@ private:
   ConfigBool* m_cpu_clock_override_checkbox;
   QSlider* m_cpu_clock_override_slider;
   QLabel* m_cpu_clock_override_slider_label;
-  QLabel* m_cpu_clock_override_description;
 
   ConfigBool* m_custom_rtc_checkbox;
   QDateTimeEdit* m_custom_rtc_datetime;
@@ -48,5 +47,4 @@ private:
   QLabel* m_mem1_override_slider_label;
   QSlider* m_mem2_override_slider;
   QLabel* m_mem2_override_slider_label;
-  QLabel* m_ram_override_description;
 };


### PR DESCRIPTION
Small oversight from #13422.