### PR TITLE
Android: Fix incorrect ID in layout-ldrtl/list_item_mapping.xml

### DIFF
--- a/Source/Android/app/src/main/res/layout-ldrtl/list_item_mapping.xml
+++ b/Source/Android/app/src/main/res/layout-ldrtl/list_item_mapping.xml
@@ -22,7 +22,7 @@
         android:layout_marginTop="@dimen/spacing_large"
         android:textSize="16sp"
         android:textAlignment="viewStart"
-        android:layout_toStartOf="@+id/button_more_settings"
+        android:layout_toStartOf="@+id/button_advanced_settings"
         tools:text="Setting Name" />
 
     <TextView


### PR DESCRIPTION
Probably a copy-paste error from layout-ldrtl/list_item_setting.xml. This error made it so a long setting name could overlap with the checkbox next to it if Dolphin was running with right-to-left layout.

The incorrect ID was apparently also causing the app:lintVitalRelease build task to fail. I guess we're not running that build task, because I only heard of this from someone building Dolphin locally.