### PR TITLE
Check buffer out/size in HID_USBv5/USB_VEN GetVersion Ioctl

### DIFF
--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -29,6 +29,8 @@ std::optional<IPCReply> USB_HIDv5::IOCtl(const IOCtlRequest& request)
   switch (request.request)
   {
   case USB::IOCTL_USBV5_GETVERSION:
+    if (request.buffer_out == 0 || request.buffer_out_size != 32)
+      return IPCReply(IPC_EINVAL);
     memory.Write_U32(USBV5_VERSION, request.buffer_out);
     return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV5_GETDEVICECHANGE:

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -29,6 +29,8 @@ std::optional<IPCReply> USB_VEN::IOCtl(const IOCtlRequest& request)
   switch (request.request)
   {
   case USB::IOCTL_USBV5_GETVERSION:
+    if (request.buffer_out == 0 || request.buffer_out_size != 32)
+      return IPCReply(IPC_EINVAL);
     memory.Write_U32(USBV5_VERSION, request.buffer_out);
     return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV5_GETDEVICECHANGE:


### PR DESCRIPTION
I noticed these missing checks when I found a bug in this piece of code:
```c
        s32 ret5 = IOS::IOCtl(this->hidFd, IOS::IOCTL_HID5_GET_VERSION, nullptr, 0, nullptr, 0);
        if (ret5 == 0x50001) {
            this->hidVersion = 5;
        }
```
There are a few issues with this, but what is relevant for Dolphin is that we were passing a nullptr and size 0 for the out buffer/size. Since Dolphin had no size check here, it accepted that ioctl and wrote the version at address 0/0x80000000, which meant that it overwrote the game ID. I'd have expected at least an `EINVAL` error and the game ID left untouched, which is also what happens on real IOS. It doesn't fix the bug (the version is written to the buffer and not returned), but this would've made debugging this a lot easier.

I've also added a `buffer_out == 0` check simply because that's consistent with the other checks, and it does apply here as well (as in, IOS will also reject the ioctl if size is 32 but out is 0). Technically though ([according to Wiibrew](https://wiibrew.org/wiki//dev/usb/ven) and some quick testing), actual IOS is more strict and requires a buffer pointer aligned to 32 bytes and in mem2, but I left that out (those extra checks are also not present in the other ioctl handlers).