### PR TITLE
Common: Move some duplicate container element construction logic into a ManuallyConstructedValue template.

### DIFF
--- a/Source/Core/Common/TypeUtils.h
+++ b/Source/Core/Common/TypeUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <type_traits>
 
 namespace Common
@@ -82,4 +83,54 @@ static_assert(!IsNOf<int, 1, int, int>::value);
 static_assert(IsNOf<int, 2, int, int>::value);
 static_assert(IsNOf<int, 2, int, short>::value);  // Type conversions ARE allowed
 static_assert(!IsNOf<int, 2, int, char*>::value);
+
+// Lighter than optional<T> but you must manage object lifetime yourself.
+// You must call Destroy if you call Construct.
+// Useful for containers.
+template <typename T>
+class ManuallyConstructedValue
+{
+public:
+  template <typename... Args>
+  T& Construct(Args&&... args)
+  {
+    static_assert(sizeof(ManuallyConstructedValue) == sizeof(T));
+
+// TODO: Remove placement-new version when we can require Clang 16.
+#if defined(__cpp_aggregate_paren_init) && (__cpp_aggregate_paren_init >= 201902L)
+    return *std::construct_at(&m_value.data, std::forward<Args>(args)...);
+#else
+    return *::new (&m_value.data) T{std::forward<Args>(args)...};
+#endif
+  }
+
+  void Destroy() { std::destroy_at(&m_value.data); }
+
+  T* Ptr() { return &m_value.data; }
+  const T* Ptr() const { return &m_value.data; }
+  T& Ref() { return m_value.data; }
+  const T& Ref() const { return m_value.data; }
+
+  T* operator->() { return Ptr(); }
+  const T* operator->() const { return Ptr(); }
+  T& operator*() { return Ref(); }
+  const T& operator*() const { return Ref(); }
+
+private:
+  union Value
+  {
+    // The union allows this object's automatic construction to be avoided.
+    T data;
+
+    Value() {}
+    ~Value() {}
+
+    Value& operator=(const Value&) = delete;
+    Value(const Value&) = delete;
+    Value& operator=(Value&&) = delete;
+    Value(Value&&) = delete;
+
+  } m_value;
+};
+
 }  // namespace Common


### PR DESCRIPTION
In #13431 I figured out a `union` trick for `SPSCQueue` to delay construction of objects without having to resort to indirect storage or scary `std::launder` nonsense.

I've moved that trick to a `ManuallyConstructedValue` template and and made `SmallVector` also use it.