### PR TITLE
Externals: Update miniupnp to v2.3.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,3 +90,6 @@
 [submodule "Externals/zstd/zstd"]
 	path = Externals/zstd/zstd
 	url = https://github.com/facebook/zstd.git
+[submodule "Externals/miniupnp"]
+	path = Externals/miniupnp
+	url = https://github.com/miniupnp/miniupnp


### PR DESCRIPTION
Let's try this again without the kneejerk closing at the first sight of a joke.

This PR replaces #13420. I've used git submodule, but for some reason the project files are not changed when I drop the files from the new version into `Externals/miniupnp`. Is this because we are already using v2.3.9?