### PR TITLE
GameSettings: disable efb2tex for two Cabela's games

### DIFF
--- a/Data/Sys/GameSettings/SH8.ini
+++ b/Data/Sys/GameSettings/SH8.ini
@@ -1,0 +1,5 @@
+# SH8E52, SH8P52 - Cabela's Adventure Camp
+
+[Video_Hacks]
+# This keeps the in-game bloom effect from becoming brighter and brighter.
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SUV.ini
+++ b/Data/Sys/GameSettings/SUV.ini
@@ -1,0 +1,5 @@
+# SUVE52, SUVP52 - Cabela's Dangerous Hunts 2013
+
+[Video_Hacks]
+# This keeps the in-game bloom effect from becoming brighter and brighter.
+EFBToTextureEnable = False


### PR DESCRIPTION
This keeps the in-game bloom effect from becoming brighter and brighter, see [issue 13797](https://bugs.dolphin-emu.org/issues/13797).