### PR TITLE
[DO NOT MERGE] Android: try to make my Pixel 6 run at full speed

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:dataExtractionRules="@xml/backup_rules_api_31"
         android:supportsRtl="true"
+        android:appCategory="game"
         android:isGame="true"
         android:banner="@drawable/banner_tv"
         android:hasFragileUserData="true"
@@ -46,6 +47,9 @@
         <meta-data
             android:name="android.max_aspect"
             android:value="2.1"/>
+        <meta-data
+            android:name="android.game_mode_config"
+            android:resource="@xml/game_mode_config" />
         <profileable
             android:shell="true"
             tools:targetApi="29" />

--- a/Source/Android/app/src/main/res/xml/game_mode_config.xml
+++ b/Source/Android/app/src/main/res/xml/game_mode_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <game-mode-config
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:supportsBatteryGameMode="false"
-    android:supportsPerformanceGameMode="false"
+    android:supportsBatteryGameMode="true"
+    android:supportsPerformanceGameMode="true"
 />

--- a/Source/Android/app/src/main/res/xml/game_mode_config.xml
+++ b/Source/Android/app/src/main/res/xml/game_mode_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<game-mode-config
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsBatteryGameMode="false"
+    android:supportsPerformanceGameMode="false"
+/>


### PR DESCRIPTION
Just guessing at what will make my Pixel 6 run Mario Sunshine at full speed, other than when I'm actively causing UI updates.
Specifically, I can trigger this speedup tapping or dragging my finger on the system notification bar, left side menu, controller overlay, etc. Holding my finger in place doesn't do anything. Pressing volume or power buttons also works since it brings up the volume overlay or fades the screen out.
Seems to be CPU based, since raising the internal resolution makes no difference (another good idea would be to have separate CPU and GPU usage stats in the overlay instead of just guessing based on the maximum speed estimate).
Making it a PR for ease of getting builds.

https://github.com/dolphin-emu/dolphin/pull/10206#issuecomment-2867912911