### PR TITLE
VideoCommon: move position/normal/bitangent/tangent transformation to accessible functions in VertexShaderGen

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -74,6 +74,147 @@ VertexShaderUid GetVertexShaderUid()
   return out;
 }
 
+static void WriteTransforms(APIType api_type, const ShaderHostConfig& host_config,
+                            const vertex_shader_uid_data* uid_data, ShaderCode& out)
+{
+  out.Write("vec4 dolphin_transform_position(vec4 rawpos)\n");
+  out.Write("{{\n");
+  if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
+  {
+    // Vertex format has a per-vertex matrix
+    out.Write("\tint posidx = int(posmtx.r);\n"
+              "\tvec4 P0 = " I_TRANSFORMMATRICES "[posidx];\n"
+              "\tvec4 P1 = " I_TRANSFORMMATRICES "[posidx + 1];\n"
+              "\tvec4 P2 = " I_TRANSFORMMATRICES "[posidx + 2];\n");
+  }
+  else
+  {
+    // One shared matrix
+    out.Write("\tvec4 P0 = " I_POSNORMALMATRIX "[0];\n"
+              "\tvec4 P1 = " I_POSNORMALMATRIX "[1];\n"
+              "\tvec4 P2 = " I_POSNORMALMATRIX "[2];\n");
+  }
+  out.Write("\t// Multiply the position vector by the position matrix\n"
+            "\treturn vec4(dot(P0, rawpos), dot(P1, rawpos), dot(P2, rawpos), 1.0);\n");
+  out.Write("}}\n\n");
+
+  out.Write("vec4 dolphin_project_position(vec4 pos)\n");
+  out.Write("{{\n");
+  out.Write("\treturn vec4(dot(" I_PROJECTION "[0], pos), dot(" I_PROJECTION
+            "[1], pos), dot(" I_PROJECTION "[2], pos), dot(" I_PROJECTION "[3], pos));\n");
+  out.Write("}}\n\n");
+
+  out.Write("vec3 dolphin_transform_normal(vec3 norm)\n");
+  out.Write("{{\n");
+
+  if ((uid_data->components & VB_HAS_NORMAL) != 0)
+  {
+    if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
+    {
+      // Vertex format has a per-vertex matrix
+      out.Write("\tint posidx = int(posmtx.r);\n");
+      out.Write("\tint normidx = posidx & 31;\n"
+                "\tvec3 N0 = " I_NORMALMATRICES "[normidx].xyz;\n"
+                "\tvec3 N1 = " I_NORMALMATRICES "[normidx + 1].xyz;\n"
+                "\tvec3 N2 = " I_NORMALMATRICES "[normidx + 2].xyz;\n");
+    }
+    else
+    {
+      // One shared matrix
+      out.Write("\tvec3 N0 = " I_POSNORMALMATRIX "[3].xyz;\n"
+                "\tvec3 N1 = " I_POSNORMALMATRIX "[4].xyz;\n"
+                "\tvec3 N2 = " I_POSNORMALMATRIX "[5].xyz;\n");
+    }
+    // The scale of the transform matrix is used to control the size of the emboss map effect, by
+    // changing the scale of the transformed binormals (which only get used by emboss map texgens).
+    // By normalising the first transformed normal (which is used by lighting calculations and needs
+    // to be unit length), the same transform matrix can do double duty, scaling for emboss mapping,
+    // and not scaling for lighting.
+    out.Write("\treturn vec3(dot(N0, norm), dot(N1, norm), dot(N2, "
+              "norm));\n");
+  }
+  else
+  {
+    out.Write("\treturn norm;\n");
+  }
+
+  out.Write("}}\n\n");
+
+  out.Write("vec3 dolphin_transform_binormal(vec3 binormal)\n");
+  out.Write("{{\n");
+
+  if ((uid_data->components & VB_HAS_NORMAL) != 0)
+  {
+    if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
+    {
+      // Vertex format has a per-vertex matrix
+      out.Write("\tint posidx = int(posmtx.r);\n");
+      out.Write("\tint normidx = posidx & 31;\n"
+                "\tvec3 N0 = " I_NORMALMATRICES "[normidx].xyz;\n"
+                "\tvec3 N1 = " I_NORMALMATRICES "[normidx + 1].xyz;\n"
+                "\tvec3 N2 = " I_NORMALMATRICES "[normidx + 2].xyz;\n");
+    }
+    else
+    {
+      // One shared matrix
+      out.Write("\tvec3 N0 = " I_POSNORMALMATRIX "[3].xyz;\n"
+                "\tvec3 N1 = " I_POSNORMALMATRIX "[4].xyz;\n"
+                "\tvec3 N2 = " I_POSNORMALMATRIX "[5].xyz;\n");
+    }
+
+    // The scale of the transform matrix is used to control the size of the emboss map effect, by
+    // changing the scale of the transformed binormals (which only get used by emboss map texgens).
+    // By normalising the first transformed normal (which is used by lighting calculations and needs
+    // to be unit length), the same transform matrix can do double duty, scaling for emboss mapping,
+    // and not scaling for lighting.
+    out.Write("\treturn vec3(dot(N0, binormal), dot(N1, binormal), dot(N2, "
+              "binormal));\n");
+  }
+  else
+  {
+    out.Write("\treturn vec3(0, 0, 0);\n");
+  }
+
+  out.Write("}}\n\n");
+
+  out.Write("vec3 dolphin_transform_tangent(vec3 tangent)\n");
+  out.Write("{{\n");
+
+  if ((uid_data->components & VB_HAS_NORMAL) != 0)
+  {
+    if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
+    {
+      // Vertex format has a per-vertex matrix
+      out.Write("\tint posidx = int(posmtx.r);\n");
+      out.Write("\tint normidx = posidx & 31;\n"
+                "\tvec3 N0 = " I_NORMALMATRICES "[normidx].xyz;\n"
+                "\tvec3 N1 = " I_NORMALMATRICES "[normidx + 1].xyz;\n"
+                "\tvec3 N2 = " I_NORMALMATRICES "[normidx + 2].xyz;\n");
+    }
+    else
+    {
+      // One shared matrix
+      out.Write("\tvec3 N0 = " I_POSNORMALMATRIX "[3].xyz;\n"
+                "\tvec3 N1 = " I_POSNORMALMATRIX "[4].xyz;\n"
+                "\tvec3 N2 = " I_POSNORMALMATRIX "[5].xyz;\n");
+    }
+
+    // The scale of the transform matrix is used to control the size of the emboss map effect, by
+    // changing the scale of the transformed binormals (which only get used by emboss map texgens).
+    // By normalising the first transformed normal (which is used by lighting calculations and needs
+    // to be unit length), the same transform matrix can do double duty, scaling for emboss mapping,
+    // and not scaling for lighting.
+    out.Write("\treturn vec3(dot(N0, tangent), dot(N1, tangent), dot(N2, "
+              "tangent));\n");
+  }
+  else
+  {
+    out.Write("\treturn vec3(0, 0, 0);\n");
+  }
+
+  out.Write("}}\n\n");
+}
+
 static void WriteTexCoordTransforms(APIType api_type, const ShaderHostConfig& host_config,
                                     const vertex_shader_uid_data* uid_data, ShaderCode& out)
 {
@@ -337,6 +478,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   }
 
   WriteTexCoordTransforms(api_type, host_config, uid_data, out);
+  WriteTransforms(api_type, host_config, uid_data, out);
 
   out.Write("void main()\n{{\n");
 
@@ -383,53 +525,17 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     }
   }
 
-  // transforms
-  if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
-  {
-    // Vertex format has a per-vertex matrix
-    out.Write("int posidx = int(posmtx.r);\n"
-              "float4 P0 = " I_TRANSFORMMATRICES "[posidx];\n"
-              "float4 P1 = " I_TRANSFORMMATRICES "[posidx + 1];\n"
-              "float4 P2 = " I_TRANSFORMMATRICES "[posidx + 2];\n"
-              "int normidx = posidx & 31;\n"
-              "float3 N0 = " I_NORMALMATRICES "[normidx].xyz;\n"
-              "float3 N1 = " I_NORMALMATRICES "[normidx + 1].xyz;\n"
-              "float3 N2 = " I_NORMALMATRICES "[normidx + 2].xyz;\n");
-  }
-  else
-  {
-    // One shared matrix
-    out.Write("float4 P0 = " I_POSNORMALMATRIX "[0];\n"
-              "float4 P1 = " I_POSNORMALMATRIX "[1];\n"
-              "float4 P2 = " I_POSNORMALMATRIX "[2];\n"
-              "float3 N0 = " I_POSNORMALMATRIX "[3].xyz;\n"
-              "float3 N1 = " I_POSNORMALMATRIX "[4].xyz;\n"
-              "float3 N2 = " I_POSNORMALMATRIX "[5].xyz;\n");
-  }
-
-  out.Write("// Multiply the position vector by the position matrix\n"
-            "float4 pos = float4(dot(P0, rawpos), dot(P1, rawpos), dot(P2, rawpos), 1.0);\n");
+  out.Write("\tvec4 pos = dolphin_transform_position(rawpos);\n");
   if ((uid_data->components & VB_HAS_NORMAL) == 0)
-    out.Write("float3 rawnormal = " I_CACHED_NORMAL ".xyz;\n");
+    out.Write("\tvec3 rawnormal = " I_CACHED_NORMAL ".xyz;\n");
+  out.Write("\tvec3 _normal = normalize(dolphin_transform_normal(rawnormal));\n");
+
   if ((uid_data->components & VB_HAS_TANGENT) == 0)
-    out.Write("float3 rawtangent = " I_CACHED_TANGENT ".xyz;\n");
+    out.Write("\tvec3 rawtangent = " I_CACHED_TANGENT ".xyz;\n");
   if ((uid_data->components & VB_HAS_BINORMAL) == 0)
-    out.Write("float3 rawbinormal = " I_CACHED_BINORMAL ".xyz;\n");
+    out.Write("\tvec3 rawbinormal = " I_CACHED_BINORMAL ".xyz;\n");
 
-  // The scale of the transform matrix is used to control the size of the emboss map effect, by
-  // changing the scale of the transformed binormals (which only get used by emboss map texgens).
-  // By normalising the first transformed normal (which is used by lighting calculations and needs
-  // to be unit length), the same transform matrix can do double duty, scaling for emboss mapping,
-  // and not scaling for lighting.
-  out.Write("float3 _normal = normalize(float3(dot(N0, rawnormal), dot(N1, rawnormal), dot(N2, "
-            "rawnormal)));\n"
-            "float3 _tangent = float3(dot(N0, rawtangent), dot(N1, rawtangent), dot(N2, "
-            "rawtangent));\n"
-            "float3 _binormal = float3(dot(N0, rawbinormal), dot(N1, rawbinormal), dot(N2, "
-            "rawbinormal));\n");
-
-  out.Write("o.pos = float4(dot(" I_PROJECTION "[0], pos), dot(" I_PROJECTION
-            "[1], pos), dot(" I_PROJECTION "[2], pos), dot(" I_PROJECTION "[3], pos));\n");
+  out.Write("\to.pos = dolphin_project_position(pos);\n");
 
   out.Write("int4 lacc;\n"
             "float3 ldir, h, cosAttn, distAttn;\n"
@@ -505,9 +611,11 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
       // transform the light dir into tangent space
       out.Write("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n",
                 LIGHT_POS_PARAMS(texinfo.embosslightshift));
+      out.Write("\tvec3 tangent = dolphin_transform_tangent(rawtangent);\n");
+      out.Write("\tvec3 binormal = dolphin_transform_binormal(rawbinormal);\n");
       out.Write(
-          "o.tex{}.xyz = o.tex{}.xyz + float3(dot(ldir, _tangent), dot(ldir, _binormal), 0.0);\n",
-          i, texinfo.embosssourceshift);
+          "o.tex{}.xyz = o.tex{}.xyz + float3(dot(ldir, tangent), dot(ldir, binormal), 0.0);\n", i,
+          texinfo.embosssourceshift);
 
       break;
     case TexGenType::Color0:
@@ -551,8 +659,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     }
     else
     {
-      out.Write("other_pos = float4(dot(P0, other_pos), dot(P1, other_pos), dot(P2, other_pos), "
-                "1.0f);\n");
+      out.Write("other_pos = dolphin_transform_position(other_pos);\n");
     }
     GenerateVSLineExpansion(out, "", uid_data->numTexGens);
   }


### PR DESCRIPTION
I was hoping to expose matrix functions (as seen in #13350 ) but fifoci seems to have some issues with it?

From discussing with @TellowKrinkle , it seems like the shader compiler might have the ability to change its order of operations which leads to ever so slightly different results.  There are two fifo files that are more than just minor differences ([mp3-bloom](https://fifo.ci/compare/13357203-13355833/) and [chibi-robo-zfighting](https://fifo.ci/compare/13357114-13355744/)).

As this change blocks other features being merged, I'd like the team to pick one of the PRs that they feel most comfortable with.  Functionally, the matrices are a nicer solution but not sure if the change is acceptable (certainly gives me a bit of concern).