### PR TITLE
MappingWidget: Add Advanced Configuration Button to Point And Point Passthrough "Enable" boxes

### DIFF
--- a/Source/Android/jni/Input/ControlGroup.cpp
+++ b/Source/Android/jni/Input/ControlGroup.cpp
@@ -55,14 +55,14 @@ JNIEXPORT jboolean JNICALL
 Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_ControlGroup_getEnabled(
     JNIEnv* env, jobject obj)
 {
-  return static_cast<jboolean>(GetPointer(env, obj)->enabled);
+  return static_cast<jboolean>(GetPointer(env, obj)->enabled.GetValue());
 }
 
 JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_ControlGroup_setEnabled(
     JNIEnv* env, jobject obj, jboolean value)
 {
-  GetPointer(env, obj)->enabled = value;
+  GetPointer(env, obj)->enabled.SetValue(value);
 }
 
 JNIEXPORT jint JNICALL

--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -311,7 +311,7 @@ void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_gr
   const auto ang_vel = imu_gyroscope_group->GetState();
 
   // Reset if pointing is disabled or we have no gyro data.
-  if (!imu_ir_group->enabled || !ang_vel.has_value())
+  if (!imu_ir_group->enabled.GetValue() || !ang_vel.has_value())
   {
     *state = {};
     return;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -497,7 +497,7 @@ void Wiimote::BuildDesiredWiimoteState(DesiredWiimoteState* target_state,
       ConvertAccelData(GetTotalAcceleration(), ACCEL_ZERO_G << 2, ACCEL_ONE_G << 2);
 
   // Calculate IR camera state.
-  if (m_ir_passthrough->enabled)
+  if (m_ir_passthrough->enabled.GetValue())
   {
     target_state->camera_points = GetPassthroughCameraPoints(m_ir_passthrough);
   }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -893,7 +893,8 @@ void IRPassthroughMappingIndicator::Draw()
 
   p.scale(1.0, -1.0);
 
-  auto pen = GetInputDotPen(m_ir_group.enabled ? GetAdjustedInputColor() : GetRawInputColor());
+  auto pen =
+      GetInputDotPen(m_ir_group.enabled.GetValue() ? GetAdjustedInputColor() : GetRawInputColor());
 
   for (std::size_t i = 0; i != WiimoteEmu::CameraLogic::NUM_POINTS; ++i)
   {

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -103,13 +103,24 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
     break;
   }
 
+  // Mapping indicator.
+  if (indicator != nullptr)
+  {
+    auto* const indicator_layout = new QBoxLayout(QBoxLayout::Direction::Down);
+    indicator_layout->addWidget(indicator);
+    indicator_layout->setAlignment(Qt::AlignCenter);
+    form_layout->addRow(indicator_layout);
+
+    connect(this, &MappingWidget::Update, indicator, qOverload<>(&MappingIndicator::update));
+  }
+
+  // "Enabled" checkbox.
   if (group->HasEnabledSetting())
   {
     AddSettingWidget(form_layout, group->enabled_setting.get());
 
-    auto enable_labels = [form_layout](bool enabled) {
-      // Skipping the "Enabled" checkbox row itself.
-      constexpr int start_index = 1;
+    auto enable_labels = [form_layout, start_index = form_layout->rowCount()](bool enabled) {
+      // Skipping the "Enabled" checkbox row itself and the mapping indicator, if it exists.
       for (int i = start_index; i < form_layout->count(); ++i)
       {
         auto* const item = form_layout->itemAt(i, QFormLayout::LabelRole);
@@ -131,15 +142,9 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
     });
   }
 
-  if (indicator)
+  // "Calibrate" button.
+  if (indicator != nullptr)
   {
-    const auto indicator_layout = new QBoxLayout(QBoxLayout::Direction::Down);
-    indicator_layout->addWidget(indicator);
-    indicator_layout->setAlignment(Qt::AlignCenter);
-    form_layout->addRow(indicator_layout);
-
-    connect(this, &MappingWidget::Update, indicator, qOverload<>(&MappingIndicator::update));
-
     const bool need_calibration = group->type == ControllerEmu::GroupType::Cursor ||
                                   group->type == ControllerEmu::GroupType::Stick ||
                                   group->type == ControllerEmu::GroupType::Tilt ||

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -103,6 +103,34 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
     break;
   }
 
+  if (group->HasEnabledSetting())
+  {
+    AddSettingWidget(form_layout, group->enabled_setting.get());
+
+    auto enable_labels = [form_layout](bool enabled) {
+      // Skipping the "Enabled" checkbox row itself.
+      constexpr int start_index = 1;
+      for (int i = start_index; i < form_layout->count(); ++i)
+      {
+        auto* const item = form_layout->itemAt(i, QFormLayout::LabelRole);
+        if (item == nullptr)
+          continue;
+
+        auto* const widget = item->widget();
+        if (widget == nullptr)
+          continue;
+
+        widget->setEnabled(enabled);
+      }
+    };
+
+    connect(this, &MappingWidget::Update, this, [group, enable_labels, enabled = true]() mutable {
+      if (enabled == group->enabled_setting->GetValue())
+        return;
+      enable_labels(enabled = !enabled);
+    });
+  }
+
   if (indicator)
   {
     const auto indicator_layout = new QBoxLayout(QBoxLayout::Direction::Down);
@@ -131,28 +159,6 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
     CreateControl(control.get(), form_layout, !indicator);
 
   AddSettingWidgets(form_layout, group, ControllerEmu::SettingVisibility::Normal);
-
-  if (group->default_value != ControllerEmu::ControlGroup::DefaultValue::AlwaysEnabled)
-  {
-    QLabel* group_enable_label = new QLabel(tr("Enable"));
-    QCheckBox* group_enable_checkbox = new QCheckBox();
-    group_enable_checkbox->setChecked(group->enabled);
-    form_layout->insertRow(0, group_enable_label, group_enable_checkbox);
-    auto enable_group_by_checkbox = [group, form_layout, group_enable_label,
-                                     group_enable_checkbox] {
-      group->enabled = group_enable_checkbox->isChecked();
-      for (int i = 0; i < form_layout->count(); ++i)
-      {
-        QWidget* widget = form_layout->itemAt(i)->widget();
-        if (widget != nullptr && widget != group_enable_label && widget != group_enable_checkbox)
-          widget->setEnabled(group->enabled);
-      }
-    };
-    enable_group_by_checkbox();
-    connect(group_enable_checkbox, &QCheckBox::toggled, this, enable_group_by_checkbox);
-    connect(this, &MappingWidget::ConfigChanged, this,
-            [group_enable_checkbox, group] { group_enable_checkbox->setChecked(group->enabled); });
-  }
 
   const auto advanced_setting_count =
       std::ranges::count(group->numeric_settings, ControllerEmu::SettingVisibility::Advanced,
@@ -202,36 +208,42 @@ void MappingWidget::AddSettingWidgets(QFormLayout* layout, ControllerEmu::Contro
     if (setting->GetVisibility() != visibility)
       continue;
 
-    QWidget* setting_widget = nullptr;
+    AddSettingWidget(layout, setting.get());
+  }
+}
 
-    switch (setting->GetType())
-    {
-    case ControllerEmu::SettingType::Double:
-      setting_widget = new MappingDouble(
-          this, static_cast<ControllerEmu::NumericSetting<double>*>(setting.get()));
-      break;
+void MappingWidget::AddSettingWidget(QFormLayout* layout,
+                                     ControllerEmu::NumericSettingBase* setting)
+{
+  QWidget* setting_widget = nullptr;
 
-    case ControllerEmu::SettingType::Bool:
-      setting_widget =
-          new MappingBool(this, static_cast<ControllerEmu::NumericSetting<bool>*>(setting.get()));
-      break;
+  switch (setting->GetType())
+  {
+  case ControllerEmu::SettingType::Double:
+    setting_widget =
+        new MappingDouble(this, static_cast<ControllerEmu::NumericSetting<double>*>(setting));
+    break;
 
-    default:
-      // FYI: Widgets for additional types can be implemented as needed.
-      break;
-    }
+  case ControllerEmu::SettingType::Bool:
+    setting_widget =
+        new MappingBool(this, static_cast<ControllerEmu::NumericSetting<bool>*>(setting));
+    break;
 
-    if (setting_widget)
-    {
-      const auto hbox = new QHBoxLayout;
+  default:
+    // FYI: Widgets for additional types can be implemented as needed.
+    break;
+  }
 
-      hbox->addWidget(setting_widget);
-      setting_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  if (setting_widget != nullptr)
+  {
+    auto* const hbox = new QHBoxLayout;
 
-      hbox->addWidget(CreateSettingAdvancedMappingButton(*setting));
+    hbox->addWidget(setting_widget);
+    setting_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
-      layout->addRow(tr(setting->GetUIName()), hbox);
-    }
+    hbox->addWidget(CreateSettingAdvancedMappingButton(*setting));
+
+    layout->addRow(tr(setting->GetUIName()), hbox);
   }
 }
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -50,8 +50,11 @@ protected:
                                int columns);
   void CreateControl(const ControllerEmu::Control* control, QFormLayout* layout, bool indicator);
   QPushButton* CreateSettingAdvancedMappingButton(ControllerEmu::NumericSettingBase& setting);
+
+  void AddSettingWidget(QFormLayout* layout, ControllerEmu::NumericSettingBase* setting);
   void AddSettingWidgets(QFormLayout* layout, ControllerEmu::ControlGroup* group,
                          ControllerEmu::SettingVisibility visibility);
+
   void ShowAdvancedControlGroupDialog(ControllerEmu::ControlGroup* group);
 
 private:

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -15,6 +15,7 @@
 
 #include "Common/IniFile.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
 namespace ControllerEmu
@@ -62,7 +63,7 @@ public:
     Disabled,
   };
 
-  explicit ControlGroup(std::string name, GroupType type = GroupType::Other,
+  explicit ControlGroup(const std::string& name, GroupType type = GroupType::Other,
                         DefaultValue default_value = DefaultValue::AlwaysEnabled);
   ControlGroup(std::string name, std::string ui_name, GroupType type = GroupType::Other,
                DefaultValue default_value = DefaultValue::AlwaysEnabled);
@@ -98,12 +99,17 @@ public:
     return std::copysign(std::max(T{0}, std::abs(input) - deadzone) / (T{1} - deadzone), input);
   }
 
+  bool HasEnabledSetting() const;
+
   const std::string name;
   const std::string ui_name;
   const GroupType type;
-  const DefaultValue default_value;
 
-  bool enabled = true;
+  // The default "enabled" state.
+  const DefaultValue default_value;
+  SettingValue<bool> enabled;
+  std::unique_ptr<NumericSetting<bool>> enabled_setting;
+
   std::vector<std::unique_ptr<Control>> controls;
   std::vector<std::unique_ptr<NumericSettingBase>> numeric_settings;
 };


### PR DESCRIPTION
I was creating a controller config that would automatically detect my Controller or Wiimote and act accordingly but the Point and Point Passthrough sections didn't have the advanced config button as the checkboxes are created separate from the rest.

Accidentally nuked the repository closing previous pull request #13701

Cleaned commit history, fixed ptr issue and removed the failed build files I accidentally added per jordan-woyak's request