### PR TITLE
Android: Don't call NativeLibrary methods during class init

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1961,7 +1961,7 @@ class SettingsFragmentPresenter(
                 IntSetting.LOGGER_VERBOSITY,
                 R.string.log_verbosity,
                 0,
-                logVerbosityEntries, logVerbosityValues
+                getLogVerbosityEntries(), getLogVerbosityValues()
             )
         )
         sl.add(
@@ -1993,7 +1993,7 @@ class SettingsFragmentPresenter(
             ) { SettingsAdapter.clearLog() })
 
         sl.add(HeaderSetting(context, R.string.log_types, 0))
-        for (logType in LOG_TYPE_NAMES) {
+        for (logType in NativeLibrary.GetLogTypeNames()) {
             sl.add(LogSwitchSetting(logType.first, logType.second, ""))
         }
     }
@@ -2543,7 +2543,7 @@ class SettingsFragmentPresenter(
     fun setAllLogTypes(value: Boolean) {
         val settings = fragmentView.settings
 
-        for (logType in LOG_TYPE_NAMES) {
+        for (logType in NativeLibrary.GetLogTypeNames()) {
             AdHocBooleanSetting(
                 Settings.FILE_LOGGER,
                 Settings.SECTION_LOGGER_LOGS,
@@ -2604,26 +2604,29 @@ class SettingsFragmentPresenter(
     }
 
     companion object {
-        private val LOG_TYPE_NAMES = NativeLibrary.GetLogTypeNames()
         const val ARG_CONTROLLER_TYPE = "controller_type"
         const val ARG_SERIALPORT1_TYPE = "serialport1_type"
 
         // Value obtained from LogLevel in Common/Logging/Log.h
-        private val logVerbosityEntries: Int
-            get() =
-                if (NativeLibrary.GetMaxLogLevel() == 5) {
-                    R.array.logVerbosityEntriesMaxLevelDebug
-                } else {
-                    R.array.logVerbosityEntriesMaxLevelInfo
-                }
+        private fun getLogVerbosityEntries(): Int {
+            // GetMaxLogLevel is effectively a constant, but we can't call it before loading
+            // the native library
+            return if (NativeLibrary.GetMaxLogLevel() == 5) {
+                R.array.logVerbosityEntriesMaxLevelDebug
+            } else {
+                R.array.logVerbosityEntriesMaxLevelInfo
+            }
+        }
 
         // Value obtained from LogLevel in Common/Logging/Log.h
-        private val logVerbosityValues: Int
-            get() =
-                if (NativeLibrary.GetMaxLogLevel() == 5) {
-                    R.array.logVerbosityValuesMaxLevelDebug
-                } else {
-                    R.array.logVerbosityValuesMaxLevelInfo
-                }
+        private fun getLogVerbosityValues(): Int {
+            // GetMaxLogLevel is effectively a constant, but we can't call it before loading
+            // the native library
+            return if (NativeLibrary.GetMaxLogLevel() == 5) {
+                R.array.logVerbosityValuesMaxLevelDebug
+            } else {
+                R.array.logVerbosityValuesMaxLevelInfo
+            }
+        }
     }
 }


### PR DESCRIPTION
There's no guarantee that directory initialization has completed by this point, so we can't safely use NativeLibrary.

I'm making this change because of a crash being reported in Google Play Console. The exact way it's crashing is mysterious to me, so I'm not sure if this commit fixes the crash, but I think this commit is a reasonable change to make even if it doesn't fix the crash. Backtrace from Google Play Console:

```
  #00  pc 0x0000000000469074  /data/app/~~m0kqybFNfeqnDenQFc53XQ==/org.dolphinemu.dolphinemu-Mtaw0lU8DVUQbte2ZjBp3w==/lib/arm64/libmain.so (std::__ndk1::pair<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>::pair[abi:nn180000]<char const* const&, char const* const&, 0>(char const* const&, char const* const&)) (BuildId: 64cfebf5b574b6729ebc51799aa94ccc3238cbcc)
  #01  pc 0x0000000000468e9c  /data/app/~~m0kqybFNfeqnDenQFc53XQ==/org.dolphinemu.dolphinemu-Mtaw0lU8DVUQbte2ZjBp3w==/lib/arm64/libmain.so (std::__ndk1::pair<std::__ndk1::__tree_iterator<std::__ndk1::__value_type<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>, std::__ndk1::__tree_node<std::__ndk1::__value_type<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>, void*>*, long>, bool> std::__ndk1::__tree<std::__ndk1::__value_type<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>, std::__ndk1::__map_value_compare<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>, std::__ndk1::__value_type<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>, std::__ndk1::less<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>, true>, std::__ndk1::allocator<std::__ndk1::__value_type<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>>>::__emplace_unique_impl<char const* const&, char const* const&>(char const* const&, char const* const&)) (BuildId: 64cfebf5b574b6729ebc51799aa94ccc3238cbcc)
  #02  pc 0x0000000000462f08  /data/app/~~m0kqybFNfeqnDenQFc53XQ==/org.dolphinemu.dolphinemu-Mtaw0lU8DVUQbte2ZjBp3w==/lib/arm64/libmain.so (Common::Log::LogManager::GetLogTypes()) (BuildId: 64cfebf5b574b6729ebc51799aa94ccc3238cbcc)
  #03  pc 0x000000000044339c  /data/app/~~m0kqybFNfeqnDenQFc53XQ==/org.dolphinemu.dolphinemu-Mtaw0lU8DVUQbte2ZjBp3w==/lib/arm64/libmain.so (Java_org_dolphinemu_dolphinemu_NativeLibrary_GetLogTypeNames+56) (BuildId: 64cfebf5b574b6729ebc51799aa94ccc3238cbcc)
  #04  pc 0x000000000031456c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+108)
  #05  pc 0x0000000000781508  /apex/com.android.art/lib64/libart.so (nterp_helper+152)
  #06  pc 0x00000000002d94d4  /data/app/~~m0kqybFNfeqnDenQFc53XQ==/org.dolphinemu.dolphinemu-Mtaw0lU8DVUQbte2ZjBp3w==/base.apk (org.dolphinemu.dolphinemu.features.settings.ui.SettingsFragmentPresenter.<clinit>+16)
[...]
```