### PR TITLE
Disable icache for The Ant Bully [Wii]

### DIFF
--- a/Data/Sys/GameSettings/RI3.ini
+++ b/Data/Sys/GameSettings/RI3.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# The JIT cache causes problems with emulated icache invalidation in this game resulting in areas failing to load
+DisableICache = True
 
 [OnFrame]
 # Add memory patches to be applied every frame here.


### PR DESCRIPTION
This fixes an invalid read error that would happen specifically in the Wii version. This doesn't seem to affect the GC version afaik.

This fixes [issue 12385](https://bugs.dolphin-emu.org/issues/12385).