### PR TITLE
AchievementManager: MEM2 Support

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -1317,10 +1317,10 @@ void AchievementManager::Request(const rc_api_request_t* request,
 u32 AchievementManager::MemoryVerifier(u32 address, u8* buffer, u32 num_bytes, rc_client_t* client)
 {
   auto& system = Core::System::GetInstance();
-  u32 ram_size = system.GetMemory().GetRamSizeReal();
-  if (address >= ram_size)
-    return 0;
-  return std::min(ram_size - address, num_bytes);
+  u32 mem2_size = system.GetMemory().GetExRamSizeReal();
+  if (address < MEM1_SIZE + mem2_size)
+    return std::min(MEM1_SIZE + mem2_size - address, num_bytes);
+  return 0;
 }
 
 u32 AchievementManager::MemoryPeeker(u32 address, u8* buffer, u32 num_bytes, rc_client_t* client)

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -76,6 +76,9 @@ public:
   using RichPresence = std::array<char, RP_SIZE>;
   using Badge = VideoCommon::CustomTextureData::ArraySlice::Level;
   static constexpr size_t MAX_DISPLAYED_LBOARDS = 4;
+  // This is hardcoded to 24MiB because rcheevos currently hardcodes it to 24MiB.
+  static constexpr u32 MEM1_SIZE = 0x01800000;
+  static constexpr u32 MEM2_START = 0x10000000;
 
   static constexpr std::string_view DEFAULT_PLAYER_BADGE_FILENAME = "achievements_player.png";
   static constexpr std::string_view DEFAULT_GAME_BADGE_FILENAME = "achievements_game.png";


### PR DESCRIPTION
A couple portions of AchievementManager were still limiting to MEM1 despite everything else supporting Wii.