### PR TITLE
DolphinQt/RenderWidget: Grab focus on mouse button press.

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -384,6 +384,10 @@ bool RenderWidget::event(QEvent* event)
     SetCursorLocked(false);
     break;
   case QEvent::MouseButtonPress:
+
+    // Grab focus to stop unwanted keyboard input UI interaction.
+    setFocus();
+
     if (isActiveWindow())
     {
       // Lock the cursor with any mouse button click (behave the same as window focus change).


### PR DESCRIPTION
Make RenderWidget grab focus when clicked on.

This stops the super annoying situation of keyboard inputs changing the log config or whatever UI was recently interacted with.

I don't know how I put up with this for so long.