### PR TITLE
Fix debugger disabled bug

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -2020,7 +2020,7 @@ void MainWindow::ShowAchievementSettings()
 
 void MainWindow::OnHardcoreChanged()
 {
-  if (Config::Get(Config::RA_HARDCORE_ENABLED))
+  if (AchievementManager::GetInstance().IsHardcoreModeActive())
     Settings::Instance().SetDebugModeEnabled(false);
   emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
 }


### PR DESCRIPTION
Fixing an oversight: this was causing the debugger to be disabled if achievements were disabled but hardcore mode was still enabled in the .ini. This fix properly checks for hardcore state via AchievementManager which takes both settings into account.