### PR TITLE
GameINI: Set texture cache accuracy for Scooby-Doo! Night of 100 Frights PAL

### DIFF
--- a/Data/Sys/GameSettings/GIHP78.ini
+++ b/Data/Sys/GameSettings/GIHP78.ini
@@ -1,0 +1,5 @@
+# GIHP78 - Scooby-Doo! Night of 100 Frights
+
+[Video_Settings]
+# Fixes video stuttering on FMVs encoded at 25 FPS
+SafeTextureCacheColorSamples = 512


### PR DESCRIPTION
FMVs have horrible video stuttering without it.
Gameplay FPS penalty is in the margin of error.
Tested on GIHP78.
It might be possible that the NTSC version is not affected? (Most FMVs on the PAL version are encoded at 25 FPS, but the ones encoded at 30 FPS do not seem to have the issue.)

https://github.com/user-attachments/assets/9dde4c9b-8134-4d57-96d6-11bfca7ab0fb

