### PR TITLE
Vulkan: Eliminate m_last_present_done flag.

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -440,7 +440,6 @@ void CommandBufferManager::SubmitCommandBuffer(u32 command_buffer_index,
                                      nullptr};
 
     m_last_present_result = vkQueuePresentKHR(g_vulkan_context->GetPresentQueue(), &present_info);
-    m_last_present_done.Set();
     if (m_last_present_result != VK_SUCCESS)
     {
       // VK_ERROR_OUT_OF_DATE_KHR is not fatal, just means we need to recreate our swap chain.

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -4,20 +4,12 @@
 #pragma once
 
 #include <array>
-#include <cstddef>
-#include <deque>
 #include <functional>
-#include <map>
 #include <memory>
-#include <mutex>
-#include <thread>
-#include <utility>
 #include <vector>
 
 #include <Common/WorkQueueThread.h>
-#include "Common/BlockingLoop.h"
 #include "Common/Flag.h"
-#include "Common/Semaphore.h"
 
 #include "VideoBackends/Vulkan/Constants.h"
 
@@ -92,7 +84,6 @@ public:
   // Was the last present submitted to the queue a failure? If so, we must recreate our swapchain.
   bool CheckLastPresentFail() { return m_last_present_failed.TestAndClear(); }
   VkResult GetLastPresentResult() const { return m_last_present_result; }
-  bool CheckLastPresentDone() { return m_last_present_done.TestAndClear(); }
 
   // Schedule a vulkan resource for destruction later on. This will occur when the command buffer
   // is next re-used, and the GPU has finished working with the specified resource.
@@ -164,7 +155,6 @@ private:
   Common::WorkQueueThreadSP<PendingCommandBufferSubmit> m_submit_thread;
   VkSemaphore m_present_semaphore = VK_NULL_HANDLE;
   Common::Flag m_last_present_failed;
-  Common::Flag m_last_present_done;
   VkResult m_last_present_result = VK_SUCCESS;
   bool m_use_threaded_submission = false;
   u32 m_descriptor_set_count = DESCRIPTOR_SETS_PER_POOL;

--- a/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
@@ -3,14 +3,9 @@
 
 #include "VideoBackends/Vulkan/VKGfx.h"
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdio>
-#include <limits>
-#include <string>
-#include <tuple>
 
-#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
@@ -225,8 +220,7 @@ bool VKGfx::BindBackbuffer(const ClearColor& clear_color)
 {
   StateTracker::GetInstance()->EndRenderPass();
 
-  if (!g_command_buffer_mgr->CheckLastPresentDone())
-    g_command_buffer_mgr->WaitForWorkerThreadIdle();
+  g_command_buffer_mgr->WaitForWorkerThreadIdle();
 
   // Handle host window resizes.
   CheckForSurfaceChange();


### PR DESCRIPTION
This flag was introduced in #11262.

The usage was racey in that `m_last_present_failed` was not updated until after `m_last_present_done` was `Set()`.

Moving `m_last_present_done.Set()` to the end of `SubmitCommandBuffer` would be an easy enough fix, but the flag isn't even needed. We can just `WaitForWorkerThreadIdle`.