### PR TITLE
AudioCommon/CubebUtils: Fix logged file name.

### DIFF
--- a/Source/Core/AudioCommon/CubebUtils.h
+++ b/Source/Core/AudioCommon/CubebUtils.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
 
 struct cubeb;


### PR DESCRIPTION
Our cubeb logging is broken on Linux.
```
56:00:998 onst char *):924 I[Audio]: Requested buffer attributes maxlength 4294967295, tlength 4800, prebuf 4294967295, minreq 1200, fragsize 1200
56:01:006 onst char *):1035 I[Audio]: Output buffer attributes maxlength 4194304, tlength 3600, prebuf 2404, minreq 1200, fragsize 1200
56:01:006 onst char *):1049 I[Audio]: Cubeb stream (0x77fb9c005620) init successful.
56:01:691 onst char *):1115 I[Audio]: Cubeb stream (0x77fb9c005620) started successfully.
56:01:693 onst char *):1131 I[Audio]: Cubeb stream (0x77fb9c005620) stopped successfully.
56:01:958 onst char *):1115 I[Audio]: Cubeb stream (0x77fb9c005620) started successfully.
56:02:813 AudioCommon/AudioCommon.cpp:83 I[Audio]: Shutting down sound stream
56:02:813 onst char *):1131 I[Audio]: Cubeb stream (0x77fb9c005620) stopped successfully.
56:02:813 onst char *):1131 I[Audio]: Cubeb stream (0x77fb9c005620) stopped successfully.
56:02:813 onst char *):1082 I[Audio]: Cubeb stream (0x77fb9c005620) destroyed successfully.
```

I assume it's caused by https://github.com/mozilla/cubeb/commit/9caa5b113a2a4faef8bd31894fc2d762b884a5cf which attempts to log just the filename instead of the full path.


On Windows, cubeb still gave us a full path. I don't think they have the appropriate macro to print just the filename?

Anyways, trying to figure out which version of cubeb is being used and what sort of filename on what system isn't worth it.
I made it only print the part of the filename after the last slash character.
```
05:04:895 cubeb_pulse.c:924 I[Audio]: Requested buffer attributes maxlength 4294967295, tlength 4800, prebuf 4294967295, minreq 1200, fragsize 1200
05:04:902 cubeb_pulse.c:1035 I[Audio]: Output buffer attributes maxlength 4194304, tlength 3600, prebuf 2404, minreq 1200, fragsize 1200
05:04:902 cubeb_pulse.c:1049 I[Audio]: Cubeb stream (0x796fd8004d20) init successful.
05:05:563 cubeb_pulse.c:1115 I[Audio]: Cubeb stream (0x796fd8004d20) started successfully.
05:05:564 cubeb_pulse.c:1131 I[Audio]: Cubeb stream (0x796fd8004d20) stopped successfully.
05:05:818 cubeb_pulse.c:1115 I[Audio]: Cubeb stream (0x796fd8004d20) started successfully.
05:11:312 AudioCommon/AudioCommon.cpp:83 I[Audio]: Shutting down sound stream
05:11:312 cubeb_pulse.c:1131 I[Audio]: Cubeb stream (0x796fd8004d20) stopped successfully.
05:11:312 cubeb_pulse.c:1131 I[Audio]: Cubeb stream (0x796fd8004d20) stopped successfully.
05:11:312 cubeb_pulse.c:1082 I[Audio]: Cubeb stream (0x796fd8004d20) destroyed successfully.
```