### PR TITLE
Common and VideoCommon: Change texture data from std::vector to Common::UniqueBuffer.

### DIFF
--- a/Source/Core/Common/Buffer.h
+++ b/Source/Core/Common/Buffer.h
@@ -40,6 +40,10 @@ public:
 
   void assign(PtrType ptr, size_type new_size) { BufferBase{std::move(ptr), new_size}.swap(*this); }
   void reset(size_type new_size = 0) { BufferBase{new_size}.swap(*this); }
+  void clear() { reset(); }
+
+  // Resize is purposely not provided as it often unnecessarily copies data about to be overwritten.
+  void resize(std::size_t) = delete;
 
   std::pair<PtrType, size_type> extract()
   {

--- a/Source/Core/Common/Image.h
+++ b/Source/Core/Common/Image.h
@@ -3,14 +3,15 @@
 
 #pragma once
 
+#include <span>
 #include <string>
-#include <vector>
 
+#include "Common/Buffer.h"
 #include "Common/CommonTypes.h"
 
 namespace Common
 {
-bool LoadPNG(const std::vector<u8>& input, std::vector<u8>* data_out, u32* width_out,
+bool LoadPNG(std::span<const u8> input, Common::UniqueBuffer<u8>* data_out, u32* width_out,
              u32* height_out);
 
 enum class ImageByteFormat

--- a/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementBox.cpp
@@ -85,7 +85,7 @@ void AchievementBox::UpdateData()
       color = AchievementManager::GOLD;
     else if (m_achievement->unlocked & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE)
       color = AchievementManager::BLUE;
-    QImage i_badge(&badge.data.front(), badge.width, badge.height, QImage::Format_RGBA8888);
+    QImage i_badge(badge.data.data(), badge.width, badge.height, QImage::Format_RGBA8888);
     m_badge->setPixmap(
         QPixmap::fromImage(i_badge).scaled(64, 64, Qt::KeepAspectRatio, Qt::SmoothTransformation));
     m_badge->adjustSize();

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -438,7 +438,7 @@ bool GameFile::ReadPNGBanner(const std::string& path)
     return false;
 
   GameBanner& banner = m_pending.custom_banner;
-  std::vector<u8> data_out;
+  Common::UniqueBuffer<u8> data_out;
   if (!Common::LoadPNG(png_data, &data_out, &banner.width, &banner.height))
     return false;
 

--- a/Source/Core/VideoCommon/Assets/CustomTextureData.h
+++ b/Source/Core/VideoCommon/Assets/CustomTextureData.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
+#include <span>
 #include <string>
-#include <vector>
 
+#include "Common/Buffer.h"
 #include "Common/CommonTypes.h"
 #include "VideoCommon/TextureConfig.h"
 
@@ -18,7 +19,7 @@ public:
   {
     struct Level
     {
-      std::vector<u8> data;
+      Common::UniqueBuffer<u8> data;
       AbstractTextureFormat format = AbstractTextureFormat::RGBA8;
       u32 width = 0;
       u32 height = 0;
@@ -33,5 +34,5 @@ bool LoadDDSTexture(CustomTextureData* texture, const std::string& filename);
 bool LoadDDSTexture(CustomTextureData::ArraySlice::Level* level, const std::string& filename,
                     u32 mip_level);
 bool LoadPNGTexture(CustomTextureData::ArraySlice::Level* level, const std::string& filename);
-bool LoadPNGTexture(CustomTextureData::ArraySlice::Level* level, const std::vector<u8>& buffer);
+bool LoadPNGTexture(CustomTextureData::ArraySlice::Level* level, std::span<const u8> buffer);
 }  // namespace VideoCommon


### PR DESCRIPTION
Using `Common::UniqueBuffer` avoids unnecessary zero-initialization of these buffers.
I suppose it also prevents any inadvertent copying of the data.