### PR TITLE
Update licenses.md

### DIFF
--- a/Externals/licenses.md
+++ b/Externals/licenses.md
@@ -1,82 +1,212 @@
-Dolphin includes or links code of the following third-party software projects:
+# Dolphin Third-Party Licenses
+
+Dolphin includes or links code of the following third-party software projects (this list may not be exhaustive):
 
 - [ALSA](http://www.alsa-project.org/):
-   [LGPLv2.1+](http://git.alsa-project.org/?p=alsa-lib.git;a=blob;f=COPYING)
+  [LGPL-2.1-or-later](http://git.alsa-project.org/?p=alsa-lib.git;a=blob;f=COPYING)
+
 - [BlueZ](http://www.bluez.org/):
-   [LGPLv2.1+](https://git.kernel.org/cgit/bluetooth/bluez.git/tree/COPYING.LIB)
+  [LGPL-2.1-or-later](https://git.kernel.org/cgit/bluetooth/bluez.git/tree/COPYING.LIB)
+
 - [Bochs](http://bochs.sourceforge.net/):
-   [LGPLv2.1+](http://bochs.sourceforge.net/cgi-bin/lxr/source/COPYING)
+  [LGPL-2.1-or-later](http://bochs.sourceforge.net/cgi-bin/lxr/source/COPYING)
+
 - [bzip2](https://www.sourceware.org/bzip2/):
-   [bzip2 license](https://www.sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;hb=HEAD) (similar to 3-clause BSD)
+  [bzip2-1.0.8](https://www.sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;hb=HEAD)
+
 - [cpp-ipc](https://github.com/mutouyun/cpp-ipc):
-   [MIT](https://github.com/mutouyun/cpp-ipc/blob/master/LICENSE)
+  [MIT](https://github.com/mutouyun/cpp-ipc/blob/master/LICENSE)
+
+- [cpp-optparse](https://github.com/weisslj/cpp-optparse):
+  [MIT](https://github.com/weisslj/cpp-optparse/blob/main/LICENSE)
+
 - [cubeb](https://github.com/kinetiknz/cubeb):
-   [ISC](https://github.com/kinetiknz/cubeb/blob/master/LICENSE)
+  [ISC](https://github.com/kinetiknz/cubeb/blob/master/LICENSE)
+
 - [Discord-RPC](https://github.com/discordapp/discord-rpc):
-   [MIT](https://github.com/discordapp/discord-rpc/blob/master/LICENSE)
+  [MIT](https://github.com/discordapp/discord-rpc/blob/master/LICENSE)
+
+- [Ed25519](https://github.com/orlp/ed25519):
+  [Zlib](https://github.com/orlp/ed25519/blob/master/license.txt)
+
 - [ENet](http://enet.bespin.org/):
-   [MIT](http://enet.bespin.org/License.html)
+  [MIT](http://enet.bespin.org/License.html)
+
 - [expr](https://github.com/zserge/expr):
-   [MIT](https://github.com/zserge/expr/blob/master/LICENSE)
+  [MIT](https://github.com/zserge/expr/blob/master/LICENSE)
+
 - [FatFs](http://elm-chan.org/fsw/ff/00index_e.html):
-   [BSD 1-Clause](http://elm-chan.org/fsw/ff/doc/appnote.html#license)
+  [BSD-1-Clause](http://elm-chan.org/fsw/ff/doc/appnote.html#license)
+
+- [FFmpeg](https://www.ffmpeg.org/):
+  - LGPL-2.1-or-later
+  - AND GPL-2.0-or-later
+
+  [source](https://ffmpeg.org/legal.html)
+
+- [fmt](https://fmt.dev/):
+  [MIT](https://github.com/fmtlib/fmt/blob/master/LICENSE)
+
+- FreeSurround:
+  GPL-2.0-or-later
+
 - [GCEmu](http://sourceforge.net/projects/gcemu-project/):
-   GPLv2+
+  GPL-2.0-or-later
+
 - [gettext](https://www.gnu.org/software/gettext/):
-   [GPLv3+](http://git.savannah.gnu.org/cgit/gettext.git/tree/COPYING)
+  [GPL-3.0-or-later](http://git.savannah.gnu.org/cgit/gettext.git/tree/COPYING)
+
+- [glslang](https://github.com/KhronosGroup/glslang):
+  - BSD-3-Clause
+  - AND BSD-2-Clause
+  - AND MIT
+  - AND Apache-2.0
+  - AND GPL-3.0-only WITH Bison-exception-2.2
+
+  [source](https://github.com/KhronosGroup/glslang/blob/main/LICENSE.txt)
+
 - [googletest](https://github.com/google/googletest):
-   [BSD 3-Clause](https://github.com/google/googletest/blob/master/LICENSE)
+  [BSD-3-Clause](https://github.com/google/googletest/blob/master/LICENSE)
+
+- [hidapi](https://libusb.info/hidapi/):
+  - [GPL-3.0-only](https://github.com/libusb/hidapi/blob/master/LICENSE-gpl3.txt)
+  - OR [BSD-3-Clause](https://github.com/libusb/hidapi/blob/master/LICENSE-bsd.txt)
+  - OR [HIDAPI](https://github.com/libusb/hidapi/blob/master/LICENSE-orig.txt)
+
+  [source](https://github.com/libusb/hidapi/blob/master/LICENSE.txt)
+
+- [imgui](https://github.com/ocornut/imgui):
+  [MIT](https://github.com/ocornut/imgui/blob/master/LICENSE.txt)
+
+- [implot](https://github.com/epezent/implot):
+  [MIT](https://github.com/epezent/implot/blob/master/LICENSE)
+
+- [libadrenotools](https://github.com/bylaws/libadrenotools):
+  [BSD-2-Clause](https://github.com/bylaws/libadrenotools/blob/master/LICENSE)
+
 - [libao](https://www.xiph.org/ao/):
-   [GPLv2+](https://trac.xiph.org/browser/trunk/ao/README)
+  [GPL-2.0-or-later](https://gitlab.xiph.org/xiph/libao/-/blob/master/COPYING)
+
 - [libav](https://libav.org/):
-   [GPLv2+](https://libav.org/legal.html)
+  [GPL-2.0-or-later](https://libav.org/legal.html)
+
 - [libcdio](https://www.gnu.org/software/libcdio/):
-   [GPLv3+](http://git.savannah.gnu.org/gitweb/?p=libcdio.git;a=blob_plain;f=COPYING)
+  [GPL-3.0-or-later](http://git.savannah.gnu.org/gitweb/?p=libcdio.git;a=blob_plain;f=COPYING)
+
 - [libiconv](https://www.gnu.org/software/libiconv/):
-   [LGPLv2.1+](http://git.savannah.gnu.org/cgit/libiconv.git/tree/COPYING.LIB)
+  [LGPL-2.1-or-later](http://git.savannah.gnu.org/cgit/libiconv.git/tree/COPYING.LIB)
+
 - [liblzma](https://tukaani.org/xz/):
-   [Public domain](https://git.tukaani.org/?p=xz.git;a=blob_plain;f=COPYING;hb=HEAD)
+  [Public domain](https://git.tukaani.org/?p=xz.git;a=blob_plain;f=COPYING;hb=HEAD)
+
 - [libspng](https://github.com/randy408/libspng):
-   [BSD 2-Clause](https://github.com/randy408/libspng/blob/master/LICENSE)
+  [BSD-2-Clause](https://github.com/randy408/libspng/blob/master/LICENSE)
+
 - [libusb](http://libusb.info/):
-   [LGPLv2.1+](https://github.com/libusb/libusb/blob/master/COPYING)
+  [LGPL-2.1-or-later](https://github.com/libusb/libusb/blob/master/COPYING)
+
 - [LLVM](http://llvm.org/):
-   [University of Illinois/NCSA Open Source license](http://llvm.org/docs/DeveloperPolicy.html#license)
+  [NCSA](http://llvm.org/docs/DeveloperPolicy.html#license)
+
+- [lz4](http://www.lz4.org/):
+  - [BSD-2-Clause-Patent](https://github.com/lz4/lz4/blob/dev/lib/LICENSE) for all files in the `lib` directory
+  - GPL-2.0-or-later unless otherwise specified for all other files
+
+  [source](https://github.com/lz4/lz4/blob/dev/LICENSE)
+
 - [LZO](http://www.oberhumer.com/opensource/lzo/):
-   [GPLv2+](http://www.oberhumer.com/opensource/gpl.html)
-- [mGBA](http://mgba.io)
-   [MPL 2.0](https://github.com/mgba-emu/mgba/blob/master/LICENSE)
+  [GPL-2.0-or-later](http://www.oberhumer.com/opensource/gpl.html)
+
+- [Mbed TLS](https://www.trustedfirmware.org/projects/mbed-tls/):
+  - Apache-2.0
+  - OR GPL-2.0-or-later
+
+  [source](https://github.com/Mbed-TLS/mbedtls/blob/development/LICENSE)
+
+- [mGBA](http://mgba.io):
+  [MPL-2.0](https://github.com/mgba-emu/mgba/blob/master/LICENSE)
+
 - [MiniUPnPc](http://miniupnp.free.fr/):
-   [BSD 3-Clause](https://github.com/miniupnp/miniupnp/blob/master/miniupnpc/LICENSE)
+  [BSD-3-Clause](https://github.com/miniupnp/miniupnp/blob/master/miniupnpc/LICENSE)
+
+- [minizip-ng](https://github.com/zlib-ng/minizip-ng):
+  [Zlib](https://github.com/zlib-ng/minizip-ng/blob/develop/LICENSE)
+
+- [MoltenVK](https://github.com/KhronosGroup/MoltenVK):
+  [Apache-2.0](https://github.com/KhronosGroup/MoltenVK/blob/main/LICENSE)
+
 - [Microsoft Visual C++ Runtime Library](http://www.microsoft.com/en-us/download/details.aspx?id=40784):
-   [System Library if not distributed](https://www.gnu.org/licenses/gpl-faq.html#WindowsRuntimeAndGPL)
+  [System Library if not distributed](https://www.gnu.org/licenses/gpl-faq.html#WindowsRuntimeAndGPL)
+
 - [OpenAL Soft](http://kcat.strangesoft.net/openal.html):
-   [LGPLv2+](http://repo.or.cz/w/openal-soft.git/blob/HEAD:/COPYING)
+  [LGPL-2.0-or-later](http://repo.or.cz/w/openal-soft.git/blob/HEAD:/COPYING)
+
 - [OpenGL Header (MESA)](http://mesa3d.org/):
-   [MIT](http://cgit.freedesktop.org/mesa/mesa/tree/include/GL/gl.h)
+  [MIT](http://cgit.freedesktop.org/mesa/mesa/tree/include/GL/gl.h)
+
 - [OpenGL Extension Header (Khronos)](https://www.opengl.org/registry/#headers):
-   [MIT](https://www.opengl.org/registry/api/GL/glext.h)
+  [MIT](https://www.opengl.org/registry/api/GL/glext.h)
+
 - [PearPC](http://pearpc.sourceforge.net/):
-   [GPLv2](http://pearpc.cvs.sourceforge.net/viewvc/pearpc/pearpc/COPYING?view=markup) (with permission by the author to license under GPLv2+)
-- [mbed TLS](https://tls.mbed.org/):
-   [Apache 2.0](https://github.com/ARMmbed/mbedtls/blob/development/LICENSE)
+  [GPL-2.0-only](http://pearpc.cvs.sourceforge.net/viewvc/pearpc/pearpc/COPYING?view=markup) (with permission by the author to license
+  under GPL-2.0-or-later)
+- [PicoJSON](https://github.com/kazuho/picojson)
+  [BSD-2-Clause](https://github.com/kazuho/picojson/blob/master/LICENSE)
+
+- [PugiXML](https://pugixml.org/):
+  [MIT](https://github.com/zeux/pugixml/blob/master/LICENSE.md)
+
 - [PulseAudio](http://www.freedesktop.org/wiki/Software/PulseAudio/):
-   [LGPLv2.1+](http://cgit.freedesktop.org/pulseaudio/pulseaudio/tree/LICENSE)
-- [Qt5](http://qt-project.org/):
-   [LGPLv3 and other licenses](http://doc.qt.io/qt-5/licensing.html)
+  [LGPL-2.1-or-later](http://cgit.freedesktop.org/pulseaudio/pulseaudio/tree/LICENSE)
+
+- [Qt6](http://qt-project.org/):
+  - LGPL-3.0-only
+  - Certain modules are licensed under the GPL-3.0-only license
+  - Qt examples are licensed under a BSD-3-Clause license
+
+  [source](http://doc.qt.io/qt-6/licensing.html)
+
+- [rcheevos](https://github.com/RetroAchievements/rcheevos):
+  [MIT](https://github.com/RetroAchievements/rcheevos/blob/develop/LICENSE)
+
 - [SDL](https://www.libsdl.org/):
-   [zlib license](http://hg.libsdl.org/SDL/file/tip/COPYING.txt)
+  [Zlib](http://hg.libsdl.org/SDL/file/tip/COPYING.txt)
+
 - [SFML](http://www.sfml-dev.org/):
-   [zlib license](http://www.sfml-dev.org/license.php)
+  [Zlib](http://www.sfml-dev.org/license.php)
+
+- [SPIRV-Cross](https://github.com/KhronosGroup/SPIRV-Cross):
+  [Apache-2.0](https://github.com/KhronosGroup/SPIRV-Cross/blob/main/LICENSE)
+
 - [TAP-Windows](https://openvpn.net/):
-   header only
+  header only
+
+- [TinyGLTF](https://github.com/syoyo/tinygltf):
+  [MIT](https://github.com/syoyo/tinygltf/blob/release/LICENSE)
+
+- [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers):
+  - Apache-2.0
+  - AND MIT
+
+  [source](https://github.com/KhronosGroup/Vulkan-Headers/blob/main/LICENSE.md)
+
+- [VulkanMemoryAllocator](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator):
+  [MIT](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/master/LICENSE.txt)
+
 - [Windows Implementation Libraries](https://github.com/microsoft/wil):
-   [MIT](https://github.com/microsoft/wil/blob/master/LICENSE)
+  [MIT](https://github.com/microsoft/wil/blob/master/LICENSE)
+
 - [xxHash](https://github.com/Cyan4973/xxHash):
-   [BSD 2-Clause](https://github.com/Cyan4973/xxHash/blob/master/LICENSE)
+  [BSD-2-Clause](https://github.com/Cyan4973/xxHash/blob/master/LICENSE)
+
 - [YACardEmu](https://github.com/GXTX/YACardEmu)
-   [GPLv2+](https://github.com/GXTX/YACardEmu/blob/master/license.txt)
+  [GPL-2.0-or-later](https://github.com/GXTX/YACardEmu/blob/master/license.txt)
+
 - [zlib-ng](https://github.com/zlib-ng/zlib-ng):
-   [zlib license](https://github.com/zlib-ng/zlib-ng/blob/develop/LICENSE.md)
+  [Zlib](https://github.com/zlib-ng/zlib-ng/blob/develop/LICENSE.md)
+
 - [Zstandard](https://facebook.github.io/zstd/):
-   [BSD 3-Clause](https://github.com/facebook/zstd/blob/dev/LICENSE) or [GPLv2](https://github.com/facebook/zstd/blob/dev/COPYING)
+  - [BSD-3-Clause](https://github.com/facebook/zstd/blob/dev/LICENSE)
+  - OR [GPL-2.0-only](https://github.com/facebook/zstd/blob/dev/COPYING)
+
+  [source](https://github.com/facebook/zstd/blob/dev/README.md#license)


### PR DESCRIPTION
The previous licenses.md was not using [SPDX License identifiers](https://spdx.org/licenses/) despite the claim in COPYING. I also added quite a few missing licenses, and took the liberty to make the markdown more readable.