### PR TITLE
GameINI: Disable Dual Core for Shadow the Hedgehog

### DIFF
--- a/Data/Sys/GameSettings/GUP.ini
+++ b/Data/Sys/GameSettings/GUP.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnFrame]
 # Add memory patches to be applied every frame here.


### PR DESCRIPTION
Saw a high volume of dual core causing crashes with the launch of RA set.