### PR TITLE
AchievementManager: Fix unknown hash achievements deadlock

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -719,6 +719,8 @@ void AchievementManager::DoState(PointerWrap& p)
 
 void AchievementManager::CloseGame()
 {
+  m_queue.Cancel();
+  m_image_queue.Cancel();
   {
     std::lock_guard lg{m_lock};
     m_active_challenges.clear();
@@ -730,8 +732,6 @@ void AchievementManager::CloseGame()
     m_locked_badges.clear();
     m_leaderboard_map.clear();
     m_rich_presence.fill('\0');
-    m_queue.Cancel();
-    m_image_queue.Cancel();
     m_system.store(nullptr, std::memory_order_release);
     if (Config::Get(Config::RA_DISCORD_PRESENCE_ENABLED))
       Discord::UpdateDiscordPresence();


### PR DESCRIPTION
Within AchievementManager, CloseGame being called when LoadGame fails was causing m_queue.Cancel to be called within a lock when Cancel itself locks until it is empty, causing a deadlock. This is resolved by cancelling the queues outside of the lock when they are safe to wait for resolutions.