### PR TITLE
Debugger Add note-type symbols .

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -51,6 +51,7 @@ void SymbolDB::Clear(const char* prefix)
 {
   // TODO: honor prefix
   m_functions.clear();
+  m_notes.clear();
   m_checksum_to_function.clear();
 }
 

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -29,6 +29,16 @@ struct SCall
   u32 call_address;
 };
 
+struct Note
+{
+  std::string name;
+  u32 address = 0;
+  u32 size = 0;
+  int layer = 0;
+
+  Note() = default;
+};
+
 struct Symbol
 {
   enum class Type
@@ -71,6 +81,7 @@ class SymbolDB
 {
 public:
   using XFuncMap = std::map<u32, Symbol>;
+  using XNoteMap = std::map<u32, Note>;
   using XFuncPtrMap = std::map<u32, std::set<Symbol*>>;
 
   SymbolDB();
@@ -86,6 +97,7 @@ public:
   std::vector<Symbol*> GetSymbolsFromHash(u32 hash);
 
   const XFuncMap& Symbols() const { return m_functions; }
+  const XNoteMap& Notes() const { return m_notes; }
   XFuncMap& AccessSymbols() { return m_functions; }
   bool IsEmpty() const;
   void Clear(const char* prefix = "");
@@ -94,6 +106,7 @@ public:
 
 protected:
   XFuncMap m_functions;
+  XNoteMap m_notes;
   XFuncPtrMap m_checksum_to_function;
 };
 }  // namespace Common

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -182,6 +182,16 @@ Common::Note* PPCSymbolDB::GetNoteFromAddr(u32 addr)
   return nullptr;
 }
 
+void PPCSymbolDB::DeleteFunction(u32 start_address)
+{
+  m_functions.erase(start_address);
+}
+
+void PPCSymbolDB::DeleteNote(u32 start_address)
+{
+  m_notes.erase(start_address);
+}
+
 std::string_view PPCSymbolDB::GetDescription(u32 addr)
 {
   if (const Common::Symbol* const symbol = GetSymbolFromAddr(addr))

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -25,13 +25,16 @@ public:
   void AddKnownSymbol(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
                       const std::string& name, const std::string& object_name,
                       Common::Symbol::Type type = Common::Symbol::Type::Function);
+  void AddKnownNote(u32 start_addr, u32 size, const std::string& name);
 
   Common::Symbol* GetSymbolFromAddr(u32 addr) override;
+  bool NoteExists() const { return !m_notes.empty(); }
+  Common::Note* GetNoteFromAddr(u32 addr);
+  void DetermineNoteLayers();
 
   std::string_view GetDescription(u32 addr);
 
   void FillInCallers();
-
   bool LoadMap(const Core::CPUThreadGuard& guard, const std::string& filename, bool bad = false);
   bool SaveSymbolMap(const std::string& filename) const;
   bool SaveCodeMap(const Core::CPUThreadGuard& guard, const std::string& filename) const;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -31,6 +31,8 @@ public:
   bool NoteExists() const { return !m_notes.empty(); }
   Common::Note* GetNoteFromAddr(u32 addr);
   void DetermineNoteLayers();
+  void DeleteFunction(u32 start_address);
+  void DeleteNote(u32 start_address);
 
   std::string_view GetDescription(u32 addr);
 

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -221,6 +221,8 @@ add_executable(dolphin-emu
   Debugger/CodeViewWidget.h
   Debugger/CodeWidget.cpp
   Debugger/CodeWidget.h
+  Debugger/EditSymbolDialog.cpp
+  Debugger/EditSymbolDialog.h
   Debugger/GekkoSyntaxHighlight.cpp
   Debugger/GekkoSyntaxHighlight.h
   Debugger/JitBlockTableModel.cpp

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -37,6 +37,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 #include "DolphinQt/Debugger/AssembleInstructionDialog.h"
+#include "DolphinQt/Debugger/EditSymbolDialog.h"
 #include "DolphinQt/Debugger/PatchInstructionDialog.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/FromStdString.h"
@@ -579,8 +580,6 @@ void CodeViewWidget::OnContextMenu()
 
   const u32 addr = GetContextAddress();
 
-  const bool has_symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
-
   auto* follow_branch_action =
       menu->addAction(tr("Follow &Branch"), this, &CodeViewWidget::OnFollowBranch);
 
@@ -600,17 +599,17 @@ void CodeViewWidget::OnContextMenu()
       menu->addAction(tr("Copy Tar&get Address"), this, &CodeViewWidget::OnCopyTargetAddress);
   menu->addSeparator();
 
-  auto* symbol_rename_action =
-      menu->addAction(tr("&Rename Symbol"), this, &CodeViewWidget::OnRenameSymbol);
-  auto* symbol_size_action =
-      menu->addAction(tr("Set Symbol &Size"), this, &CodeViewWidget::OnSetSymbolSize);
-  auto* symbol_end_action =
-      menu->addAction(tr("Set Symbol &End Address"), this, &CodeViewWidget::OnSetSymbolEndAddress);
+  auto* symbol_add_action =
+      menu->addAction(tr("&Add function symbol"), this, &CodeViewWidget::OnAddFunction);
+  auto* symbol_edit_action =
+      menu->addAction(tr("&Edit function symbol"), this, &CodeViewWidget::OnEditSymbol);
+
+  auto* note_add_action = menu->addAction(tr("Add Note"), this, &CodeViewWidget::OnAddNote);
+  auto* note_edit_action = menu->addAction(tr("Edit Note"), this, &CodeViewWidget::OnEditNote);
+
   menu->addSeparator();
 
   auto* run_to_action = menu->addAction(tr("Run &to Here"), this, &CodeViewWidget::OnRunToHere);
-  auto* function_action =
-      menu->addAction(tr("&Add Function"), this, &CodeViewWidget::OnAddFunction);
   auto* ppc_action = menu->addAction(tr("PPC vs Host"), this, &CodeViewWidget::OnPPCComparison);
   auto* insert_blr_action = menu->addAction(tr("&Insert BLR"), this, &CodeViewWidget::OnInsertBLR);
   auto* insert_nop_action = menu->addAction(tr("Insert &NOP"), this, &CodeViewWidget::OnInsertNOP);
@@ -659,19 +658,23 @@ void CodeViewWidget::OnContextMenu()
   follow_branch_action->setEnabled(follow_branch_enabled);
 
   for (auto* action :
-       {copy_address_action, copy_line_action, copy_hex_action, function_action, run_to_action,
-        ppc_action, insert_blr_action, insert_nop_action, replace_action, assemble_action})
+       {copy_address_action, copy_line_action, copy_hex_action, symbol_add_action,
+        symbol_edit_action, note_add_action, note_edit_action, run_to_action, ppc_action,
+        insert_blr_action, insert_nop_action, replace_action, assemble_action})
   {
     action->setEnabled(running);
   }
-
-  for (auto* action : {symbol_rename_action, symbol_size_action, symbol_end_action})
-    action->setEnabled(has_symbol);
 
   for (auto* action : {copy_target_memory, show_target_memory})
   {
     action->setEnabled(valid_load_store);
   }
+
+  auto* note = m_ppc_symbol_db.GetNoteFromAddr(addr);
+  note_edit_action->setEnabled(note != nullptr);
+  // A note cannot be added ontop of the starting address of another note.
+  if (note != nullptr && note->address == addr)
+    note_add_action->setEnabled(false);
 
   restore_action->setEnabled(running &&
                              m_system.GetPowerPC().GetDebugInterface().HasEnabledPatch(addr));
@@ -896,6 +899,13 @@ void CodeViewWidget::OnPPCComparison()
 void CodeViewWidget::OnAddFunction()
 {
   const u32 addr = GetContextAddress();
+  const int confirm =
+      QMessageBox::warning(this, tr("Add Function Symbol"),
+                           tr("Force new function symbol to be made at %1?").arg(addr, 0, 16),
+                           QMessageBox::Ok | QMessageBox::Cancel);
+
+  if (confirm != QMessageBox::Ok)
+    return;
 
   Core::CPUThreadGuard guard(m_system);
 
@@ -932,25 +942,80 @@ void CodeViewWidget::OnFollowBranch()
   SetAddress(branch_addr, SetAddressUpdate::WithDetailedUpdate);
 }
 
-void CodeViewWidget::OnRenameSymbol()
+void CodeViewWidget::OnEditSymbol()
 {
   const u32 addr = GetContextAddress();
-
   Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
 
-  if (!symbol)
+  if (symbol == nullptr)
+  {
+    OnAddFunction();
+    return;
+  }
+
+  std::string name = symbol->name;
+  u32 size = symbol->size;
+  const u32 symbol_address = symbol->address;
+
+  EditSymbolDialog dialog(this, symbol_address, &size, &name);
+
+  if (dialog.exec() != QDialog::Accepted)
     return;
 
-  bool good;
-  const QString name =
-      QInputDialog::getText(this, tr("Rename Symbol"), tr("Symbol Name:"), QLineEdit::Normal,
-                            QString::fromStdString(symbol->name), &good, Qt::WindowCloseButtonHint);
-
-  if (good && !name.isEmpty())
+  if (dialog.DeleteRequested())
   {
-    symbol->Rename(name.toStdString());
-    emit Host::GetInstance()->PPCSymbolsChanged();
+    OnDeleteSymbol();
+    return;
   }
+
+  if (symbol->name != name)
+    symbol->Rename(name);
+
+  if (symbol->size != size)
+  {
+    Core::CPUThreadGuard guard(m_system);
+    PPCAnalyst::ReanalyzeFunction(guard, symbol->address, *symbol, size);
+  }
+
+  emit Host::GetInstance()->PPCSymbolsChanged();
+}
+
+void CodeViewWidget::OnDeleteSymbol()
+{
+  const u32 addr = GetContextAddress();
+  Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
+
+  if (symbol == nullptr)
+    return;
+
+  const int confirm = QMessageBox::warning(this, tr("Delete Function Symbol"),
+                                           tr("Delete function symbol: %1\nat %2?")
+                                               .arg(QString::fromStdString(symbol->name))
+                                               .arg(addr, 0, 16),
+                                           QMessageBox::Ok | QMessageBox::Cancel);
+
+  if (confirm != QMessageBox::Ok)
+    return;
+
+  m_ppc_symbol_db.DeleteFunction(symbol->address);
+
+  emit Host::GetInstance()->PPCSymbolsChanged();
+}
+
+void CodeViewWidget::OnAddNote()
+{
+  const u32 note_address = GetContextAddress();
+  std::string name = "";
+  u32 size = 4;
+
+  EditSymbolDialog dialog(this, note_address, &size, &name, EditSymbolDialog::Type::Note);
+
+  if (dialog.exec() != QDialog::Accepted || dialog.DeleteRequested())
+    return;
+
+  m_ppc_symbol_db.AddKnownNote(note_address, size, name);
+  m_ppc_symbol_db.DetermineNoteLayers();
+  emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
 void CodeViewWidget::OnSelectionChanged()
@@ -966,53 +1031,57 @@ void CodeViewWidget::OnSelectionChanged()
   }
 }
 
-void CodeViewWidget::OnSetSymbolSize()
+void CodeViewWidget::OnEditNote()
 {
-  const u32 addr = GetContextAddress();
+  const u32 context_address = GetContextAddress();
+  Common::Note* const note = m_ppc_symbol_db.GetNoteFromAddr(context_address);
 
-  Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
-
-  if (!symbol)
+  if (note == nullptr)
     return;
 
-  bool good;
-  const int size = QInputDialog::getInt(
-      this, tr("Rename Symbol"), tr("Symbol Size (%1):").arg(QString::fromStdString(symbol->name)),
-      symbol->size, 1, 0xFFFF, 1, &good, Qt::WindowCloseButtonHint);
+  std::string name = note->name;
+  u32 size = note->size;
+  const u32 note_address = note->address;
 
-  if (!good)
+  EditSymbolDialog dialog(this, note_address, &size, &name, EditSymbolDialog::Type::Note);
+
+  if (dialog.exec() != QDialog::Accepted)
     return;
 
-  Core::CPUThreadGuard guard(m_system);
+  if (dialog.DeleteRequested())
+  {
+    OnDeleteNote();
+    return;
+  }
 
-  PPCAnalyst::ReanalyzeFunction(guard, symbol->address, *symbol, size);
+  if (note->name != name || note->size != size)
+  {
+    m_ppc_symbol_db.AddKnownNote(note_address, size, name);
+    m_ppc_symbol_db.DetermineNoteLayers();
+  }
+
   emit Host::GetInstance()->PPCSymbolsChanged();
 }
 
-void CodeViewWidget::OnSetSymbolEndAddress()
+void CodeViewWidget::OnDeleteNote()
 {
-  const u32 addr = GetContextAddress();
+  const u32 context_address = GetContextAddress();
+  Common::Note* const note = m_ppc_symbol_db.GetNoteFromAddr(context_address);
 
-  Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
-
-  if (!symbol)
+  if (note == nullptr)
     return;
 
-  bool good;
-  const QString name = QInputDialog::getText(
-      this, tr("Set Symbol End Address"),
-      tr("Symbol End Address (%1):").arg(QString::fromStdString(symbol->name)), QLineEdit::Normal,
-      QStringLiteral("%1").arg(addr + symbol->size, 8, 16, QLatin1Char('0')), &good,
-      Qt::WindowCloseButtonHint);
+  const int confirm = QMessageBox::warning(this, tr("Delete Note"),
+                                           tr("Delete Note: %1\nat %2?")
+                                               .arg(QString::fromStdString(note->name))
+                                               .arg(context_address, 0, 16),
+                                           QMessageBox::Ok | QMessageBox::Cancel);
 
-  const u32 address = name.toUInt(&good, 16);
-
-  if (!good)
+  if (confirm != QMessageBox::Ok)
     return;
 
-  Core::CPUThreadGuard guard(m_system);
+  m_ppc_symbol_db.DeleteNote(note->address);
 
-  PPCAnalyst::ReanalyzeFunction(guard, symbol->address, *symbol, address - symbol->address);
   emit Host::GetInstance()->PPCSymbolsChanged();
 }
 

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -87,13 +87,15 @@ private:
   void OnCopyFunction();
   void OnCopyCode();
   void OnCopyHex();
-  void OnRenameSymbol();
   void OnSelectionChanged();
-  void OnSetSymbolSize();
-  void OnSetSymbolEndAddress();
   void OnRunToHere();
   void OnAddFunction();
+  void OnEditSymbol();
+  void OnDeleteSymbol();
+  void OnAddNote();
   void OnPPCComparison();
+  void OnEditNote();
+  void OnDeleteNote();
   void OnInsertBLR();
   void OnInsertNOP();
   void OnReplaceInstruction();

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -61,11 +61,13 @@ private:
   void UpdateCallstack();
   void UpdateFunctionCalls(const Common::Symbol* symbol);
   void UpdateFunctionCallers(const Common::Symbol* symbol);
+  void UpdateNotes();
 
   void OnPPCSymbolsChanged();
   void OnSearchAddress();
   void OnSearchSymbols();
   void OnSelectSymbol();
+  void OnSelectNote();
   void OnSelectCallstack();
   void OnSelectFunctionCallers();
   void OnSelectFunctionCalls();
@@ -84,6 +86,7 @@ private:
   QListWidget* m_callstack_list;
   QLineEdit* m_search_symbols;
   QListWidget* m_symbols_list;
+  QListWidget* m_note_list;
   QLineEdit* m_search_calls;
   QListWidget* m_function_calls_list;
   QLineEdit* m_search_callers;

--- a/Source/Core/DolphinQt/Debugger/EditSymbolDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/EditSymbolDialog.cpp
@@ -1,0 +1,153 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Debugger/EditSymbolDialog.h"
+
+#include <QAbstractButton>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QRegularExpression>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+EditSymbolDialog::EditSymbolDialog(QWidget* parent, const u32 symbol_address, u32* symbol_size,
+                                   std::string* symbol_name, Type type)
+    : QDialog(parent), m_symbol_name(symbol_name), m_symbol_size(symbol_size),
+      m_symbol_address(symbol_address)
+{
+  m_type = type == Type::Symbol ? tr("Symbol") : tr("Note");
+  setWindowTitle(tr("Edit %1").arg(m_type));
+  CreateWidgets();
+  ConnectWidgets();
+}
+
+void EditSymbolDialog::CreateWidgets()
+{
+  m_buttons = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
+  m_buttons->addButton(tr("Reset"), QDialogButtonBox::ResetRole);
+  m_buttons->addButton(tr("Delete"), QDialogButtonBox::DestructiveRole);
+
+  QLabel* info_label = new QLabel(tr("Editing %1 starting at: %2\nWarning: Must save the symbol "
+                                     "map for changes to be kept.")
+                                      .arg(m_type)
+                                      .arg(QString::number(m_symbol_address, 16)));
+  m_name_edit = new QLineEdit();
+  m_name_edit->setPlaceholderText(tr("%1 name").arg(m_type));
+
+  auto* size_layout = new QHBoxLayout;
+  QLabel* address_end_label = new QLabel(tr("End Address"));
+  QLabel* size_lines_label = new QLabel(tr("Lines"));
+  QLabel* size_hex_label = new QLabel(tr("Size: 0x"));
+  m_address_end_edit = new QLineEdit();
+  m_size_lines_spin = new QSpinBox();
+  m_size_hex_edit = new QLineEdit();
+
+  size_hex_label->setAlignment(Qt::AlignCenter | Qt::AlignRight);
+  size_lines_label->setAlignment(Qt::AlignCenter | Qt::AlignRight);
+
+  // Get system font and use to size boxes.
+  QFont font;
+  QFontMetrics fm(font);
+  const int width = fm.horizontalAdvance(QLatin1Char('0')) * 2;
+  m_address_end_edit->setFixedWidth(width * 6);
+  m_size_hex_edit->setFixedWidth(width * 5);
+  m_size_lines_spin->setFixedWidth(width * 5);
+  m_size_hex_edit->setMaxLength(7);
+  m_size_lines_spin->setRange(0, 99999);
+
+  // Accept hex input only
+  QRegularExpression rx(QStringLiteral("[0-9a-fA-F]{0,8}"));
+  QValidator* validator = new QRegularExpressionValidator(rx, this);
+  m_address_end_edit->setValidator(validator);
+  m_size_hex_edit->setValidator(validator);
+
+  size_layout->addWidget(address_end_label);
+  size_layout->addWidget(m_address_end_edit);
+  size_layout->addWidget(size_hex_label);
+  size_layout->addWidget(m_size_hex_edit);
+  size_layout->addWidget(size_lines_label);
+  size_layout->addWidget(m_size_lines_spin);
+
+  auto* layout = new QVBoxLayout();
+  layout->addWidget(info_label);
+  layout->addWidget(m_name_edit);
+  layout->addLayout(size_layout);
+  layout->addWidget(m_buttons);
+
+  setLayout(layout);
+
+  FillFunctionData();
+}
+
+void EditSymbolDialog::FillFunctionData()
+{
+  m_name_edit->setText(QString::fromStdString(*m_symbol_name));
+  m_size_lines_spin->setValue(*m_symbol_size / 4);
+  m_size_hex_edit->setText(QString::number(*m_symbol_size, 16));
+  m_address_end_edit->setText(
+      QStringLiteral("%1").arg(m_symbol_address + *m_symbol_size, 8, 16, QLatin1Char('0')));
+}
+
+void EditSymbolDialog::UpdateAddressData(u32 size)
+{
+  // Not sure what the max size should be. Definitely not a full 8, so set to 7.
+  size = size & 0xFFFFFFF;
+
+  m_size_lines_spin->setValue(size / 4);
+  m_size_hex_edit->setText(QString::number(size, 16));
+  m_address_end_edit->setText(
+      QStringLiteral("%1").arg(m_symbol_address + size, 8, 16, QLatin1Char('0')));
+}
+
+void EditSymbolDialog::ConnectWidgets()
+{
+  connect(m_size_lines_spin, QOverload<int>::of(&QSpinBox::valueChanged), this,
+          [this](int value) { UpdateAddressData(value * 4); });
+
+  connect(m_size_hex_edit, &QLineEdit::editingFinished, this, [this] {
+    bool good;
+    const u32 size = m_size_hex_edit->text().toUInt(&good, 16);
+    if (good)
+      UpdateAddressData(size);
+  });
+
+  connect(m_address_end_edit, &QLineEdit::textEdited, this, [this] {
+    bool good;
+    const u32 end = m_address_end_edit->text().toUInt(&good, 16);
+    if (good && end > m_symbol_address)
+      UpdateAddressData(end - m_symbol_address);
+  });
+
+  connect(m_buttons, &QDialogButtonBox::accepted, this, &EditSymbolDialog::Accepted);
+  connect(m_buttons, &QDialogButtonBox::rejected, this, &EditSymbolDialog::reject);
+  connect(m_buttons, &QDialogButtonBox::clicked, this, [this](QAbstractButton* btn) {
+    const auto role = m_buttons->buttonRole(btn);
+    if (role == QDialogButtonBox::ButtonRole::ResetRole)
+    {
+      FillFunctionData();
+    }
+    else if (role == QDialogButtonBox::ButtonRole::DestructiveRole)
+    {
+      m_delete_chosen = true;
+      QDialog::accept();
+    }
+  });
+}
+
+void EditSymbolDialog::Accepted()
+{
+  const std::string name = m_name_edit->text().toStdString();
+
+  if (*m_symbol_name != name)
+    *m_symbol_name = name;
+
+  bool good;
+  const u32 size = m_size_hex_edit->text().toUInt(&good, 16);
+
+  if (good && *m_symbol_size != size)
+    *m_symbol_size = size;
+
+  QDialog::accept();
+}

--- a/Source/Core/DolphinQt/Debugger/EditSymbolDialog.h
+++ b/Source/Core/DolphinQt/Debugger/EditSymbolDialog.h
@@ -1,0 +1,51 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+#include <string>
+
+#include <QDialog>
+#include <QString>
+#include "Common/CommonTypes.h"
+
+class QLineEdit;
+class QDialogButtonBox;
+class QSpinBox;
+
+class EditSymbolDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  enum class Type
+  {
+    Symbol,
+    Note,
+  };
+
+  explicit EditSymbolDialog(QWidget* parent, const u32 symbol_address, u32* symbol_size,
+                            std::string* symbol_name, Type type = Type::Symbol);
+
+  bool DeleteRequested() const { return m_delete_chosen; }
+
+private:
+  void CreateWidgets();
+  void ConnectWidgets();
+  void FillFunctionData();
+  void UpdateAddressData(u32 size);
+  void Accepted();
+
+  QLineEdit* m_name_edit;
+  QSpinBox* m_size_lines_spin;
+  QLineEdit* m_size_hex_edit;
+  QLineEdit* m_address_end_edit;
+
+  QDialogButtonBox* m_buttons;
+
+  QString m_type;
+  std::string* m_symbol_name;
+  u32* m_symbol_size;
+  const u32 m_symbol_address;
+
+  bool m_delete_chosen = false;
+};

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -144,6 +144,7 @@
     <ClCompile Include="Debugger\BreakpointWidget.cpp" />
     <ClCompile Include="Debugger\CodeViewWidget.cpp" />
     <ClCompile Include="Debugger\CodeWidget.cpp" />
+    <ClCompile Include="Debugger\EditSymbolDialog.cpp" />
     <ClCompile Include="Debugger\GekkoSyntaxHighlight.cpp" />
     <ClCompile Include="Debugger\JitBlockTableModel.cpp" />
     <ClCompile Include="Debugger\JITWidget.cpp" />
@@ -364,6 +365,7 @@
     <QtMoc Include="Debugger\BreakpointWidget.h" />
     <QtMoc Include="Debugger\CodeViewWidget.h" />
     <QtMoc Include="Debugger\CodeWidget.h" />
+    <QtMoc Include="Debugger\EditSymbolDialog.h" />
     <QtMoc Include="Debugger\GekkoSyntaxHighlight.h" />
     <QtMoc Include="Debugger\JitBlockTableModel.h" />
     <QtMoc Include="Debugger\JITWidget.h" />


### PR DESCRIPTION
*Warning: backup your symbol map before testing* Could have saving issues.

Adds a new type of symbol called Note that is always displayed on top of other symbols.  The purpose is to mark individual lines or sections of code as something, such as a bookmark or an explanation of what it is.  For example, if you have a 300 line function and want to have the ability to quickly navigate to an instruction in the center, you would just put a note there.

Adds note search box as a tabbed option next to the symbols search box.
Adds new popup dialog for editing symbols and notes.

The custom note loading logic is important, as it lets you overlap multiple notes of different sizes. I wasn't sure if I should make it a part of the function map, so I kept it separate and much simpler than a function symbol. Notes won't display in callers/callees and such.

The UI is a bit rough. I made it so deleting the name of a function/note will popup a delete confirmation dialog.  I could probably just make a UI button for that in the popup.  I tried to manage most editing options in as few context items as possible, to avoid a submenu.  There needs to be a separate Add and Edit note option for overlaying one over another (as in SS below).

![image](https://github.com/user-attachments/assets/9476e2d8-876d-40f1-bffb-791b36585b8a)