### PR TITLE
Core and Vulkan: Change WorkQueueThread to WorkQueueThreadSP in a few places.

### DIFF
--- a/Source/Core/Core/HW/DVD/DVDThread.h
+++ b/Source/Core/Core/HW/DVD/DVDThread.h
@@ -126,7 +126,7 @@ private:
 
   u64 m_next_id = 0;
 
-  Common::WorkQueueThread<ReadRequest> m_dvd_thread;
+  Common::WorkQueueThreadSP<ReadRequest> m_dvd_thread;
 
   Common::WaitableSPSCQueue<ReadResult> m_result_queue;
   std::map<u64, ReadResult> m_result_map;

--- a/Source/Core/Core/IOS/Network/IP/Top.h
+++ b/Source/Core/Core/IOS/Network/IP/Top.h
@@ -120,7 +120,7 @@ private:
   IPCReply HandleICMPPingRequest(const IOCtlVRequest& request);
 
   Common::SocketContext m_socket_context;
-  Common::WorkQueueThread<AsyncTask> m_work_queue;
+  Common::WorkQueueThreadSP<AsyncTask> m_work_queue;
   std::mutex m_async_reply_lock;
   std::queue<AsyncReply> m_async_replies;
 };

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -110,8 +110,8 @@ private:
   NWC24::NWC24Dl m_dl_list;
   NWC24::Mail::WC24SendList m_send_list;
   NWC24::Mail::WC24FriendList m_friend_list;
-  Common::WorkQueueThread<AsyncTask> m_work_queue;
-  Common::WorkQueueThread<std::function<void()>> m_scheduler_work_queue;
+  Common::WorkQueueThreadSP<AsyncTask> m_work_queue;
+  Common::WorkQueueThreadSP<std::function<void()>> m_scheduler_work_queue;
   std::mutex m_async_reply_lock;
   std::mutex m_scheduler_buffer_lock;
   std::queue<AsyncReply> m_async_replies;

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -161,7 +161,7 @@ private:
     u32 present_image_index;
     u32 command_buffer_index;
   };
-  Common::WorkQueueThread<PendingCommandBufferSubmit> m_submit_thread;
+  Common::WorkQueueThreadSP<PendingCommandBufferSubmit> m_submit_thread;
   VkSemaphore m_present_semaphore = VK_NULL_HANDLE;
   Common::Flag m_last_present_failed;
   Common::Flag m_last_present_done;


### PR DESCRIPTION
These places only manage their queue from a single thread.
Using `WorkQueueThreadSP` eliminates the mutex locking.