### PR TITLE
SDL: Check if touchpad exists before getting input

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDLGamepad.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDLGamepad.h
@@ -362,11 +362,15 @@ public:
     const int touchpad_index = 0;
     const int finger_index = 0;
 
-    Uint8 state = 0;
-    SDL_GameControllerGetTouchpadFinger(m_gamecontroller, touchpad_index, finger_index, &state,
-                                        &m_touchpad_x, &m_touchpad_y, &m_touchpad_pressure);
-    m_touchpad_x = m_touchpad_x * 2 - 1;
-    m_touchpad_y = m_touchpad_y * 2 - 1;
+    if (SDL_GameControllerGetNumTouchpads(m_gamecontroller) > touchpad_index &&
+        SDL_GameControllerGetNumTouchpadFingers(m_gamecontroller, touchpad_index) > finger_index)
+    {
+      Uint8 state = 0;
+      SDL_GameControllerGetTouchpadFinger(m_gamecontroller, touchpad_index, finger_index, &state,
+                                          &m_touchpad_x, &m_touchpad_y, &m_touchpad_pressure);
+      m_touchpad_x = m_touchpad_x * 2 - 1;
+      m_touchpad_y = m_touchpad_y * 2 - 1;
+    }
 
     return Core::DeviceRemoval::Keep;
   }


### PR DESCRIPTION
Verify a touchpad is present before polling it for input. Without this check, if you have a controller that doesn't have a touchpad the Debug log gets spammed with the message `error: Parameter 'touchpad' is invalid`, and its touchpad values quickly shoot to -inf.

One would think every touchpad supports at least 1 finger, but in case there's some weird edge case check the finger count to be sure.