### PR TITLE
DolphinQt/TAS: Use non-default std::atomic struct constructor to fix build with libstdc++ 15.

### DIFF
--- a/Source/Core/DolphinQt/TAS/TASControlState.h
+++ b/Source/Core/DolphinQt/TAS/TASControlState.h
@@ -38,6 +38,6 @@ private:
     int value = 0;
   };
 
-  std::atomic<State> m_ui_thread_state;
-  std::atomic<State> m_cpu_thread_state;
+  std::atomic<State> m_ui_thread_state = State{};
+  std::atomic<State> m_cpu_thread_state = State{};
 };


### PR DESCRIPTION
As far as I understand the existing code is valid, but libstdc++ 15 claims `std::atomic<State>` has no default-ctor.