### PR TITLE
GameINI: Enable EFB Access for Jimmy Neutron Boy Genius

### DIFF
--- a/Data/Sys/GameSettings/GJN.ini
+++ b/Data/Sys/GameSettings/GJN.ini
@@ -1,4 +1,4 @@
-# GJNE78 - Jimmy Neutron Boy Genius
+# GJNP78, GJNE78, GJND78 - Jimmy Neutron Boy Genius
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,4 +12,7 @@
 [Video_Settings]
 
 [Video_Hacks]
+# Fixes missing splash logo at boot, title screen, and loading screens.
+EFBAccessEnable = True
+# Fixes FMVs not showing.
 ImmediateXFBEnable = False


### PR DESCRIPTION
This game requires EFB Access to display some images: the splash logo at boot, the title screen, and loading screens.

The performance difference during gameplay is in the margin of error.

The title screen performance *tanks* with EFB Access: it becomes barely over full speed on my computer, despite the actual game being playable at 9x speed.
Also in this game, for some reason, after the attract demo plays, the title screen performance becomes worse: with EFB access, the post-attract performance is less than 15 VPS.
But without EFB Access, players wouldn't know that they need to press Start (and not any other button) to play this beloved classic.
(And after pressing Start, the title screen is over.)

### Before
A black screen.

### After
![GJNP78_2025-05-13_22-11-34](https://github.com/user-attachments/assets/3520dc59-4a45-43b0-b765-78043f03ca22)
