### PR TITLE
WorkQueueThread: Implement in terms of WaitableSPSCQueue. Add unit tests.

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -37,7 +37,7 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
 
   connect(qApp, &QApplication::aboutToQuit, this, [this] {
     m_processing_halted = true;
-    m_load_thread.Shutdown(true);
+    m_load_thread.StopAndCancel();
   });
   connect(this, &QFileSystemWatcher::directoryChanged, this, &GameTracker::UpdateDirectory);
   connect(this, &QFileSystemWatcher::fileChanged, this, &GameTracker::UpdateFile);

--- a/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAssetLoader.cpp
@@ -69,9 +69,9 @@ void CustomAssetLoader::Init()
   });
 }
 
-void CustomAssetLoader ::Shutdown()
+void CustomAssetLoader::Shutdown()
 {
-  m_asset_load_thread.Shutdown(true);
+  m_asset_load_thread.StopAndCancel();
 
   m_asset_monitor_thread_shutdown.Set();
   m_asset_monitor_thread.join();

--- a/Source/UnitTests/Common/CMakeLists.txt
+++ b/Source/UnitTests/Common/CMakeLists.txt
@@ -19,6 +19,7 @@ add_dolphin_test(SettingsHandlerTest SettingsHandlerTest.cpp)
 add_dolphin_test(SPSCQueueTest SPSCQueueTest.cpp)
 add_dolphin_test(StringUtilTest StringUtilTest.cpp)
 add_dolphin_test(SwapTest SwapTest.cpp)
+add_dolphin_test(WorkQueueThreadTest WorkQueueThreadTest.cpp)
 
 if (_M_X86_64)
   add_dolphin_test(x64EmitterTest x64EmitterTest.cpp)

--- a/Source/UnitTests/Common/WorkQueueThreadTest.cpp
+++ b/Source/UnitTests/Common/WorkQueueThreadTest.cpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "Common/WorkQueueThread.h"
+
+TEST(WorkQueueThread, Simple)
+{
+  Common::WorkQueueThreadSP<int> worker;
+
+  constexpr int BIG_VAL = 1000;
+
+  int x = 0;
+  const auto func = [&](int value) { x = value; };
+
+  worker.Push(1);
+  worker.WaitForCompletion();
+  // Still zero because it's not running.
+  EXPECT_EQ(x, 0);
+
+  // Does nothing if not running.
+  worker.Shutdown();
+
+  worker.Reset("test worker", func);
+  worker.WaitForCompletion();
+  // Items pushed before Reset are processed.
+  EXPECT_EQ(x, 1);
+
+  worker.Shutdown();
+  worker.Push(0);
+  worker.WaitForCompletion();
+  // Still 1 because it's no longer running.
+  EXPECT_EQ(x, 1);
+
+  worker.Cancel();
+  worker.Reset("test worker", func);
+  worker.WaitForCompletion();
+  // Still 1 because the work was canceled.
+  EXPECT_EQ(x, 1);
+
+  for (int i = 0; i != BIG_VAL; ++i)
+    worker.Push(i);
+  worker.Cancel();
+  // Could be any one of the pushed values.
+  EXPECT_LT(x, BIG_VAL);
+  GTEST_LOG_(INFO) << "Canceled work after item " << x;
+
+  worker.Push(2);
+  worker.WaitForCompletion();
+  // Still running after cancelation.
+  EXPECT_EQ(x, 2);
+}

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -58,6 +58,7 @@
     <ClCompile Include="Common\SPSCQueueTest.cpp" />
     <ClCompile Include="Common\StringUtilTest.cpp" />
     <ClCompile Include="Common\SwapTest.cpp" />
+    <ClCompile Include="Common\WorkQueueThreadTest.cpp" />
     <ClCompile Include="Core\CoreTimingTest.cpp" />
     <ClCompile Include="Core\DSP\DSPAcceleratorTest.cpp" />
     <ClCompile Include="Core\DSP\DSPAssemblyTest.cpp" />


### PR DESCRIPTION
`WorkQueueThread` is now implemented with `WaitableSPSCQueue`.
It is simpler, with fewer moving parts, and the worker no longer needs a mutex to access the queue.

A "single producer" `WorkQueueThreadSP` is introduced that uses no mutex for management of the worker.
PR #13475 will eliminate the mutex in `Event` making it entirely mutex-free.

I suspect most/all usages of `WorkQueueThread` are managed by a single thread and can be changed to `WorkQueueThreadSP`, but I'll assess that in future PRs.

I replaced the `Shutdown(bool cancel = false)` interface with `Shutdown()` which completes work, and `StopAndCancel()` which cancels work.

I added some unit tests.