### PR TITLE
GameINI: Disable Immediately Present XFB for Dragon Ball Z: Budokai and Dragon Ball Z: Budokai 2

### DIFF
--- a/Data/Sys/GameSettings/GD7.ini
+++ b/Data/Sys/GameSettings/GD7.ini
@@ -1,0 +1,5 @@
+# GD7JB2, GD7E70, GD7PB2 - Dragon Ball Z: Budokai
+
+[Video_Hacks]
+# Frame pacing
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GZ3.ini
+++ b/Data/Sys/GameSettings/GZ3.ini
@@ -1,0 +1,5 @@
+# GZ3E70, GZ3PB2 - Dragon Ball Z: Budokai 2
+
+[Video_Hacks]
+# Frame pacing
+ImmediateXFBEnable = False


### PR DESCRIPTION
Having it enabled makes the frame pacing so bad that the frame rate feels like half of what it actually is, no matter if you are in gameplay or in cutscenes.

Note that I only have the first game (GD7PB2), I _assume_ that the Budokai 2 is also affected, but that needs to be tested before merging this.

![image](https://github.com/user-attachments/assets/6ca12123-ffd3-4cba-9be6-87b9f933a847)
