### PR TITLE
RetroAchievements - Wii and WiiWare Support

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -997,6 +997,7 @@ void AchievementManager::LoadGameCallback(int result, const char* error_message,
       // Allow developer tools for unidentified games
       rc_client_set_read_memory_function(instance.m_client, MemoryPeeker);
       instance.m_system.store(&Core::System::GetInstance(), std::memory_order_release);
+      return;
     }
     instance.CloseGame();
     return;

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -122,7 +122,7 @@ public:
   void SetUpdateCallback(UpdateCallback callback);
   void Login(const std::string& password);
   bool HasAPIToken() const;
-  void LoadGame(const std::string& file_path, const DiscIO::Volume* volume);
+  void LoadGame(const DiscIO::Volume* volume);
   bool IsGameLoaded() const;
   void SetBackgroundExecutionAllowed(bool allowed);
 
@@ -193,8 +193,7 @@ private:
 
   static picojson::value LoadApprovedList();
 
-  static void* FilereaderOpenByFilepath(const char* path_utf8);
-  static void* FilereaderOpenByVolume(const char* path_utf8);
+  static void* FilereaderOpen(const char* path_utf8);
   static void FilereaderSeek(void* file_handle, int64_t offset, int origin);
   static int64_t FilereaderTell(void* file_handle);
   static size_t FilereaderRead(void* file_handle, void* buffer, size_t requested_bytes);

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -23,6 +23,7 @@
 #include <rcheevos/include/rc_api_runtime.h>
 #include <rcheevos/include/rc_api_user.h>
 #include <rcheevos/include/rc_client.h>
+#include <rcheevos/include/rc_hash.h>
 #include <rcheevos/include/rc_runtime.h>
 
 #include "Common/CommonTypes.h"
@@ -198,6 +199,8 @@ private:
   static int64_t FilereaderTell(void* file_handle);
   static size_t FilereaderRead(void* file_handle, void* buffer, size_t requested_bytes);
   static void FilereaderClose(void* file_handle);
+
+  static u32 FindConsoleID(const DiscIO::Platform& platform);
 
   void LoadDefaultBadges();
   static void LoginCallback(int result, const char* error_message, rc_client_t* client,

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -597,8 +597,6 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
         SetupGCMemory(system, guard);
       }
 
-      AchievementManager::GetInstance().LoadGame(executable.path, nullptr);
-
       if (!executable.reader->LoadIntoMemory(system))
       {
         PanicAlertFmtT("Failed to load the executable to memory.");

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -623,6 +623,8 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
       if (!Boot_WiiWAD(system, wad))
         return false;
 
+      AchievementManager::GetInstance().LoadGame(&wad);
+
       SConfig::OnTitleDirectlyBooted(guard);
       return true;
     }

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -398,7 +398,7 @@ void DVDInterface::SetDisc(std::unique_ptr<DiscIO::VolumeDisc> disc,
     m_auto_disc_change_index = 0;
   }
 
-  AchievementManager::GetInstance().LoadGame("", disc.get());
+  AchievementManager::GetInstance().LoadGame(disc.get());
 
   // Assume that inserting a disc requires having an empty disc before
   if (had_disc != has_disc)


### PR DESCRIPTION
Update the rcheevos submodule with new hashes and provide the updated wiring to AchievementManager to properly hash and load Wii and WiiWare titles.

Note that this is merely support; actual achievements will be released and available when a rollout is complete.