### PR TITLE
UICommon: Include implicit header

### DIFF
--- a/Source/Core/UICommon/DiscordPresence.h
+++ b/Source/Core/UICommon/DiscordPresence.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 


### PR DESCRIPTION
The header isn't implicitly included on musl.

Bug: https://bugs.gentoo.org/952952