### PR TITLE
Common: Add AsyncWorkThread.

### DIFF
--- a/Source/Core/AudioCommon/CubebStream.h
+++ b/Source/Core/AudioCommon/CubebStream.h
@@ -39,7 +39,7 @@ private:
   std::vector<float> m_floatstereo_buffer;
 
 #ifdef _WIN32
-  Common::WorkQueueThread<std::function<void()>> m_work_queue;
+  Common::AsyncWorkThread m_work_queue;
   bool m_coinit_success = false;
   bool m_should_couninit = false;
 #endif

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -299,8 +299,8 @@ private:
   std::string m_title_estimate;
 #endif  // RC_CLIENT_SUPPORTS_RAINTEGRATION
 
-  Common::WorkQueueThread<std::function<void()>> m_queue;
-  Common::WorkQueueThread<std::function<void()>> m_image_queue;
+  Common::AsyncWorkThread m_queue;
+  Common::AsyncWorkThread m_image_queue;
   mutable std::recursive_mutex m_lock;
   std::recursive_mutex m_filereader_lock;
 };  // class AchievementManager

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -102,7 +102,7 @@ private:
   int samples_avail;
 
 #ifdef _WIN32
-  Common::WorkQueueThread<std::function<void()>> m_work_queue;
+  Common::AsyncWorkThread m_work_queue;
   bool m_coinit_success = false;
   bool m_should_couninit = false;
 #endif

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -169,8 +169,7 @@ NetKDRequestDevice::NetKDRequestDevice(EmulationKernel& ios, const std::string& 
   });
 
   m_handle_mail = !ios.GetIOSC().IsUsingDefaultId() && !m_send_list.IsDisabled();
-  m_scheduler_work_queue.Reset("WiiConnect24 Scheduler Worker",
-                               [](std::function<void()> task) { task(); });
+  m_scheduler_work_queue.Reset("WiiConnect24 Scheduler Worker");
 
   m_scheduler_timer_thread = std::thread([this] { SchedulerTimer(); });
 }
@@ -218,7 +217,7 @@ void NetKDRequestDevice::SchedulerTimer()
       std::lock_guard lg(m_scheduler_lock);
       if (m_mail_span <= mail_time_state && m_handle_mail)
       {
-        m_scheduler_work_queue.EmplaceItem([this] { SchedulerWorker(SchedulerEvent::Mail); });
+        m_scheduler_work_queue.Push([this] { SchedulerWorker(SchedulerEvent::Mail); });
         INFO_LOG_FMT(IOS_WC24, "NET_KD_REQ: Dispatching Mail Task from Scheduler");
         mail_time_state = 0;
       }
@@ -226,7 +225,7 @@ void NetKDRequestDevice::SchedulerTimer()
       if (m_download_span <= download_time_state && !m_dl_list.IsDisabled())
       {
         INFO_LOG_FMT(IOS_WC24, "NET_KD_REQ: Dispatching Download Task from Scheduler");
-        m_scheduler_work_queue.EmplaceItem([this] { SchedulerWorker(SchedulerEvent::Download); });
+        m_scheduler_work_queue.Push([this] { SchedulerWorker(SchedulerEvent::Download); });
         download_time_state = 0;
       }
     }

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -111,7 +111,7 @@ private:
   NWC24::Mail::WC24SendList m_send_list;
   NWC24::Mail::WC24FriendList m_friend_list;
   Common::WorkQueueThreadSP<AsyncTask> m_work_queue;
-  Common::WorkQueueThreadSP<std::function<void()>> m_scheduler_work_queue;
+  Common::AsyncWorkThreadSP m_scheduler_work_queue;
   std::mutex m_async_reply_lock;
   std::mutex m_scheduler_buffer_lock;
   std::queue<AsyncReply> m_async_replies;


### PR DESCRIPTION
There were a few places that used `Common::WorkQueueThread<std::function<void()>>`.

I've added an `AsyncWorkThread` that makes doing that a bit less ugly.