### PR TITLE
DolphinQt: Replace widespread SetQWidgetWindowDecorations calls with an event filter.

### DIFF
--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -23,7 +23,6 @@
 #include "DolphinQt/Config/CheatWarningWidget.h"
 #include "DolphinQt/Config/HardcoreWarningWidget.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 ARCodeWidget::ARCodeWidget(std::string game_id, u16 game_revision, bool restart_required)
     : m_game_id(std::move(game_id)), m_game_revision(game_revision),
@@ -257,7 +256,6 @@ void ARCodeWidget::OnCodeAddClicked()
   ar.enabled = true;
 
   m_cheat_code_editor->SetARCode(&ar);
-  SetQWidgetWindowDecorations(m_cheat_code_editor);
   if (m_cheat_code_editor->exec() == QDialog::Rejected)
     return;
 
@@ -275,7 +273,6 @@ void ARCodeWidget::OnCodeEditClicked()
 
   const auto* const selected = items[0];
   auto& current_ar = m_ar_codes[m_code_list->row(selected)];
-  SetQWidgetWindowDecorations(m_cheat_code_editor);
 
   if (current_ar.user_defined)
   {

--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
@@ -13,7 +13,6 @@
 
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
@@ -60,7 +59,6 @@ void CommonControllersWidget::OnControllerInterfaceConfigure()
   ControllerInterfaceWindow* window = new ControllerInterfaceWindow(this);
   window->setAttribute(Qt::WA_DeleteOnClose, true);
   window->setWindowModality(Qt::WindowModality::WindowModal);
-  SetQWidgetWindowDecorations(window);
   window->show();
 }
 

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
@@ -14,7 +14,6 @@
 #include "Common/Config/Config.h"
 #include "DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h"
 
 DualShockUDPClientWidget::DualShockUDPClientWidget()
@@ -112,7 +111,6 @@ void DualShockUDPClientWidget::OnServerAdded()
   DualShockUDPClientAddServerDialog add_server_dialog(this);
   connect(&add_server_dialog, &DualShockUDPClientAddServerDialog::accepted, this,
           &DualShockUDPClientWidget::RefreshServerList);
-  SetQWidgetWindowDecorations(&add_server_dialog);
   add_server_dialog.exec();
 }
 

--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -25,7 +25,6 @@
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 
 #include "UICommon/UICommon.h"
@@ -367,7 +366,6 @@ void FilesystemWidget::ExtractDirectory(const DiscIO::Partition& partition, cons
     dialog.Reset();
   });
 
-  SetQWidgetWindowDecorations(dialog.GetRaw());
   dialog.GetRaw()->exec();
   future.get();
 }

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -19,7 +19,6 @@
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 FreeLookWidget::FreeLookWidget(QWidget* parent) : QWidget(parent)
@@ -104,7 +103,6 @@ void FreeLookWidget::OnFreeLookControllerConfigured()
   MappingWindow* window = new MappingWindow(this, MappingWindow::Type::MAPPING_FREELOOK, index);
   window->setAttribute(Qt::WA_DeleteOnClose, true);
   window->setWindowModality(Qt::WindowModality::WindowModal);
-  SetQWidgetWindowDecorations(window);
   window->show();
 }
 

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -24,7 +24,6 @@
 #include "DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
@@ -140,7 +139,6 @@ void GamecubeControllersWidget::OnGCPadConfigure(size_t index)
   case SerialInterface::SIDEVICE_WIIU_ADAPTER:
   {
     GCPadWiiUConfigDialog dialog(static_cast<int>(index), this);
-    SetQWidgetWindowDecorations(&dialog);
     dialog.exec();
     return;
   }
@@ -166,7 +164,6 @@ void GamecubeControllersWidget::OnGCPadConfigure(size_t index)
   MappingWindow* window = new MappingWindow(this, type, static_cast<int>(index));
   window->setAttribute(Qt::WA_DeleteOnClose, true);
   window->setWindowModality(Qt::WindowModality::WindowModal);
-  SetQWidgetWindowDecorations(window);
   window->show();
 }
 

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -30,7 +30,6 @@
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/QtUtils.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 
 GeckoCodeWidget::GeckoCodeWidget(std::string game_id, std::string gametdb_id, u16 game_revision,
@@ -210,7 +209,6 @@ void GeckoCodeWidget::AddCode()
   code.enabled = true;
 
   m_cheat_code_editor->SetGeckoCode(&code);
-  SetQWidgetWindowDecorations(m_cheat_code_editor);
   if (m_cheat_code_editor->exec() == QDialog::Rejected)
     return;
 
@@ -228,7 +226,6 @@ void GeckoCodeWidget::EditCode()
   const int index = item->data(Qt::UserRole).toInt();
 
   m_cheat_code_editor->SetGeckoCode(&m_gecko_codes[index]);
-  SetQWidgetWindowDecorations(m_cheat_code_editor);
   if (m_cheat_code_editor->exec() == QDialog::Rejected)
     return;
 

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -25,7 +25,6 @@
 #include "DolphinQt/Config/Graphics/PostProcessingConfigWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipPushButton.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 #include "VideoCommon/PostProcessing.h"
@@ -629,7 +628,6 @@ void EnhancementsWidget::AddDescriptions()
 void EnhancementsWidget::ConfigureColorCorrection()
 {
   ColorCorrectionConfigWindow dialog(this);
-  SetQWidgetWindowDecorations(&dialog);
   dialog.exec();
 }
 
@@ -637,6 +635,5 @@ void EnhancementsWidget::ConfigurePostProcessingShader()
 {
   const std::string shader = ReadSetting(Config::GFX_ENHANCE_POST_SHADER);
   PostProcessingConfigWindow dialog(this, shader);
-  SetQWidgetWindowDecorations(&dialog);
   dialog.exec();
 }

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -27,7 +27,6 @@
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 #include "VideoCommon/VideoBackendBase.h"
@@ -199,7 +198,6 @@ void GeneralWidget::BackendWarning()
       confirm_sw.setWindowTitle(tr("Confirm backend change"));
       confirm_sw.setText(tr(warningMessage->c_str()));
 
-      SetQWidgetWindowDecorations(&confirm_sw);
       if (confirm_sw.exec() != QMessageBox::Yes)
       {
         m_backend_combo->setCurrentIndex(m_previous_backend);

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.cpp
@@ -11,7 +11,6 @@
 
 #include "Core/FreeLookManager.h"
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "InputCommon/InputConfig.h"
 
 FreeLookRotation::FreeLookRotation(MappingWindow* window) : MappingWidget(window)
@@ -34,7 +33,6 @@ void FreeLookRotation::CreateMainLayout()
     ControllerInterfaceWindow* window = new ControllerInterfaceWindow(this);
     window->setAttribute(Qt::WA_DeleteOnClose, true);
     window->setWindowModality(Qt::WindowModality::WindowModal);
-    SetQWidgetWindowDecorations(window);
     window->show();
   });
   m_main_layout->addLayout(alternate_input_layout, 0, 0, 1, -1);

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -28,7 +28,6 @@
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/QtUtils/BlockUserInputFilter.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
@@ -259,8 +258,6 @@ IOWindow::IOWindow(MappingWindow* window, ControllerEmu::EmulatedController* con
     : QDialog(window), m_reference(ref), m_original_expression(ref->GetExpression()),
       m_controller(controller), m_type(type)
 {
-  SetQWidgetWindowDecorations(this);
-
   CreateMainLayout();
 
   connect(window, &MappingWindow::Update, this, &IOWindow::Update);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -18,7 +18,6 @@
 #include "DolphinQt/Config/Mapping/MappingIndicator.h"
 #include "DolphinQt/Config/Mapping/MappingNumeric.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
@@ -282,7 +281,6 @@ void MappingWidget::ShowAdvancedControlGroupDialog(ControllerEmu::ControlGroup* 
   // Enable "Close" button functionality.
   connect(button_box, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
 
-  SetQWidgetWindowDecorations(&dialog);
   dialog.exec();
 }
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -51,7 +51,6 @@
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/QtUtils.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/WindowActivationEventFilter.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 #include "DolphinQt/Settings.h"
@@ -271,7 +270,6 @@ void MappingWindow::OnDeleteProfilePressed()
     error.setIcon(QMessageBox::Critical);
     error.setWindowTitle(tr("Error"));
     error.setText(tr("The profile '%1' does not exist").arg(profile_name));
-    SetQWidgetWindowDecorations(&error);
     error.exec();
     return;
   }
@@ -284,7 +282,6 @@ void MappingWindow::OnDeleteProfilePressed()
   confirm.setInformativeText(tr("This cannot be undone!"));
   confirm.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
 
-  SetQWidgetWindowDecorations(&confirm);
   if (confirm.exec() != QMessageBox::Yes)
   {
     return;
@@ -312,7 +309,6 @@ void MappingWindow::OnLoadProfilePressed()
     error.setIcon(QMessageBox::Critical);
     error.setWindowTitle(tr("Error"));
     error.setText(tr("The profile '%1' does not exist").arg(m_profiles_combo->currentText()));
-    SetQWidgetWindowDecorations(&error);
     error.exec();
     return;
   }

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.cpp
@@ -15,7 +15,6 @@
 
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
 #include "DolphinQt/QtUtils/QtUtils.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 #include "InputCommon/InputConfig.h"
 
@@ -43,7 +42,6 @@ void WiimoteEmuExtensionMotionInput::CreateNunchukLayout()
   warning_layout->addWidget(warning_input_sources_button);
   connect(warning_input_sources_button, &QPushButton::clicked, this, [this] {
     ControllerInterfaceWindow window{this};
-    SetQWidgetWindowDecorations(&window);
     window.exec();
   });
   layout->addLayout(warning_layout, 0, 0, 1, -1);

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.cpp
@@ -16,7 +16,6 @@
 
 #include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
 #include "DolphinQt/QtUtils/QtUtils.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 #include "InputCommon/InputConfig.h"
 
@@ -41,7 +40,6 @@ void WiimoteEmuMotionControlIMU::CreateMainLayout()
   warning_layout->addWidget(warning_input_sources_button);
   connect(warning_input_sources_button, &QPushButton::clicked, this, [this] {
     ControllerInterfaceWindow window{this};
-    SetQWidgetWindowDecorations(&window);
     window.exec();
   });
 

--- a/Source/Core/DolphinQt/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt/Config/PatchesWidget.cpp
@@ -16,7 +16,6 @@
 
 #include "DolphinQt/Config/HardcoreWarningWidget.h"
 #include "DolphinQt/Config/NewPatchDialog.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 #include "UICommon/GameFile.h"
 
@@ -94,7 +93,6 @@ void PatchesWidget::OnAdd()
   bool new_patch_confirmed = false;
   {
     NewPatchDialog dialog(this, patch);
-    SetQWidgetWindowDecorations(&dialog);
     new_patch_confirmed = dialog.exec();
   }
   if (new_patch_confirmed)
@@ -124,7 +122,6 @@ void PatchesWidget::OnEdit()
   bool new_patch_confirmed = false;
   {
     NewPatchDialog dialog(this, patch);
-    SetQWidgetWindowDecorations(&dialog);
     new_patch_confirmed = dialog.exec();
   }
   if (new_patch_confirmed)

--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -21,7 +21,6 @@
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeVerifier.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 VerifyWidget::VerifyWidget(std::shared_ptr<DiscIO::Volume> volume) : m_volume(std::move(volume))
@@ -180,7 +179,6 @@ void VerifyWidget::Verify()
                    progress.Reset();
                    return verifier.GetResult();
                  });
-  SetQWidgetWindowDecorations(progress.GetRaw());
   progress.GetRaw()->exec();
 
   std::optional<DiscIO::VolumeVerifier::Result> result = future.get();

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -37,7 +37,6 @@
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
@@ -378,7 +377,6 @@ void WiimoteControllersWidget::OnWiimoteConfigure(size_t index)
   MappingWindow* window = new MappingWindow(this, type, static_cast<int>(index));
   window->setAttribute(Qt::WA_DeleteOnClose, true);
   window->setWindowModality(Qt::WindowModality::WindowModal);
-  SetQWidgetWindowDecorations(window);
   window->show();
 }
 

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -31,7 +31,6 @@
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "UICommon/GameFile.h"
 #include "UICommon/UICommon.h"
 
@@ -283,7 +282,6 @@ bool ConvertDialog::ShowAreYouSureDialog(const QString& text)
   warning.setInformativeText(text);
   warning.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
 
-  SetQWidgetWindowDecorations(&warning);
   return warning.exec() == QMessageBox::Yes;
 }
 
@@ -408,7 +406,6 @@ void ConvertDialog::Convert()
                                     .arg(dst_info.fileName()));
         confirm_replace.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
 
-        SetQWidgetWindowDecorations(&confirm_replace);
         if (confirm_replace.exec() == QMessageBox::No)
           continue;
       }
@@ -519,7 +516,6 @@ void ConvertDialog::Convert()
         break;
       }
 
-      SetQWidgetWindowDecorations(progress_dialog.GetRaw());
       progress_dialog.GetRaw()->exec();
       if (!success.get())
       {

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -47,7 +47,6 @@
 #include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -30,7 +30,6 @@
 #include "DolphinQt/Debugger/BreakpointDialog.h"
 #include "DolphinQt/Debugger/MemoryWidget.h"
 #include "DolphinQt/Host.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
@@ -442,7 +441,6 @@ void BreakpointWidget::OnNewBreakpoint()
 {
   BreakpointDialog* dialog = new BreakpointDialog(this);
   dialog->setAttribute(Qt::WA_DeleteOnClose, true);
-  SetQWidgetWindowDecorations(dialog);
   dialog->exec();
 }
 
@@ -453,7 +451,6 @@ void BreakpointWidget::OnEditBreakpoint(u32 address, bool is_instruction_bp)
     auto* dialog = new BreakpointDialog(
         this, m_system.GetPowerPC().GetBreakPoints().GetRegularBreakpoint(address));
     dialog->setAttribute(Qt::WA_DeleteOnClose, true);
-    SetQWidgetWindowDecorations(dialog);
     dialog->exec();
   }
   else
@@ -461,7 +458,6 @@ void BreakpointWidget::OnEditBreakpoint(u32 address, bool is_instruction_bp)
     auto* dialog =
         new BreakpointDialog(this, m_system.GetPowerPC().GetMemChecks().GetMemCheck(address));
     dialog->setAttribute(Qt::WA_DeleteOnClose, true);
-    SetQWidgetWindowDecorations(dialog);
     dialog->exec();
   }
 

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -40,7 +40,6 @@
 #include "DolphinQt/Debugger/PatchInstructionDialog.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/FromStdString.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
@@ -743,7 +742,6 @@ void CodeViewWidget::AutoStep(CodeTrace::AutoStop option)
             .arg(QString::fromStdString(fmt::format("{:#x}", fmt::join(mem_out, ", "))));
 
     msgbox.setInformativeText(msgtext);
-    SetQWidgetWindowDecorations(&msgbox);
     msgbox.exec();
 
   } while (msgbox.clickedButton() == (QAbstractButton*)run_button);
@@ -1031,7 +1029,6 @@ void CodeViewWidget::DoPatchInstruction(bool assemble)
   if (assemble)
   {
     AssembleInstructionDialog dialog(this, addr, debug_interface.ReadInstruction(guard, addr));
-    SetQWidgetWindowDecorations(&dialog);
     if (dialog.exec() == QDialog::Accepted)
     {
       debug_interface.SetPatch(guard, addr, dialog.GetCode());
@@ -1041,7 +1038,6 @@ void CodeViewWidget::DoPatchInstruction(bool assemble)
   else
   {
     PatchInstructionDialog dialog(this, addr, debug_interface.ReadInstruction(guard, addr));
-    SetQWidgetWindowDecorations(&dialog);
     if (dialog.exec() == QDialog::Accepted)
     {
       debug_interface.SetPatch(guard, addr, dialog.GetCode());

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -29,7 +29,6 @@
 #include "Core/System.h"
 #include "DolphinQt/Debugger/BranchWatchDialog.h"
 #include "DolphinQt/Host.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 static const QString BOX_SPLITTER_STYLESHEET = QStringLiteral(
@@ -222,7 +221,6 @@ void CodeWidget::OnBranchWatchDialog()
     m_branch_watch_dialog = new BranchWatchDialog(m_system, m_system.GetPowerPC().GetBranchWatch(),
                                                   m_ppc_symbol_db, this, this);
   }
-  SetQWidgetWindowDecorations(m_branch_watch_dialog);
   m_branch_watch_dialog->show();
   m_branch_watch_dialog->raise();
   m_branch_watch_dialog->activateWindow();

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -18,7 +18,6 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 #include "DolphinQt/Host.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 RegisterWidget::RegisterWidget(QWidget* parent)
@@ -309,7 +308,6 @@ void RegisterWidget::AutoStep(const std::string& reg) const
       break;
 
     // Can keep running and try again after a time out.
-    SetQWidgetWindowDecorations(&msgbox);
     msgbox.exec();
     if (msgbox.clickedButton() != (QAbstractButton*)run_button)
       break;

--- a/Source/Core/DolphinQt/DiscordHandler.cpp
+++ b/Source/Core/DolphinQt/DiscordHandler.cpp
@@ -16,7 +16,6 @@
 
 #include "DolphinQt/DiscordJoinRequestDialog.h"
 #include "DolphinQt/QtUtils/RunOnObject.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 DiscordHandler::DiscordHandler(QWidget* parent) : QObject{parent}, m_parent{parent}
 {
@@ -61,7 +60,6 @@ void DiscordHandler::ShowNewJoinRequest(const std::string& id, const std::string
   std::lock_guard<std::mutex> lock(m_request_dialogs_mutex);
   m_request_dialogs.emplace_front(m_parent, id, discord_tag, avatar);
   DiscordJoinRequestDialog& request_dialog = m_request_dialogs.front();
-  SetQWidgetWindowDecorations(&request_dialog);
   request_dialog.show();
   request_dialog.raise();
   request_dialog.activateWindow();

--- a/Source/Core/DolphinQt/GBAWidget.cpp
+++ b/Source/Core/DolphinQt/GBAWidget.cpp
@@ -29,7 +29,6 @@
 #include "Core/System.h"
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/GameCubePane.h"
@@ -492,7 +491,6 @@ void GBAWidget::contextMenuEvent(QContextMenuEvent* event)
   size_menu->addAction(x4_action);
 
   menu->move(event->globalPos());
-  SetQWidgetWindowDecorations(menu);
   menu->show();
 }
 

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -42,7 +42,6 @@
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 using namespace ExpansionInterface;
 
@@ -695,7 +694,6 @@ void GCMemcardManager::FixChecksums()
 void GCMemcardManager::CreateNewCard(Slot slot)
 {
   GCMemcardCreateNewDialog dialog(this);
-  SetQWidgetWindowDecorations(&dialog);
   if (dialog.exec() == QDialog::Accepted)
     m_slot_file_edit[slot]->setText(QString::fromStdString(dialog.GetMemoryCardPath()));
 }

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -67,7 +67,6 @@
 #include "DolphinQt/QtUtils/DoubleClickEventFilter.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/WiiUpdate.h"
@@ -588,7 +587,6 @@ void GameList::OpenProperties()
           &GameList::OpenAchievementSettings);
 #endif  // USE_RETRO_ACHIEVEMENTS
 
-  SetQWidgetWindowDecorations(properties);
   properties->show();
 }
 
@@ -643,7 +641,6 @@ void GameList::ConvertFile()
     return;
 
   ConvertDialog dialog{std::move(games), this};
-  SetQWidgetWindowDecorations(&dialog);
   dialog.exec();
 }
 
@@ -661,7 +658,6 @@ void GameList::InstallWAD()
   result_dialog.setWindowTitle(success ? tr("Success") : tr("Failure"));
   result_dialog.setText(success ? tr("Successfully installed this title to the NAND.") :
                                   tr("Failed to install this title to the NAND."));
-  SetQWidgetWindowDecorations(&result_dialog);
   result_dialog.exec();
 }
 
@@ -679,7 +675,6 @@ void GameList::UninstallWAD()
                             "this title from the NAND without deleting its save data. Continue?"));
   warning_dialog.setStandardButtons(QMessageBox::No | QMessageBox::Yes);
 
-  SetQWidgetWindowDecorations(&warning_dialog);
   if (warning_dialog.exec() == QMessageBox::No)
     return;
 
@@ -691,7 +686,6 @@ void GameList::UninstallWAD()
   result_dialog.setWindowTitle(success ? tr("Success") : tr("Failure"));
   result_dialog.setText(success ? tr("Successfully removed this title from the NAND.") :
                                   tr("Failed to remove this title from the NAND."));
-  SetQWidgetWindowDecorations(&result_dialog);
   result_dialog.exec();
 }
 
@@ -860,7 +854,6 @@ void GameList::DeleteFile()
   confirm_dialog.setInformativeText(tr("This cannot be undone!"));
   confirm_dialog.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
 
-  SetQWidgetWindowDecorations(&confirm_dialog);
   if (confirm_dialog.exec() == QMessageBox::Yes)
   {
     for (const auto& game : GetSelectedGames())
@@ -886,7 +879,6 @@ void GameList::DeleteFile()
                                              "delete the file or whether it's still in use."));
           error_dialog.setStandardButtons(QMessageBox::Retry | QMessageBox::Abort);
 
-          SetQWidgetWindowDecorations(&error_dialog);
           if (error_dialog.exec() == QMessageBox::Abort)
             break;
         }

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
@@ -26,7 +26,6 @@
 #include "Core/System.h"
 
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
@@ -159,7 +158,6 @@ void InfinityBaseWindow::LoadFigure(FigureUIPosition slot)
 void InfinityBaseWindow::CreateFigure(FigureUIPosition slot)
 {
   CreateFigureDialog create_dlg(this, slot);
-  SetQWidgetWindowDecorations(&create_dlg);
   if (create_dlg.exec() == CreateFigureDialog::Accepted)
   {
     LoadFigurePath(slot, create_dlg.GetFilePath());

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -92,7 +92,6 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
       return QMessageBox::NoIcon;
     }());
 
-    SetQWidgetWindowDecorations(&message_box);
     const int button = message_box.exec();
     if (button == QMessageBox::Yes)
       return true;
@@ -170,6 +169,8 @@ int main(int argc, char* argv[])
   const std::vector<std::string> args = parser->args();
 
 #ifdef _WIN32
+  QtUtils::InstallWindowDecorationFilter(&app);
+
   FreeConsole();
 #endif
 
@@ -281,7 +282,6 @@ int main(int argc, char* argv[])
                       "This authorization can be revoked at any time through Dolphin's "
                       "settings."));
 
-      SetQWidgetWindowDecorations(&analytics_prompt);
       const int answer = analytics_prompt.exec();
 
       Config::SetBase(Config::MAIN_ANALYTICS_PERMISSION_ASKED, true);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -112,7 +112,6 @@
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/QtUtils/RunOnObject.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/WindowActivationEventFilter.h"
 #include "DolphinQt/RenderWidget.h"
 #include "DolphinQt/ResourcePackManager.h"
@@ -243,7 +242,6 @@ MainWindow::MainWindow(Core::System& system, std::unique_ptr<BootParameters> boo
   restoreGeometry(settings.value(QStringLiteral("mainwindow/geometry")).toByteArray());
   if (!Settings::Instance().IsBatchModeEnabled())
   {
-    SetQWidgetWindowDecorations(this);
     show();
   }
 
@@ -1299,7 +1297,6 @@ void MainWindow::ShowFreeLookWindow()
 #endif  // USE_RETRO_ACHIEVEMENTS
   }
 
-  SetQWidgetWindowDecorations(m_freelook_window);
   m_freelook_window->show();
   m_freelook_window->raise();
   m_freelook_window->activateWindow();
@@ -1313,7 +1310,6 @@ void MainWindow::ShowSettingsWindow()
     InstallHotkeyFilter(m_settings_window);
   }
 
-  SetQWidgetWindowDecorations(m_settings_window);
   m_settings_window->show();
   m_settings_window->raise();
   m_settings_window->activateWindow();
@@ -1334,7 +1330,6 @@ void MainWindow::ShowGeneralWindow()
 void MainWindow::ShowAboutDialog()
 {
   AboutDialog about{this};
-  SetQWidgetWindowDecorations(&about);
   about.exec();
 }
 
@@ -1346,7 +1341,6 @@ void MainWindow::ShowHotkeyDialog()
     InstallHotkeyFilter(m_hotkey_window);
   }
 
-  SetQWidgetWindowDecorations(m_hotkey_window);
   m_hotkey_window->show();
   m_hotkey_window->raise();
   m_hotkey_window->activateWindow();
@@ -1369,7 +1363,6 @@ void MainWindow::ShowGraphicsWindow()
     InstallHotkeyFilter(m_graphics_window);
   }
 
-  SetQWidgetWindowDecorations(m_graphics_window);
   m_graphics_window->show();
   m_graphics_window->raise();
   m_graphics_window->activateWindow();
@@ -1377,7 +1370,6 @@ void MainWindow::ShowGraphicsWindow()
 
 void MainWindow::ShowNetPlaySetupDialog()
 {
-  SetQWidgetWindowDecorations(m_netplay_setup_dialog);
   m_netplay_setup_dialog->show();
   m_netplay_setup_dialog->raise();
   m_netplay_setup_dialog->activateWindow();
@@ -1388,7 +1380,6 @@ void MainWindow::ShowNetPlayBrowser()
   auto* browser = new NetPlayBrowser(this);
   browser->setAttribute(Qt::WA_DeleteOnClose, true);
   connect(browser, &NetPlayBrowser::Join, this, &MainWindow::NetPlayJoin);
-  SetQWidgetWindowDecorations(browser);
   browser->exec();
 }
 
@@ -1401,7 +1392,6 @@ void MainWindow::ShowFIFOPlayer()
             [this](const QString& path) { StartGame(path, ScanForSecondDisc::No); });
   }
 
-  SetQWidgetWindowDecorations(m_fifo_window);
   m_fifo_window->show();
   m_fifo_window->raise();
   m_fifo_window->activateWindow();
@@ -1414,7 +1404,6 @@ void MainWindow::ShowSkylanderPortal()
     m_skylander_window = new SkylanderPortalWindow();
   }
 
-  SetQWidgetWindowDecorations(m_skylander_window);
   m_skylander_window->show();
   m_skylander_window->raise();
   m_skylander_window->activateWindow();
@@ -1427,7 +1416,6 @@ void MainWindow::ShowInfinityBase()
     m_infinity_window = new InfinityBaseWindow();
   }
 
-  SetQWidgetWindowDecorations(m_infinity_window);
   m_infinity_window->show();
   m_infinity_window->raise();
   m_infinity_window->activateWindow();
@@ -1852,7 +1840,6 @@ void MainWindow::OnImportNANDBackup()
     dialog.Reset();
   });
 
-  SetQWidgetWindowDecorations(dialog.GetRaw());
   dialog.GetRaw()->exec();
 
   result.wait();
@@ -1966,7 +1953,6 @@ void MainWindow::ShowTASInput()
     const auto si_device = Config::Get(Config::GetInfoForSIDevice(i));
     if (si_device == SerialInterface::SIDEVICE_GC_GBA_EMULATED)
     {
-      SetQWidgetWindowDecorations(m_gba_tas_input_windows[i]);
       m_gba_tas_input_windows[i]->show();
       m_gba_tas_input_windows[i]->raise();
       m_gba_tas_input_windows[i]->activateWindow();
@@ -1974,7 +1960,6 @@ void MainWindow::ShowTASInput()
     else if (si_device != SerialInterface::SIDEVICE_NONE &&
              si_device != SerialInterface::SIDEVICE_GC_GBA)
     {
-      SetQWidgetWindowDecorations(m_gc_tas_input_windows[i]);
       m_gc_tas_input_windows[i]->show();
       m_gc_tas_input_windows[i]->raise();
       m_gc_tas_input_windows[i]->activateWindow();
@@ -1986,7 +1971,6 @@ void MainWindow::ShowTASInput()
     if (Config::Get(Config::GetInfoForWiimoteSource(i)) == WiimoteSource::Emulated &&
         (!Core::IsRunning(m_system) || m_system.IsWii()))
     {
-      SetQWidgetWindowDecorations(m_wii_tas_input_windows[i]);
       m_wii_tas_input_windows[i]->show();
       m_wii_tas_input_windows[i]->raise();
       m_wii_tas_input_windows[i]->activateWindow();
@@ -2012,7 +1996,6 @@ void MainWindow::ShowAchievementsWindow()
     m_achievements_window = new AchievementsWindow(this);
   }
 
-  SetQWidgetWindowDecorations(m_achievements_window);
   m_achievements_window->show();
   m_achievements_window->raise();
   m_achievements_window->activateWindow();
@@ -2037,7 +2020,6 @@ void MainWindow::ShowMemcardManager()
 {
   GCMemcardManager manager(this);
 
-  SetQWidgetWindowDecorations(&manager);
   manager.exec();
 }
 
@@ -2045,13 +2027,11 @@ void MainWindow::ShowResourcePackManager()
 {
   ResourcePackManager manager(this);
 
-  SetQWidgetWindowDecorations(&manager);
   manager.exec();
 }
 
 void MainWindow::ShowCheatsManager()
 {
-  SetQWidgetWindowDecorations(m_cheats_manager);
   m_cheats_manager->show();
 }
 
@@ -2070,7 +2050,6 @@ void MainWindow::ShowRiivolutionBootWidget(const UICommon::GameFile& game)
   auto& disc = std::get<BootParameters::Disc>(boot_params->parameters);
   RiivolutionBootWidget w(disc.volume->GetGameID(), disc.volume->GetRevision(),
                           disc.volume->GetDiscNumber(), game.GetFilePath(), this);
-  SetQWidgetWindowDecorations(&w);
 
 #ifdef USE_RETRO_ACHIEVEMENTS
   connect(&w, &RiivolutionBootWidget::OpenAchievementSettings, this,

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -67,7 +67,6 @@
 #include "DolphinQt/QtUtils/NonAutodismissibleMenu.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Updater.h"
 
@@ -1393,7 +1392,6 @@ void MenuBar::CheckNAND()
 
   {
     NANDRepairDialog dialog(result, this);
-    SetQWidgetWindowDecorations(&dialog);
     if (dialog.exec() != QDialog::Accepted)
       return;
   }
@@ -1564,7 +1562,6 @@ void MenuBar::GenerateSymbolsFromRSOAuto()
 
     return matches;
   });
-  SetQWidgetWindowDecorations(progress.GetRaw());
   progress.GetRaw()->exec();
 
   const auto matches = future.get();

--- a/Source/Core/DolphinQt/NKitWarningDialog.cpp
+++ b/Source/Core/DolphinQt/NKitWarningDialog.cpp
@@ -14,7 +14,6 @@
 
 #include "Common/Config/Config.h"
 #include "Core/Config/MainSettings.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 
 bool NKitWarningDialog::ShowUnlessDisabled(QWidget* parent)
@@ -23,7 +22,6 @@ bool NKitWarningDialog::ShowUnlessDisabled(QWidget* parent)
     return true;
 
   NKitWarningDialog dialog(parent);
-  SetQWidgetWindowDecorations(&dialog);
   return dialog.exec() == QDialog::Accepted;
 }
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -26,7 +26,6 @@
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 NetPlayBrowser::NetPlayBrowser(QWidget* parent) : QDialog(parent)
@@ -301,7 +300,6 @@ void NetPlayBrowser::accept()
     dialog.setWindowModality(Qt::WindowModal);
     dialog.setTextEchoMode(QLineEdit::Password);
 
-    SetQWidgetWindowDecorations(&dialog);
     if (dialog.exec() != QDialog::Accepted)
       return;
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -54,7 +54,6 @@
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/QtUtils/RunOnObject.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/GameCubePane.h"
@@ -215,7 +214,6 @@ void NetPlayDialog::CreateMainLayout()
   m_game_digest_menu->addAction(tr("Other game..."), this, [this] {
     GameListDialog gld(m_game_list_model, this);
 
-    SetQWidgetWindowDecorations(&gld);
     if (gld.exec() != QDialog::Accepted)
       return;
     Settings::Instance().GetNetPlayServer()->ComputeGameDigest(
@@ -337,7 +335,6 @@ void NetPlayDialog::ConnectWidgets()
     Settings::Instance().GetNetPlayServer()->KickPlayer(id);
   });
   connect(m_assign_ports_button, &QPushButton::clicked, [this] {
-    SetQWidgetWindowDecorations(m_pad_mapping);
     m_pad_mapping->exec();
 
     Settings::Instance().GetNetPlayServer()->SetPadMapping(m_pad_mapping->GetGCPadArray());
@@ -383,7 +380,6 @@ void NetPlayDialog::ConnectWidgets()
 
   connect(m_game_button, &QPushButton::clicked, [this] {
     GameListDialog gld(m_game_list_model, this);
-    SetQWidgetWindowDecorations(&gld);
     if (gld.exec() == QDialog::Accepted)
     {
       Settings& settings = Settings::Instance();

--- a/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
@@ -5,8 +5,6 @@
 
 #include <QApplication>
 
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
-
 ModalMessageBox::ModalMessageBox(QWidget* parent, Qt::WindowModality modality)
     : QMessageBox(parent != nullptr ? parent->window() : nullptr)
 {
@@ -31,7 +29,6 @@ static inline int ExecMessageBox(ModalMessageBox::Icon icon, QWidget* parent, co
   msg.setDefaultButton(default_button);
   msg.setDetailedText(detailed_text);
 
-  SetQWidgetWindowDecorations(&msg);
   return msg.exec();
 }
 

--- a/Source/Core/DolphinQt/QtUtils/SetWindowDecorations.cpp
+++ b/Source/Core/DolphinQt/QtUtils/SetWindowDecorations.cpp
@@ -1,25 +1,81 @@
 // Copyright 2023 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#if defined(_WIN32)
+
 #include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
+#include <QApplication>
+#include <QEvent>
 #include <QWidget>
+
+#include <dwmapi.h>
 
 #include "DolphinQt/Settings.h"
 
-#ifdef _WIN32
-#include <dwmapi.h>
-#endif
+namespace
+{
 
 void SetQWidgetWindowDecorations(QWidget* widget)
 {
-#ifdef _WIN32
   if (!Settings::Instance().IsThemeDark())
     return;
 
-  BOOL use_dark_title_bar = TRUE;
-  DwmSetWindowAttribute(HWND(widget->winId()),
-                        20 /* DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE */,
-                        &use_dark_title_bar, DWORD(sizeof(use_dark_title_bar)));
-#endif
+  constexpr DWORD attribute = 20;  // DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE
+  constexpr BOOL use_dark_title_bar = TRUE;
+
+  DwmSetWindowAttribute(HWND(widget->winId()), attribute, &use_dark_title_bar,
+                        DWORD(sizeof(use_dark_title_bar)));
 }
+
+class WindowDecorationFilter final : public QObject
+{
+public:
+  using QObject::QObject;
+
+  bool eventFilter(QObject* obj, QEvent* event) override
+  {
+    if (event->type() == QEvent::Show || event->type() == QEvent::ApplicationPaletteChange)
+    {
+      SetQWidgetWindowDecorations(static_cast<QWidget*>(obj));
+    }
+    return QObject::eventFilter(obj, event);
+  }
+};
+
+class WindowDecorationFilterInstaller final : public QObject
+{
+public:
+  using QObject::QObject;
+
+  bool eventFilter(QObject* obj, QEvent* event) override
+  {
+    if (event->type() == QEvent::WinIdChange)
+    {
+      auto* const widget = qobject_cast<QWidget*>(obj);
+
+      // Install the real filter on actual Window QWidgets.
+      // This avoids the need for a qobject_cast on literally every QEvent::Show.
+      if (widget && widget->isWindow())
+        widget->installEventFilter(m_decoration_filter);
+    }
+    return QObject::eventFilter(obj, event);
+  }
+
+private:
+  QObject* const m_decoration_filter = new WindowDecorationFilter{this};
+};
+
+}  // namespace
+
+namespace QtUtils
+{
+
+void InstallWindowDecorationFilter(QApplication* app)
+{
+  app->installEventFilter(new WindowDecorationFilterInstaller{app});
+}
+
+}  // namespace QtUtils
+
+#endif

--- a/Source/Core/DolphinQt/QtUtils/SetWindowDecorations.h
+++ b/Source/Core/DolphinQt/QtUtils/SetWindowDecorations.h
@@ -3,7 +3,14 @@
 
 #pragma once
 
-class QWidget;
+#if defined(_WIN32)
 
-// Changes the window decorations (title bar) to dark if the user uses dark mode on Windows.
-void SetQWidgetWindowDecorations(QWidget* widget);
+class QApplication;
+
+namespace QtUtils
+{
+// Changes the window decorations (title bar) for Windows "Dark" mode or "Dark" Dolphin Style.
+void InstallWindowDecorationFilter(QApplication*);
+}  // namespace QtUtils
+
+#endif

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -14,7 +14,6 @@
 #include "Common/FileUtil.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "UICommon/ResourcePack/Manager.h"
 
 ResourcePackManager::ResourcePackManager(QWidget* widget) : QDialog(widget)
@@ -241,7 +240,6 @@ void ResourcePackManager::Remove()
   box.setIcon(QMessageBox::Warning);
   box.setStandardButtons(QMessageBox::Yes | QMessageBox::Abort);
 
-  SetQWidgetWindowDecorations(&box);
   if (box.exec() != QMessageBox::Yes)
     return;
 

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -39,7 +39,6 @@
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/BroadbandAdapterSettingsDialog.h"
@@ -381,28 +380,24 @@ void GameCubePane::OnConfigPressed(ExpansionInterface::Slot slot)
   {
     // TODO: convert MappingWindow to use Slot?
     MappingWindow dialog(this, MappingWindow::Type::MAPPING_GC_MICROPHONE, static_cast<int>(slot));
-    SetQWidgetWindowDecorations(&dialog);
     dialog.exec();
     return;
   }
   case ExpansionInterface::EXIDeviceType::Ethernet:
   {
     BroadbandAdapterSettingsDialog dialog(this, BroadbandAdapterSettingsDialog::Type::Ethernet);
-    SetQWidgetWindowDecorations(&dialog);
     dialog.exec();
     return;
   }
   case ExpansionInterface::EXIDeviceType::EthernetXLink:
   {
     BroadbandAdapterSettingsDialog dialog(this, BroadbandAdapterSettingsDialog::Type::XLinkKai);
-    SetQWidgetWindowDecorations(&dialog);
     dialog.exec();
     return;
   }
   case ExpansionInterface::EXIDeviceType::EthernetTapServer:
   {
     BroadbandAdapterSettingsDialog dialog(this, BroadbandAdapterSettingsDialog::Type::TapServer);
-    SetQWidgetWindowDecorations(&dialog);
     dialog.exec();
     return;
   }
@@ -410,14 +405,12 @@ void GameCubePane::OnConfigPressed(ExpansionInterface::Slot slot)
   {
     BroadbandAdapterSettingsDialog dialog(this,
                                           BroadbandAdapterSettingsDialog::Type::ModemTapServer);
-    SetQWidgetWindowDecorations(&dialog);
     dialog.exec();
     return;
   }
   case ExpansionInterface::EXIDeviceType::EthernetBuiltIn:
   {
     BroadbandAdapterSettingsDialog dialog(this, BroadbandAdapterSettingsDialog::Type::BuiltIn);
-    SetQWidgetWindowDecorations(&dialog);
     dialog.exec();
     return;
   }

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -29,7 +29,6 @@
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipPushButton.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
@@ -361,7 +360,6 @@ void GeneralPane::GenerateNewIdentity()
   message_box.setIcon(QMessageBox::Information);
   message_box.setWindowTitle(tr("Identity Generation"));
   message_box.setText(tr("New identity generated."));
-  SetQWidgetWindowDecorations(&message_box);
   message_box.exec();
 }
 #endif

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -36,7 +36,6 @@
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
 #include "DolphinQt/QtUtils/QtUtils.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/USBDeviceAddToWhitelistDialog.h"
@@ -284,7 +283,6 @@ void WiiPane::CreateSDCard()
         progress_dialog.Reset();
         return good;
       });
-      SetQWidgetWindowDecorations(progress_dialog.GetRaw());
       progress_dialog.GetRaw()->exec();
       if (!success.get())
         ModalMessageBox::warning(this, tr(Common::SD_PACK_TEXT), tr("Conversion failed."));
@@ -309,7 +307,6 @@ void WiiPane::CreateSDCard()
         progress_dialog.Reset();
         return good;
       });
-      SetQWidgetWindowDecorations(progress_dialog.GetRaw());
       progress_dialog.GetRaw()->exec();
       if (!success.get())
         ModalMessageBox::warning(this, tr(Common::SD_UNPACK_TEXT), tr("Conversion failed."));
@@ -467,7 +464,6 @@ void WiiPane::OnUSBWhitelistAddButton()
   USBDeviceAddToWhitelistDialog usb_whitelist_dialog(this);
   connect(&usb_whitelist_dialog, &USBDeviceAddToWhitelistDialog::accepted, this,
           &WiiPane::PopulateUSBPassthroughListWidget);
-  SetQWidgetWindowDecorations(&usb_whitelist_dialog);
   usb_whitelist_dialog.exec();
 }
 

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderModifyDialog.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderModifyDialog.cpp
@@ -18,7 +18,6 @@
 #include "Core/System.h"
 
 #include "DolphinQt/QtUtils/QtUtils.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 SkylanderModifyDialog::SkylanderModifyDialog(QWidget* parent, u8 slot)
     : QDialog(parent), m_slot(slot)
@@ -106,8 +105,6 @@ SkylanderModifyDialog::SkylanderModifyDialog(QWidget* parent, u8 slot)
   layout->addWidget(m_buttons);
 
   this->setLayout(layout);
-
-  SetQWidgetWindowDecorations(this);
 
   if (should_show)
   {

--- a/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
+++ b/Source/Core/DolphinQt/SkylanderPortal/SkylanderPortalWindow.cpp
@@ -35,7 +35,6 @@
 #include "Core/System.h"
 
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 #include "SkylanderModifyDialog.h"
@@ -635,7 +634,6 @@ void SkylanderPortalWindow::CreateSkylanderAdvanced()
 
   connect(buttons, &QDialogButtonBox::rejected, create_window, &QDialog::reject);
 
-  SetQWidgetWindowDecorations(create_window);
   create_window->show();
   create_window->raise();
 }

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
@@ -29,7 +29,6 @@
 
 #include "DolphinQt/QtUtils/AspectRatioWidget.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/TAS/IRWidget.h"
 #include "DolphinQt/TAS/TASCheckBox.h"
 #include "DolphinQt/TAS/TASSpinBox.h"
@@ -435,21 +434,15 @@ void WiiTASInputWindow::UpdateControlVisibility()
   if (m_active_extension == WiimoteEmu::ExtensionNumber::NUNCHUK)
   {
     setWindowTitle(tr("Wii TAS Input %1 - Wii Remote + Nunchuk").arg(m_num + 1));
-    SetQWidgetWindowDecorations(m_ir_box);
     m_ir_box->show();
-    SetQWidgetWindowDecorations(m_nunchuk_stick_box);
     m_nunchuk_stick_box->show();
     m_classic_right_stick_box->hide();
     m_classic_left_stick_box->hide();
-    SetQWidgetWindowDecorations(m_remote_accelerometer_box);
     m_remote_accelerometer_box->show();
     m_remote_gyroscope_box->setVisible(m_is_motion_plus_attached);
-    SetQWidgetWindowDecorations(m_nunchuk_accelerometer_box);
     m_nunchuk_accelerometer_box->show();
     m_triggers_box->hide();
-    SetQWidgetWindowDecorations(m_nunchuk_buttons_box);
     m_nunchuk_buttons_box->show();
-    SetQWidgetWindowDecorations(m_remote_buttons_box);
     m_remote_buttons_box->show();
     m_classic_buttons_box->hide();
   }
@@ -458,18 +451,14 @@ void WiiTASInputWindow::UpdateControlVisibility()
     setWindowTitle(tr("Wii TAS Input %1 - Classic Controller").arg(m_num + 1));
     m_ir_box->hide();
     m_nunchuk_stick_box->hide();
-    SetQWidgetWindowDecorations(m_classic_right_stick_box);
     m_classic_right_stick_box->show();
-    SetQWidgetWindowDecorations(m_classic_left_stick_box);
     m_classic_left_stick_box->show();
     m_remote_accelerometer_box->hide();
     m_remote_gyroscope_box->hide();
     m_nunchuk_accelerometer_box->hide();
-    SetQWidgetWindowDecorations(m_triggers_box);
     m_triggers_box->show();
     m_remote_buttons_box->hide();
     m_nunchuk_buttons_box->hide();
-    SetQWidgetWindowDecorations(m_classic_buttons_box);
     m_classic_buttons_box->show();
   }
   else
@@ -479,12 +468,10 @@ void WiiTASInputWindow::UpdateControlVisibility()
     m_nunchuk_stick_box->hide();
     m_classic_right_stick_box->hide();
     m_classic_left_stick_box->hide();
-    SetQWidgetWindowDecorations(m_remote_accelerometer_box);
     m_remote_accelerometer_box->show();
     m_remote_gyroscope_box->setVisible(m_is_motion_plus_attached);
     m_nunchuk_accelerometer_box->hide();
     m_triggers_box->hide();
-    SetQWidgetWindowDecorations(m_remote_buttons_box);
     m_remote_buttons_box->show();
     m_nunchuk_buttons_box->hide();
     m_classic_buttons_box->hide();

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -17,7 +17,6 @@
 #include "Common/Version.h"
 
 #include "DolphinQt/QtUtils/RunOnObject.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 #include "DolphinQt/Settings.h"
 
 // Refer to docs/autoupdate_overview.md for a detailed overview of the autoupdate process
@@ -101,7 +100,6 @@ void Updater::OnUpdateAvailable(const NewVersionInformation& info)
     connect(buttons, &QDialogButtonBox::accepted, dialog, &QDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
 
-    SetQWidgetWindowDecorations(dialog);
     return dialog->exec();
   });
 

--- a/Source/Core/DolphinQt/WiiUpdate.cpp
+++ b/Source/Core/DolphinQt/WiiUpdate.cpp
@@ -21,7 +21,6 @@
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
-#include "DolphinQt/QtUtils/SetWindowDecorations.h"
 
 namespace WiiUpdate
 {
@@ -130,7 +129,6 @@ static WiiUtils::UpdateResult ShowProgress(QWidget* parent, Callable function, A
     return res;
   });
 
-  SetQWidgetWindowDecorations(&dialog);
   dialog.exec();
   return result.get();
 }


### PR DESCRIPTION
Dark / light theme changes seem to still work properly.

The event filter code is ugly, but I think it's better than having to remember a `SetQWidgetWindowDecorations` call every time someone shows a window.