### PR TITLE
PerformanceTracker: Fix some interthread communication. Other cleanups.

### DIFF
--- a/Source/Core/VideoCommon/PerformanceTracker.cpp
+++ b/Source/Core/VideoCommon/PerformanceTracker.cpp
@@ -18,9 +18,8 @@ static constexpr double SAMPLE_RC_RATIO = 0.25;
 static constexpr u64 MAX_DT_QUEUE_SIZE = 1UL << 12u;
 static constexpr u64 MAX_QUALITY_GRAPH_SIZE = 1UL << 8u;
 
-PerformanceTracker::PerformanceTracker(std::optional<std::string> log_name,
-                                       const std::optional<DT> sample_window_duration)
-    : m_log_name{std::move(log_name)}, m_sample_window_duration{sample_window_duration}
+PerformanceTracker::PerformanceTracker(std::optional<std::string> log_name)
+    : m_log_name{std::move(log_name)}
 {
   Reset();
 }
@@ -102,10 +101,9 @@ void PerformanceTracker::HandleRawDt(DT diff)
   LogRenderTimeToFile(diff);
 }
 
-DT PerformanceTracker::GetSampleWindow() const
+DT PerformanceTracker::GetSampleWindow()
 {
-  return m_sample_window_duration.value_or(
-      duration_cast<DT>(DT_us{std::max(1, g_ActiveConfig.iPerfSampleUSec)}));
+  return duration_cast<DT>(DT_us{std::max(1, g_ActiveConfig.iPerfSampleUSec)});
 }
 
 double PerformanceTracker::GetHzAvg() const

--- a/Source/Core/VideoCommon/PerformanceTracker.h
+++ b/Source/Core/VideoCommon/PerformanceTracker.h
@@ -14,8 +14,7 @@
 class PerformanceTracker
 {
 public:
-  explicit PerformanceTracker(std::optional<std::string> log_name = std::nullopt,
-                              std::optional<DT> sample_window_duration = std::nullopt);
+  explicit PerformanceTracker(std::optional<std::string> log_name = std::nullopt);
   ~PerformanceTracker() = default;
 
   PerformanceTracker(const PerformanceTracker&) = delete;
@@ -34,7 +33,7 @@ public:
   void Count();
 
   // May call from any thread.
-  DT GetSampleWindow() const;
+  static DT GetSampleWindow();
   double GetHzAvg() const;
   DT GetDtAvg() const;
   DT GetDtStd() const;
@@ -60,9 +59,6 @@ private:
   //  and Pop'd from UpdateStats()
   Common::SPSCQueue<DT> m_raw_dts;
   std::atomic<DT> m_last_raw_dt = DT::zero();
-
-  // Amount of time to sample dt's over (defaults to config)
-  const std::optional<DT> m_sample_window_duration;
 
   // Queue + Running Total used to calculate average dt
   DT m_dt_total = DT::zero();

--- a/Source/Core/VideoCommon/PerformanceTracker.h
+++ b/Source/Core/VideoCommon/PerformanceTracker.h
@@ -14,8 +14,8 @@
 class PerformanceTracker
 {
 public:
-  PerformanceTracker(const std::optional<std::string> log_name = std::nullopt,
-                     const std::optional<DT> sample_window_duration = std::nullopt);
+  explicit PerformanceTracker(std::optional<std::string> log_name = std::nullopt,
+                              std::optional<DT> sample_window_duration = std::nullopt);
   ~PerformanceTracker() = default;
 
   PerformanceTracker(const PerformanceTracker&) = delete;
@@ -44,7 +44,7 @@ public:
 private:
   void LogRenderTimeToFile(DT val);
 
-  void HandleRawDt(DT value);
+  void HandleRawDt(DT diff);
   void PushFront(DT value);
   void PopBack();
 


### PR DESCRIPTION
VPS `PerformanceTracker::ImPlotPlotLines` unsafely accessed `m_last_time` in gpu-thread.
This was my fault from #13398.

`ImPlotPlotLines` used this value for a `predicted_frame_time`, i.e. the right-most point in the performance graph that wouldn't be measured until after the very frame that's being generated.

Two problems:
1. The cross thread variable usage was wrong.
2. The predicted time value doesn't make sense for VPS because VPS is not necessarily tied to the presentation time.

I removed the "predicted" value from the graph. Now only actually measured values are shown which eliminates both problems.

I also cleaned up some other atomic usages.