### PR TITLE
Android: Don't dismiss AdvancedMappingDialog when pressing Clear

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/ui/AdvancedMappingDialog.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/ui/AdvancedMappingDialog.kt
@@ -52,8 +52,9 @@ class AdvancedMappingDialog(
         selectDefaultDevice()
     }
 
-    val expression: String
+    var expression: String
         get() = binding.editExpression.text.toString()
+        set(value) = binding.editExpression.setText(value)
 
     override fun onItemClick(adapterView: AdapterView<*>?, view: View, position: Int, id: Long) =
         setSelectedDevice(devices[position])

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.kt
@@ -347,13 +347,15 @@ class SettingsAdapter(
         dialog.setButton(
             AlertDialog.BUTTON_NEUTRAL,
             context.getString(R.string.clear)
-        ) { _: DialogInterface?, _: Int ->
-            item.clearValue()
-            notifyItemChanged(position)
-            fragmentView.onSettingChanged()
-        }
+        ) { _: DialogInterface?, _: Int -> }
         dialog.setCanceledOnTouchOutside(false)
         dialog.show()
+
+        // We're setting this OnClickListener late so that pressing the Clear button won't result
+        // in the dialog closing
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+            dialog.expression = ""
+        }
     }
 
     fun onFilePickerDirectoryClick(item: SettingsItem, position: Int) {


### PR DESCRIPTION
If you already have a mapping set in the advanced mapping dialog and want to change it, the easiest way to do it is to press Clear and then select the new mapping from the list. But pressing Clear causes the dialog to close, forcing you to open it again, which is inconvenient. This commit makes it so the Clear button doesn't close the dialog.