### PR TITLE
GameINI: Enable Single Core for Kung Fu Panda and Shrek Forever After

### DIFF
--- a/Data/Sys/GameSettings/RKP.ini
+++ b/Data/Sys/GameSettings/RKP.ini
@@ -1,0 +1,4 @@
+# RKPJ52, RKPE52, RKPY52, RKPK52, RKPV52, RKPP52, RKPX52 - Kung Fu Panda
+
+[Core]
+CPUThread = False

--- a/Data/Sys/GameSettings/SK4.ini
+++ b/Data/Sys/GameSettings/SK4.ini
@@ -1,0 +1,4 @@
+# SK4P52, SK4E52, SK4I52 - Shrek Forever After
+
+[Core]
+CPUThread = False


### PR DESCRIPTION
The game is extremely sensitive to any timing change.
With dual-core on, changes in emulation speed will cause the game to start constantly freezing and unfreezing at random. Pressing and releasing Tab is just asking for the game to implode, especially if you do it repeatedly.
Without dual-core, pressing and releasing Tab doesn't cause issues.

Shrek Forever After may suffer from the same issue, as it uses the same engine. Someone should test it (maybe before this PR is merged).