### PR TITLE
GameINI: Disable Dual Core for Piglet's Big Game

### DIFF
--- a/Data/Sys/GameSettings/GPL.ini
+++ b/Data/Sys/GameSettings/GPL.ini
@@ -1,0 +1,11 @@
+# GPLE9G, GPLP9G, GPLD9G, GPLF9G - Piglet's Big Game
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/GWH.ini
+++ b/Data/Sys/GameSettings/GWH.ini
@@ -1,0 +1,11 @@
+# GWHP41, GWHE41 - Winnie the Pooh's Rumbly Tumbly Adventure
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.


### PR DESCRIPTION
Disable Dual Core for Piglet's Big Game and Winnie The Pooh's Rumbly Tumbly Adventure since it uses the same engine, as these games are very unstable and prone to freezing/crashing with Dual Core enabled.