### PR TITLE
Android: Remove unused onSettingsFileNotFound and friends

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
@@ -10,6 +10,11 @@ import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.features.input.model.MappingCommon
 import java.io.Closeable
 
+/**
+ * Represents a set of settings stored in the native part of Dolphin.
+ *
+ * A set of settings can be either the global settings, or game settings for a particular game.
+ */
 class Settings : Closeable {
     private var gameId: String = ""
     private var revision = 0

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.kt
@@ -230,11 +230,6 @@ class SettingsActivity : AppCompatActivity(), SettingsActivityView {
         fragment?.onSettingsFileLoaded(settings)
     }
 
-    override fun onSettingsFileNotFound() {
-        val fragment: SettingsFragmentView? = fragment
-        fragment?.loadDefaultSettings()
-    }
-
     override fun showToastMessage(message: String) {
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.kt
@@ -31,25 +31,16 @@ interface SettingsActivityView {
     fun showDialogFragment(fragment: DialogFragment)
 
     /**
-     * Called by a contained Fragment to get access to the Setting HashMap
-     * loaded from disk, so that each Fragment doesn't need to perform its own
-     * read operation.
-     *
-     * @return A possibly null HashMap of Settings.
+     * Identifies which set of settings is to be read from and written to.
      */
     val settings: Settings
 
     /**
-     * Called when an asynchronous load operation completes.
+     * Called when a Settings object becomes available.
      *
-     * @param settings The (possibly null) result of the ini load operation.
+     * @param settings The settings that this Activity should access.
      */
     fun onSettingsFileLoaded(settings: Settings)
-
-    /**
-     * Called when an asynchronous load operation fails.
-     */
-    fun onSettingsFileNotFound()
 
     /**
      * Display a popup text message on screen.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.kt
@@ -116,10 +116,6 @@ class SettingsFragment : Fragment(), SettingsFragmentView {
         adapter!!.setSettings(settingsList)
     }
 
-    override fun loadDefaultSettings() {
-        presenter.loadDefaultSettings()
-    }
-
     override fun loadSubMenu(menuKey: MenuTag) {
         if (menuKey == MenuTag.GPU_DRIVERS) {
             showGpuDriverDialog()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -100,10 +100,6 @@ class SettingsFragmentPresenter(
             }
         }
 
-    fun loadDefaultSettings() {
-        loadSettingsList()
-    }
-
     private fun loadSettingsList() {
         val sl = ArrayList<SettingsItem>()
         when (menuTag) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.kt
@@ -14,10 +14,9 @@ import org.dolphinemu.dolphinemu.utils.GpuDriverInstallResult
  */
 interface SettingsFragmentView {
     /**
-     * Called by the containing Activity to notify the Fragment that an
-     * asynchronous load operation completed.
+     * Called when a Settings object becomes available.
      *
-     * @param settings The (possibly null) result of the ini load operation.
+     * @param settings The settings that this Fragment should access.
      */
     fun onSettingsFileLoaded(settings: Settings)
 
@@ -27,12 +26,6 @@ interface SettingsFragmentView {
      * @param settingsList The settings to display
      */
     fun showSettingsList(settingsList: ArrayList<SettingsItem>)
-
-    /**
-     * Called by the containing Activity when an asynchronous load operation fails.
-     * Instructs the Fragment to load the settings screen with defaults selected.
-     */
-    fun loadDefaultSettings()
 
     /**
      * @return The Fragment's containing activity.
@@ -95,12 +88,9 @@ interface SettingsFragmentView {
      * @param value   The current value of the Setting.
      */
     fun hasMenuTagActionForValue(menuTag: MenuTag, value: Int): Boolean
+
     /**
-     * Returns whether the input mapping dialog should detect inputs from all devices,
-     * not just the device configured for the controller.
-     */
-    /**
-     * Sets whether the input mapping dialog should detect inputs from all devices,
+     * Controls whether the input mapping dialog should detect inputs from all devices,
      * not just the device configured for the controller.
      */
     var isMappingAllDevices: Boolean


### PR DESCRIPTION
Old cruft from when the Android code was loading INI files manually. We don't have any handling for failing to load settings anymore.

This change also updates related comments to reflect how things actually work nowadays.