### PR TITLE
VideoCommon: Normalize file last write time calculations to prevent reloads of the same asset.

### DIFF
--- a/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.cpp
+++ b/Source/Core/VideoCommon/Assets/DirectFilesystemAssetLibrary.cpp
@@ -32,8 +32,10 @@ std::chrono::system_clock::time_point FileTimeToSysTime(std::filesystem::file_ti
   // once it is available for use
   const auto system_time_now = std::chrono::system_clock::now();
   const auto file_time_now = decltype(file_time)::clock::now();
-  return std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+  const auto sys_time = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
       file_time - file_time_now + system_time_now);
+  // Normalize to milliseconds to avoid precision issues
+  return std::chrono::time_point_cast<std::chrono::milliseconds>(sys_time);
 #endif
 }
 


### PR DESCRIPTION
When "Load Custom Textures" is enabled, a loop checks for updates in the asset files each 500ms.
Precision inconsistencies in the chrono::clock_cast workaround can cause loads of the same asset, if the calculated last write time don't match with the previously stored value.
This fixed this, and maybe help mitigate performance issues with large custom texture packs.

TL;DR:

While working on some changes to the CustomAssetLoader, I noticed that custom textures were loading multiple times. These texture reloads weren't consistent in number, place or time period, such as when launching a game. I found that this issue affects Linux, but not Windows.

During one of the tests I conducted, over a 60-second period after game launch, the changes in the calculated last write times for the same PNG texture were as follows:

2025-03-08 18:09:55.652889927
2025-03-08 18:09:55.652890017
2025-03-08 18:09:55.652890027
2025-03-08 18:09:55.652889977
2025-03-08 18:09:55.652890017
2025-03-08 18:09:55.652890027
2025-03-08 18:09:55.652890007
2025-03-08 18:09:55.652890027
2025-03-08 18:09:55.652890037
2025-03-08 18:09:55.652890017
2025-03-08 18:09:55.652890037

And with each last write time differing from the previous stored one, the texture loads again.