### PR TITLE
SFML: Update to 3.0.1

### DIFF
--- a/Externals/SFML/CMakeLists.txt
+++ b/Externals/SFML/CMakeLists.txt
@@ -24,8 +24,8 @@ set(SRC_SYSTEM
 
 add_library(sfml-network STATIC ${SRC_NETWORK})
 add_library(sfml-system STATIC ${SRC_SYSTEM})
-target_compile_features(sfml-network PUBLIC cxx_std_17)
-target_compile_features(sfml-system PUBLIC cxx_std_17)
+target_compile_features(sfml-network PUBLIC cxx_std_20)
+target_compile_features(sfml-system PUBLIC cxx_std_20)
 target_compile_definitions(sfml-system PUBLIC SFML_STATIC)
 target_include_directories(sfml-system PUBLIC SFML/include PRIVATE SFML/src)
 target_include_directories(sfml-network PUBLIC SFML/include PRIVATE SFML/src)


### PR DESCRIPTION
Part of #13677, which is being split up for ease of review.

SFML 3.0.1 most notably brings SFML up to C++20 and fixes builds with CMake 4