### PR TITLE
GameINI: fix screen tearing in PoP:SoT FMVs

### DIFF
--- a/Data/Sys/GameSettings/GPT.ini
+++ b/Data/Sys/GameSettings/GPT.ini
@@ -12,4 +12,7 @@
 [Video_Settings]
 
 [Video_Hacks]
+# Fixes FMVs tearing
+EarlyXFBOutput = False
+# Fixes FMVs not showing
 ImmediateXFBEnable = False


### PR DESCRIPTION
Prince of Persia: Sands of Time exhibits screen tearing on FMVs in Dolphin. Tested the setting (suggested by Amphitryon in the Discord) on PC and Android and can confirm the tearing previously seen is gone with EarlyXFBOutput disabled.