### PR TITLE
DolphinQt: Make the Info tab first in the game properties dialog.

### DIFF
--- a/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
@@ -65,6 +65,7 @@ PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& ga
 
   const int padding_width = 120;
   const int padding_height = 100;
+  tab_widget->addTab(GetWrappedWidget(info, this, padding_width, padding_height), tr("Info"));
   tab_widget->addTab(GetWrappedWidget(game_config, this, padding_width, padding_height),
                      tr("Game Config"));
   tab_widget->addTab(GetWrappedWidget(patches, this, padding_width, padding_height), tr("Patches"));
@@ -73,7 +74,6 @@ PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& ga
                      tr("Gecko Codes"));
   tab_widget->addTab(GetWrappedWidget(graphics_mod_list, this, padding_width, padding_height),
                      tr("Graphics Mods"));
-  tab_widget->addTab(GetWrappedWidget(info, this, padding_width, padding_height), tr("Info"));
 
   if (game.GetPlatform() != DiscIO::Platform::ELFOrDOL)
   {


### PR DESCRIPTION
This is probably controversial. :)

This makes the `Info` tab first in the game properties dialog.
![image](https://github.com/user-attachments/assets/ff3ed7ab-9aec-496b-a8c7-e77e130b1db6)

Game right-click -> Properties now initially shows the `Info` tab.
I think this is the sort of thing that should be shown by default for "Properties".
e.g. Right-clicking a file in your OS file explorer and choosing "Properties" will show information like this.

`Game Config` is now an additional click away.
I think this is fine, and maybe even good. I don't think `Properties` should take users right to the game-specific config.
Most users probably don't even belong in there.

Opinions?