### PR TITLE
GameINI: Spider-Man SuggestedAspectRatio to 4:3

### DIFF
--- a/Data/Sys/GameSettings/GSM.ini
+++ b/Data/Sys/GameSettings/GSM.ini
@@ -12,6 +12,7 @@
 [Video]
 
 [Video_Settings]
+SuggestedAspectRatio = 2
 
 [Video_Hacks]
 ImmediateXFBEnable = False


### PR DESCRIPTION
* The game does not have a built in widescreen mode
* There exists no widescreen hack currently
* There is a first person hack, this adjustment keeps 4:3 this case as well

To trigger the constant switching pre-change, enter the training level and move the camera around, or invoke UI pop ups

https://github.com/user-attachments/assets/b872a7c1-1f43-49c3-ba24-2537c2c8abfa


