### PR TITLE
[GameINI] Zelda and Mario practice ROMs

### DIFF
--- a/Data/Sys/GameSettings/FP.ini
+++ b/Data/Sys/GameSettings/FP.ini
@@ -1,0 +1,19 @@
+# FPUS01, FPJP01 - Paper Mario Practice ROM
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+FastDepthCalc = True
+
+[Video_Hacks]
+EFBToTextureEnable = False
+
+[Video_Stereoscopy]
+StereoConvergence = 506

--- a/Data/Sys/GameSettings/NG.ini
+++ b/Data/Sys/GameSettings/NG.ini
@@ -1,0 +1,14 @@
+# NG0E01, NG1E01, NG2E01, NG0J01, NG1J01, NG2J01 - Zelda: Ocarina of Time Practice Rom
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+# Fixes Link preview not appearing in Equipment Menu screen
+EFBToTextureEnable = False 

--- a/Data/Sys/GameSettings/NKZ.ini
+++ b/Data/Sys/GameSettings/NKZ.ini
@@ -1,0 +1,16 @@
+# NKZE01, NKZJ01 - Zelda: Majora's Mask practice Rom
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+# Fixes Link preview not appearing in Equipment Menu screen
+EFBToTextureEnable = False 
+# Fixes the screen shrinking effect not working properly.
+DeferEFBCopies = False


### PR DESCRIPTION
The Practice ROMs used by speedrunners in Ocarina of Time, Majora's Mask, and Paper Mario, all for the Wii Virtual Console don't currently have their GameIni settings preapplied, leading to the game having visual glitches at boot unless users manually copy the settings from the vanilla games as well.

Here I duplicated the gameinis but with the gamecodes used by them.

NAC -> NG
https://www.practicerom.com/
https://github.com/glankk/gz

NAR -> NKZ
https://github.com/krimtonz/kz

NAE -> FP
https://github.com/JCog/fp

