### PR TITLE
Remove filename option from stubbed AchievementManager::LoadGame

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -351,7 +351,7 @@ public:
     return true;
   }
 
-  constexpr void LoadGame(const std::string&, const DiscIO::Volume*) {}
+  constexpr void LoadGame(const DiscIO::Volume*) {}
 
   constexpr void SetBackgroundExecutionAllowed(bool allowed) {}
 


### PR DESCRIPTION
Fixes: c796691d008263f214364bbb986e3ad2c900ae94

With -DUSE_RETRO_ACHIEVEMENTS=OFF
```
/home/ask/sources/dolphin/Source/Core/Core/Boot/Boot.cpp: In member function ‘bool CBoot::BootUp(Core::System&, const Core::CPUThreadGuard&, std::unique_ptr<BootParameters>)::BootTitle::operator()(const DiscIO::VolumeWAD&) const’:
/home/ask/sources/dolphin/Source/Core/Core/Boot/Boot.cpp:626:49: error: no matching function for call to ‘AchievementManager::LoadGame(const DiscIO::VolumeWAD*)’
  626 |       AchievementManager::GetInstance().LoadGame(&wad);
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/ask/sources/dolphin/Source/Core/Core/Boot/Boot.cpp:626:49: note: there is 1 candidate
In file included from /home/ask/sources/dolphin/Source/Core/Core/Boot/Boot.cpp:31:
/home/ask/sources/dolphin/Source/Core/Core/AchievementManager.h:354:18: note: candidate 1: ‘constexpr void AchievementManager::LoadGame(const std::string&, const DiscIO::Volume*)’
  354 |   constexpr void LoadGame(const std::string&, const DiscIO::Volume*) {}
      |                  ^~~~~~~~
/home/ask/sources/dolphin/Source/Core/Core/AchievementManager.h:354:18: note: candidate expects 2 arguments, 1 provided
gmake[2]: *** [Source/Core/Core/CMakeFiles/core.dir/build.make:149: Source/Core/Core/CMakeFiles/core.dir/Boot/Boot.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
/home/ask/sources/dolphin/Source/Core/Core/Core.cpp: In function ‘std::string Core::GenerateScreenshotName()’:
/home/ask/sources/dolphin/Source/Core/Core/Core.cpp:748:73: warning: ‘tm fmt::v11::localtime(time_t)’ is deprecated [-Wdeprecated-declarations]
  748 |       fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}", path_prefix, fmt::localtime(cur_time));
      |                                                           ~~~~~~~~~~~~~~^~~~~~~~~~
In file included from /home/ask/sources/dolphin/Source/Core/Core/Core.cpp:15:
/usr/include/fmt/chrono.h:538:28: note: declared here
  538 | FMT_DEPRECATED inline auto localtime(std::time_t time) -> std::tm {
      |                            ^~~~~~~~~
gmake[1]: *** [CMakeFiles/Makefile2:2015: Source/Core/Core/CMakeFiles/core.dir/all] Error 2
gmake: *** [Makefile:156: all] Error 2
```