### PR TITLE
RetroAchievements: Fix potential deadlock on shutdown.

### DIFF
--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -29,6 +29,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/Event.h"
+#include "Common/Functional.h"
 #include "Common/HttpRequest.h"
 #include "Common/JsonUtil.h"
 #include "Common/Lazy.h"
@@ -121,8 +122,12 @@ public:
   };
   using UpdateCallback = std::function<void(const UpdatedItems&)>;
 
+  using AsyncCallback = Common::MoveOnlyFunction<void()>;
+  using AsyncCallbackHandler = Common::MoveOnlyFunction<void(AsyncCallback)>;
+
   static AchievementManager& GetInstance();
-  void Init(void* hwnd);
+
+  void Init(void* hwnd, AsyncCallbackHandler async_callback_handler);
   void SetUpdateCallback(UpdateCallback callback);
   void Login(const std::string& password);
   bool HasAPIToken() const;
@@ -308,6 +313,8 @@ private:
   Common::AsyncWorkThread m_image_queue;
   mutable std::recursive_mutex m_lock;
   std::recursive_mutex m_filereader_lock;
+
+  AsyncCallbackHandler m_async_callback_handler;
 };  // class AchievementManager
 
 #else  // USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -6,13 +6,12 @@
 
 #include <QLabel>
 #include <QLineEdit>
+#include <QPushButton>
 #include <QString>
 #include <QVBoxLayout>
 
 #include "Core/AchievementManager.h"
 #include "Core/Config/AchievementSettings.h"
-#include "Core/Config/FreeLookSettings.h"
-#include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"
 #include "Core/Core.h"
 #include "Core/Movie.h"
@@ -22,7 +21,7 @@
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
+#include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
@@ -252,9 +251,14 @@ void AchievementSettingsWidget::ToggleRAIntegration()
 
   auto& instance = AchievementManager::GetInstance();
   if (Config::Get(Config::RA_ENABLED))
-    instance.Init(reinterpret_cast<void*>(winId()));
+  {
+    instance.Init(reinterpret_cast<void*>(winId()),
+                  [this](auto func) { QueueOnObject(this, std::move(func)); });
+  }
   else
+  {
     instance.Shutdown();
+  }
 }
 
 void AchievementSettingsWidget::Login()

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -274,7 +274,9 @@ MainWindow::MainWindow(Core::System& system, std::unique_ptr<BootParameters> boo
   NetPlayInit();
 
 #ifdef USE_RETRO_ACHIEVEMENTS
-  AchievementManager::GetInstance().Init(reinterpret_cast<void*>(winId()));
+  AchievementManager::GetInstance().Init(reinterpret_cast<void*>(winId()), [this](auto func) {
+    QueueOnObject(this, std::move(func));
+  });
   if (AchievementManager::GetInstance().IsHardcoreModeActive())
     Settings::Instance().SetDebugModeEnabled(false);
   // This needs to trigger on both RA_HARDCORE_ENABLED and RA_ENABLED


### PR DESCRIPTION
The issue was fully described by @Dentomologist in discord.

In short, an async task could potentially trigger shutdown which tries to wait on completion of the async task itself.

The async task callbacks now happen on the host thread.

This does complicate things, and I'm not entirely happy about that, but it does seem to solve the problem.

### Some alternative potential ways to fix this

`AchievementManager::CloseGame` could use `QueueOnObject` to run on the host-thread, but I really haven't wrapped my head around the consequences of that.

A flag could be set for the worker to skip processing of remaining tasks. The host-thread could re-enable processing later. This seemed more hacky to me.

WorkQueueThread could be altered so `Cancel` can be called from within a job, but that also seems hacky to me.