### PR TITLE
PowerPC: Correctly handle stswi/stswx to uncached memory

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -309,6 +309,8 @@ private:
   static void Helper_FloatCompareUnordered(PowerPC::PowerPCState& ppc_state, UGeckoInstruction inst,
                                            double a, double b);
 
+  static void Helper_StoreString(Interpreter& interpreter, const u32 EA, u32 n, u32 r);
+
   void UpdatePC();
   bool IsInvalidPairedSingleExecution(UGeckoInstruction inst);
 


### PR DESCRIPTION
On real hardware, stswi and stswx don't trigger any of the special behavior for uncached unaligned writes that was implemented in 543ed8a. This is confirmed by a hwtest (a new commit in https://github.com/dolphin-emu/hwtests/pull/42).

This change fixes Dolphin's stswi and stswx implementations so they stop triggering the special behavior, bringing them back to the behavior they had before 543ed8a. No games are known to be affected, but @extremscorner has reported that it affects homebrew they've made.