### PR TITLE
GameINI: Disable Dual Core for NERF N-Strike

### DIFF
--- a/Data/Sys/GameSettings/RNK.ini
+++ b/Data/Sys/GameSettings/RNK.ini
@@ -1,0 +1,4 @@
+# RNKE69, RNKP69 - NERF N-Strike
+
+[Core]
+CPUThread = False


### PR DESCRIPTION
Disable Dual Core for NERF N-Strike by default, as the game refuses to boot with Dual Core enabled.