### PR TITLE
WiimoteControllersWidget: Fix UI hang when opening Controllers window

### DIFF
--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -27,7 +27,6 @@ void ControllersWindow::showEvent(QShowEvent* event)
 {
   QDialog::showEvent(event);
   m_wiimote_controllers->UpdateBluetoothAvailableStatus();
-  m_wiimote_controllers->RefreshBluetoothAdapters();
 }
 
 void ControllersWindow::CreateMainLayout()

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include <array>
+
 #include <QWidget>
 
-#include <array>
+#include "Common/WorkQueueThread.h"
+#include "Core/IOS/USB/Bluetooth/BTReal.h"
 
 class QCheckBox;
 class QComboBox;
@@ -26,17 +29,21 @@ class WiimoteControllersWidget final : public QWidget
   Q_OBJECT
 public:
   explicit WiimoteControllersWidget(QWidget* parent);
+  ~WiimoteControllersWidget();
 
   void UpdateBluetoothAvailableStatus();
-  void RefreshBluetoothAdapters();
 
 private:
   void SaveSettings();
   void OnBluetoothPassthroughDeviceChanged(int index);
   void OnBluetoothPassthroughSyncPressed();
   void OnBluetoothPassthroughResetPressed();
+  void OnBluetoothAdapterRefreshComplete(
+      const std::vector<IOS::HLE::BluetoothRealDevice::BluetoothDeviceInfo>& devices);
   void OnWiimoteRefreshPressed();
   void OnWiimoteConfigure(size_t index);
+  void StartBluetoothAdapterRefresh();
+  void UpdateBluetoothAdapterWidgetsEnabled(Core::State state);
 
   void CreateLayout();
   void ConnectWidgets();
@@ -50,10 +57,14 @@ private:
   std::array<QHBoxLayout*, 4> m_wiimote_groups;
   std::array<QLabel*, 2> m_wiimote_pt_labels;
 
+  Common::AsyncWorkThreadSP m_bluetooth_adapter_refresh_thread;
+  bool m_bluetooth_adapter_scan_in_progress = false;
+
   QRadioButton* m_wiimote_emu;
   QRadioButton* m_wiimote_passthrough;
   QLabel* m_bluetooth_adapters_label;
   QComboBox* m_bluetooth_adapters;
+  QPushButton* m_bluetooth_adapters_refresh;
   QPushButton* m_wiimote_sync;
   QPushButton* m_wiimote_reset;
   QCheckBox* m_wiimote_continuous_scanning;


### PR DESCRIPTION
Fix the UI hanging for several seconds when opening the Controllers window.

Move the scan for Bluetooth adapters onto a separate thread so the Host thread doesn't have to wait for it.

Only automatically scan for adapters once, when opening the Controllers window for the first time. Add a Refresh button to let the user refresh the adapter list afterward.