### PR TITLE
Flatpak: Don't use CFLAGS and CXXFLAGS provided by the SDK

### DIFF
--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -44,6 +44,12 @@ modules:
   - name: dolphin-emu
     buildsystem: cmake-ninja
     builddir: true
+    build-options:
+      # don't use any default flags provided by the SDK
+      cflags: ""
+      cflags-override: true
+      cxxflags: ""
+      cxxflags-override: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DENABLE_ALSA=OFF


### PR DESCRIPTION
This is `/etc/flatpak-builder/defaults.json` on `org.kde.Sdk` 6.8:

```json
{
  "libdir": "/usr/lib/x86_64-linux-gnu",
  "cflags": "-O2 -pipe -g -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer ",
  "cxxflags": "-O2 -pipe -g -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer ",
  "cppflags": "",
  "ldflags": "-L/app/lib -Wl,-z,relro,-z,now -Wl,--as-needed "
}
```