### PR TITLE
Android: Expand bottom sheets on devices with touch too

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/ui/ProfileDialog.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/ui/ProfileDialog.kt
@@ -46,10 +46,8 @@ class ProfileDialog : BottomSheetDialogFragment() {
         binding.profileList.addItemDecoration(divider)
 
         // You can't expand a bottom sheet with a controller/remote/other non-touch devices
-        val behavior: BottomSheetBehavior<View> = BottomSheetBehavior.from(view.parent as View)
-        if (!resources.getBoolean(R.bool.hasTouch)) {
-            behavior.state = BottomSheetBehavior.STATE_EXPANDED
-        }
+        BottomSheetBehavior.from<View>(view.parent as View).state =
+            BottomSheetBehavior.STATE_EXPANDED
     }
 
     override fun onDestroyView() {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/AboutDialogFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/AboutDialogFragment.kt
@@ -38,10 +38,8 @@ class AboutDialogFragment : BottomSheetDialogFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        if (!resources.getBoolean(R.bool.hasTouch)) {
-            BottomSheetBehavior.from<View>(view.parent as View).state =
-                BottomSheetBehavior.STATE_EXPANDED
-        }
+        BottomSheetBehavior.from<View>(view.parent as View).state =
+            BottomSheetBehavior.STATE_EXPANDED
 
         val wark = resources.getString(R.string.wark)
         val branch = String.format(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/GridOptionDialogFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/GridOptionDialogFragment.kt
@@ -44,11 +44,9 @@ class GridOptionDialogFragment : BottomSheetDialogFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        // Pins fragment to the top of the dialog ensures the dialog is expanded in landscape by default
-        if (!resources.getBoolean(R.bool.hasTouch)) {
-            BottomSheetBehavior.from<View>(view.parent as View).state =
-                BottomSheetBehavior.STATE_EXPANDED
-        }
+        // Ensure the dialog is expanded in landscape by default
+        BottomSheetBehavior.from<View>(view.parent as View).state =
+            BottomSheetBehavior.STATE_EXPANDED
 
         if (activity is AppCompatActivity) {
             setUpCoverButtons()


### PR DESCRIPTION
In a few places in Dolphin, we're using BottomSheetDialogFragments. These unhelpfully tend to start out in a "collapsed" state when in landscape mode (presumably depending on factors like screen size). The user then has to manually expand them before they can meaningfully interact with them.

We've been automatically setting BottomSheetDialogFragments to the expanded state if the device Dolphin is running on doesn't support touch, since with d-pad navigation it's impossible to expand these sheets. But I think we should set them to expanded on devices that support touch too. I haven't encountered a single case where you can do anything useful with any of Dolphin's BottomSheetDialogFragments while they're collapsed, so the user always has to expand sheets manually if they start out collapsed. And just because a device supports touch doesn't necessarily mean you're interacting with it through the touch screen right now - you could be using a gamepad, for instance.