### PR TITLE
IOS/USB: Change HIDv4.cpp LogLevel to avoid INTRMSG killing performance

### DIFF
--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -34,7 +34,7 @@ std::optional<IPCReply> USB_HIDv4::IOCtl(const IOCtlRequest& request)
   auto& system = GetSystem();
   auto& memory = system.GetMemory();
 
-  request.Log(GetDeviceName(), Common::Log::LogType::IOS_USB);
+  request.Log(GetDeviceName(), Common::Log::LogType::IOS_USB, Common::Log::LogLevel::LDEBUG);
   switch (request.request)
   {
   case USB::IOCTL_USBV4_GETVERSION:


### PR DESCRIPTION
This PR changes the log level of this message as it can be sent a lot when polling inputs from a keyboard. Thus, killing performance by a lot. HIDv5.cpp doesn't log INTRMSG in such a way. If needed, log messages can be added into specific devices instead.

Ready to be reviewed & merged.