### PR TITLE
Externals/zstd: Disable ASM for MSVC compiler in CMake

### DIFF
--- a/Externals/zstd/CMakeLists.txt
+++ b/Externals/zstd/CMakeLists.txt
@@ -1,4 +1,8 @@
-project(zstd C ASM)
+project(zstd C)
+
+if(NOT MSVC)
+    enable_language(ASM)
+endif()
 
 include(CheckTypeSize)
 include(CheckFunctionExists)
@@ -120,7 +124,6 @@ set(ZSTD_SRCS
     zstd/lib/compress/zstd_preSplit.c
     zstd/lib/compress/zstdmt_compress.c
     zstd/lib/decompress/huf_decompress.c
-    zstd/lib/decompress/huf_decompress_amd64.S
     zstd/lib/decompress/zstd_ddict.c
     zstd/lib/decompress/zstd_decompress.c
     zstd/lib/decompress/zstd_decompress_block.c
@@ -128,6 +131,12 @@ set(ZSTD_SRCS
 
 add_library(zstd STATIC ${ZSTD_SRCS} ${ZSTD_PUBLIC_HDRS} ${ZSTD_PRIVATE_HDRS})
 target_compile_definitions(zstd PUBLIC ZSTD_LEGACY_SUPPORT=0)
+
+if(MSVC)
+    target_compile_definitions(zstd PUBLIC ZSTD_DISABLE_ASM)
+else()
+    target_sources(zstd PRIVATE zstd/lib/decompress/huf_decompress_amd64.S)
+endif()
 
 dolphin_disable_warnings(zstd)
 add_library(zstd::zstd ALIAS zstd)


### PR DESCRIPTION
Results in a "MSVC_RUNTIME_LIBRARY value 'MultiThreadedDLL' not known for this ASM compiler" otherwise, and [zstd doesn't support the relevant ASM code for MSVC anyway](https://github.com/facebook/zstd/blob/6af3842118ea5325480b403213b2a9fbed3d3d74/lib/common/portability_macros.h#L105-L130).


(we should really setup a cmake windows build on our build system one of these days)