### PR TITLE
Android: Allow reporting start to analytics for non-main activity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ActivityTracker.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ActivityTracker.kt
@@ -11,20 +11,18 @@ class ActivityTracker : ActivityLifecycleCallbacks {
     private var firstStart = true
 
     private fun isMainActivity(activity: Activity): Boolean {
-      return activity is MainView
+        return activity is MainView
     }
 
     override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
-      if (isMainActivity(activity)) {
-        firstStart = bundle == null
-      }
+        if (isMainActivity(activity)) {
+            firstStart = bundle == null
+        }
     }
 
     override fun onActivityStarted(activity: Activity) {
-      if (isMainActivity(activity)) {
         StartupHandler.reportStartToAnalytics(activity.applicationContext, firstStart)
         firstStart = false
-      }
     }
 
     override fun onActivityResumed(activity: Activity) {
@@ -44,9 +42,9 @@ class ActivityTracker : ActivityLifecycleCallbacks {
     }
 
     override fun onActivityStopped(activity: Activity) {
-      if (isMainActivity(activity)) {
-        StartupHandler.updateSessionTimestamp(activity.applicationContext)
-      }
+        if (isMainActivity(activity)) {
+            StartupHandler.updateSessionTimestamp(activity.applicationContext)
+        }
     }
 
     override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}


### PR DESCRIPTION
PR #13520 made it so analytics start events can only be generated when starting the main activity. However, some users launch Dolphin's emulation activity from a separate frontend application, bypassing Dolphin's main activity. This change adjusts the logic so that start events can be generated if any activity is started after 6 hours of inactivity. This more closely matches the behavior we had before PR #13520, while still ensuring duplicate start events aren't generated.

I've also fixed the inconsistent indentation in `ActivityTracker.kt`.