### PR TITLE
DolphinQt: Add utility function for creating label text with a standard icon.

### DIFF
--- a/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
@@ -13,6 +13,7 @@
 #include "Core/Core.h"
 #include "Core/System.h"
 
+#include "DolphinQt/QtUtils/QtUtils.h"
 #include "DolphinQt/Settings.h"
 
 CheatWarningWidget::CheatWarningWidget(const std::string& game_id, bool restart_required,
@@ -33,28 +34,17 @@ CheatWarningWidget::CheatWarningWidget(const std::string& game_id, bool restart_
 
 void CheatWarningWidget::CreateWidgets()
 {
-  auto* icon = new QLabel;
-
-  const auto size = 1.5 * QFontMetrics(font()).height();
-
-  QPixmap warning_icon = style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(size, size);
-
-  icon->setPixmap(warning_icon);
-
   m_text = new QLabel();
   m_config_button = new QPushButton(tr("Configure Dolphin"));
 
   m_config_button->setHidden(true);
 
-  auto* layout = new QHBoxLayout;
+  auto* const layout = new QHBoxLayout{this};
 
-  layout->addWidget(icon);
-  layout->addWidget(m_text, 1);
+  layout->addWidget(QtUtils::CreateIconWarning(this, QStyle::SP_MessageBoxWarning, m_text));
   layout->addWidget(m_config_button);
 
   layout->setContentsMargins(0, 0, 0, 0);
-
-  setLayout(layout);
 }
 
 void CheatWarningWidget::Update(bool running)

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -32,6 +32,7 @@
 #include "DolphinQt/Config/Graphics/EnhancementsWidget.h"
 #include "DolphinQt/Config/Graphics/GeneralWidget.h"
 #include "DolphinQt/Config/Graphics/HacksWidget.h"
+#include "DolphinQt/QtUtils/QtUtils.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 #include "UICommon/GameFile.h"
@@ -259,18 +260,14 @@ void GameConfigWidget::CreateWidgets()
       "settings are disabled when the global graphics backend doesn't "
       "match the game setting.");
 
-  auto help_icon = style()->standardIcon(QStyle::SP_MessageBoxQuestion);
-  auto* help_label = new QLabel(tr("These settings override core Dolphin settings."));
-  help_label->setToolTip(help_msg);
-  auto help_label_icon = new QLabel();
-  help_label_icon->setPixmap(help_icon.pixmap(12, 12));
-  help_label_icon->setToolTip(help_msg);
-  auto* help_layout = new QHBoxLayout();
-  help_layout->addWidget(help_label);
-  help_layout->addWidget(help_label_icon);
-  help_layout->addStretch();
+  auto* const help_label = new QLabel(tr("These settings override core Dolphin settings."));
 
-  layout->addLayout(help_layout);
+  auto* const help_widget =
+      QtUtils::CreateIconWarning(this, QStyle::SP_MessageBoxQuestion, help_label);
+
+  help_widget->setToolTip(help_msg);
+
+  layout->addWidget(help_widget);
   layout->addWidget(tab_widget);
   setLayout(layout);
 }

--- a/Source/Core/DolphinQt/Config/GraphicsModWarningWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GraphicsModWarningWidget.cpp
@@ -9,6 +9,7 @@
 #include <QPushButton>
 #include <QStyle>
 
+#include "DolphinQt/QtUtils/QtUtils.h"
 #include "DolphinQt/Settings.h"
 
 GraphicsModWarningWidget::GraphicsModWarningWidget(QWidget* parent) : QWidget(parent)
@@ -23,28 +24,17 @@ GraphicsModWarningWidget::GraphicsModWarningWidget(QWidget* parent) : QWidget(pa
 
 void GraphicsModWarningWidget::CreateWidgets()
 {
-  auto* icon = new QLabel;
-
-  const auto size = 1.5 * QFontMetrics(font()).height();
-
-  QPixmap warning_icon = style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(size, size);
-
-  icon->setPixmap(warning_icon);
-
   m_text = new QLabel();
-  m_config_button = new QPushButton(tr("Configure Dolphin"));
 
+  m_config_button = new QPushButton(tr("Configure Dolphin"));
   m_config_button->setHidden(true);
 
-  auto* layout = new QHBoxLayout;
+  auto* const layout = new QHBoxLayout{this};
 
-  layout->addWidget(icon);
-  layout->addWidget(m_text, 1);
+  layout->addWidget(QtUtils::CreateIconWarning(this, QStyle::SP_MessageBoxWarning, m_text));
   layout->addWidget(m_config_button);
 
   layout->setContentsMargins(0, 0, 0, 0);
-
-  setLayout(layout);
 }
 
 void GraphicsModWarningWidget::Update()

--- a/Source/Core/DolphinQt/Config/Mapping/GCKeyboardEmu.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCKeyboardEmu.cpp
@@ -15,6 +15,8 @@
 #include "Core/HW/GCKeyboard.h"
 #include "Core/HW/GCKeyboardEmu.h"
 
+#include "DolphinQt/QtUtils/QtUtils.h"
+
 GCKeyboardEmu::GCKeyboardEmu(MappingWindow* window) : MappingWidget(window)
 {
   CreateMainLayout();
@@ -22,32 +24,24 @@ GCKeyboardEmu::GCKeyboardEmu(MappingWindow* window) : MappingWidget(window)
 
 void GCKeyboardEmu::CreateMainLayout()
 {
-  const auto vbox_layout = new QVBoxLayout;
+  auto* const vbox_layout = new QVBoxLayout{this};
 
-  const auto warning_layout = new QHBoxLayout;
-  vbox_layout->addLayout(warning_layout);
-
-  const auto warning_icon = new QLabel;
-  const auto size = QFontMetrics(font()).height() * 3 / 2;
-  warning_icon->setPixmap(style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(size, size));
-  warning_layout->addWidget(warning_icon);
-
-  const auto warning_text =
+  auto* const warning_text =
       new QLabel(tr("You are configuring a \"Keyboard Controller\". "
                     "This device is exclusively for \"Phantasy Star Online Episode I & II\". "
                     "If you are unsure, turn back now and configure a \"Standard Controller\"."));
   warning_text->setWordWrap(true);
-  warning_layout->addWidget(warning_text, 1);
 
-  const auto layout = new QHBoxLayout;
+  vbox_layout->addWidget(
+      QtUtils::CreateIconWarning(this, QStyle::SP_MessageBoxWarning, warning_text));
+
+  auto* const layout = new QHBoxLayout;
 
   using KG = KeyboardGroup;
   for (auto kbg : {KG::Kb0x, KG::Kb1x, KG::Kb2x, KG::Kb3x, KG::Kb4x, KG::Kb5x})
     layout->addWidget(CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), kbg)));
 
   vbox_layout->addLayout(layout);
-
-  setLayout(vbox_layout);
 }
 
 void GCKeyboardEmu::LoadSettings()

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.cpp
@@ -14,6 +14,7 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
+#include "DolphinQt/QtUtils/QtUtils.h"
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 #include "InputCommon/InputConfig.h"
@@ -32,19 +33,18 @@ void WiimoteEmuExtensionMotionInput::CreateNunchukLayout()
 
   auto* warning_layout = new QHBoxLayout();
   auto* warning_label = new QLabel(
-      tr("WARNING: These controls are designed to interface directly with motion "
+      tr("These controls are designed to interface directly with motion "
          "sensor hardware. They are not intended for mapping traditional buttons, triggers or "
          "axes. You might need to configure alternate input sources before using these controls."));
   warning_label->setWordWrap(true);
   auto* warning_input_sources_button = new QPushButton(tr("Alternate Input Sources"));
-  warning_layout->addWidget(warning_label, 1);
-  warning_layout->addWidget(warning_input_sources_button, 0, Qt::AlignRight);
+  warning_layout->addWidget(
+      QtUtils::CreateIconWarning(this, QStyle::SP_MessageBoxWarning, warning_label), 1);
+  warning_layout->addWidget(warning_input_sources_button);
   connect(warning_input_sources_button, &QPushButton::clicked, this, [this] {
-    ControllerInterfaceWindow* window = new ControllerInterfaceWindow(this);
-    window->setAttribute(Qt::WA_DeleteOnClose, true);
-    window->setWindowModality(Qt::WindowModality::WindowModal);
-    SetQWidgetWindowDecorations(window);
-    window->show();
+    ControllerInterfaceWindow window{this};
+    SetQWidgetWindowDecorations(&window);
+    window.exec();
   });
   layout->addLayout(warning_layout, 0, 0, 1, -1);
 

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.cpp
@@ -15,6 +15,7 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
+#include "DolphinQt/QtUtils/QtUtils.h"
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 #include "InputCommon/InputConfig.h"
@@ -29,20 +30,19 @@ void WiimoteEmuMotionControlIMU::CreateMainLayout()
 {
   auto* warning_layout = new QHBoxLayout();
   auto* warning_label =
-      new QLabel(tr("WARNING: The controls under Accelerometer and Gyroscope are designed to "
+      new QLabel(tr("The controls under Accelerometer and Gyroscope are designed to "
                     "interface directly with motion sensor hardware. They are not intended for "
                     "mapping traditional buttons, triggers or axes. You might need to configure "
                     "alternate input sources before using these controls."));
   warning_label->setWordWrap(true);
   auto* warning_input_sources_button = new QPushButton(tr("Alternate Input Sources"));
-  warning_layout->addWidget(warning_label, 1);
-  warning_layout->addWidget(warning_input_sources_button, 0, Qt::AlignRight);
+  warning_layout->addWidget(
+      QtUtils::CreateIconWarning(this, QStyle::SP_MessageBoxWarning, warning_label), 1);
+  warning_layout->addWidget(warning_input_sources_button);
   connect(warning_input_sources_button, &QPushButton::clicked, this, [this] {
-    ControllerInterfaceWindow* window = new ControllerInterfaceWindow(this);
-    window->setAttribute(Qt::WA_DeleteOnClose, true);
-    window->setWindowModality(Qt::WindowModality::WindowModal);
-    SetQWidgetWindowDecorations(window);
-    window->show();
+    ControllerInterfaceWindow window{this};
+    SetQWidgetWindowDecorations(&window);
+    window.exec();
   });
 
   auto* groups_layout = new QHBoxLayout();

--- a/Source/Core/DolphinQt/QtUtils/QtUtils.cpp
+++ b/Source/Core/DolphinQt/QtUtils/QtUtils.cpp
@@ -4,6 +4,8 @@
 #include "DolphinQt/QtUtils/QtUtils.h"
 
 #include <QDateTimeEdit>
+#include <QHBoxLayout>
+#include <QLabel>
 
 namespace QtUtils
 {
@@ -17,6 +19,20 @@ void ShowFourDigitYear(QDateTimeEdit* widget)
     widget->setDisplayFormat(
         widget->displayFormat().replace(QStringLiteral("yy"), QStringLiteral("yyyy")));
   }
+}
+
+QWidget* CreateIconWarning(QWidget* parent, QStyle::StandardPixmap standard_pixmap, QLabel* label)
+{
+  const auto size = QFontMetrics(parent->font()).height() * 5 / 4;
+
+  auto* const icon = new QLabel{};
+  icon->setPixmap(parent->style()->standardIcon(standard_pixmap).pixmap(size, size));
+
+  auto* const widget = new QWidget;
+  auto* const layout = new QHBoxLayout{widget};
+  layout->addWidget(icon);
+  layout->addWidget(label, 1);
+  return widget;
 }
 
 }  // namespace QtUtils

--- a/Source/Core/DolphinQt/QtUtils/QtUtils.h
+++ b/Source/Core/DolphinQt/QtUtils/QtUtils.h
@@ -3,11 +3,17 @@
 
 #pragma once
 
+#include <QStyle>
+
 class QDateTimeEdit;
+class QLabel;
+class QWidget;
 
 namespace QtUtils
 {
 
 void ShowFourDigitYear(QDateTimeEdit* widget);
 
-}
+QWidget* CreateIconWarning(QWidget* parent, QStyle::StandardPixmap standard_pixmap, QLabel* label);
+
+}  // namespace QtUtils


### PR DESCRIPTION
This adjusts a few places where we have an icon with some warning/info text that had duplicated layout-creation, icon-creation, and size-calculation code.

This moves and increases size of the icon at the top of the game config pane.
Before:
![image](https://github.com/user-attachments/assets/779b60cf-26e2-4383-9796-d721133bb8ef)
After:
![image](https://github.com/user-attachments/assets/3630689f-0ecb-4e16-a3a5-450ecfee7111)

It slightly reduces the size of the icon in a few other places.
All After:
![image](https://github.com/user-attachments/assets/8d057c48-5397-492f-98b9-73585ee89634)
![image](https://github.com/user-attachments/assets/69d818cb-b468-40cc-b5e4-61c46330334a)
![image](https://github.com/user-attachments/assets/7aa83516-3ca7-43e6-af5a-7b5cf6905666)

Update:

Replaced Motion Input "WARNING: " text with an icon:
![image](https://github.com/user-attachments/assets/865b39cd-e1b2-45f4-9c77-8a918f95cb58)
