### PR TITLE
Advanced Panel convert QSliders into ConfigSliders

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.cpp
@@ -80,6 +80,36 @@ void ConfigSlider::OnConfigChanged()
   }
 }
 
+ConfigSliderU32::ConfigSliderU32(u32 minimum, u32 maximum, const Config::Info<u32>& setting,
+                                 u32 scale)
+    : ConfigSliderU32(minimum, maximum, setting, nullptr, scale)
+{
+}
+
+ConfigSliderU32::ConfigSliderU32(u32 minimum, u32 maximum, const Config::Info<u32>& setting,
+                                 Config::Layer* layer, u32 scale)
+    : ConfigControl(Qt::Horizontal, setting.GetLocation(), layer), m_setting(setting),
+      m_scale(scale)
+
+{
+  setMinimum(minimum);
+  setMaximum(maximum);
+  setValue(ReadValue(setting));
+  OnConfigChanged();
+
+  connect(this, &ConfigSliderU32::valueChanged, this, &ConfigSliderU32::Update);
+}
+
+void ConfigSliderU32::Update(u32 value)
+{
+  SaveValue(m_setting, value * m_scale);
+}
+
+void ConfigSliderU32::OnConfigChanged()
+{
+  setValue(ReadValue(m_setting) / m_scale);
+}
+
 ConfigSliderLabel::ConfigSliderLabel(const QString& text, ConfigSlider* slider)
     : QLabel(text), m_slider(QPointer<ConfigSlider>(slider))
 {

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
@@ -11,6 +11,7 @@
 #include "DolphinQt/Config/ConfigControls/ConfigControl.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 
+#include "Common/CommonTypes.h"
 #include "Common/Config/ConfigInfo.h"
 
 class ConfigSlider final : public ConfigControl<ToolTipSlider>
@@ -36,6 +37,25 @@ private:
 
   // Mappings for slider ticks to config values. Identity mapping is assumed if this is empty.
   std::vector<int> m_tick_values;
+};
+
+class ConfigSliderU32 final : public ConfigControl<ToolTipSlider>
+{
+  Q_OBJECT
+public:
+  ConfigSliderU32(u32 minimum, u32 maximum, const Config::Info<u32>& setting, u32 scale = 1);
+  ConfigSliderU32(u32 minimum, u32 maximum, const Config::Info<u32>& setting, Config ::Layer* layer,
+                  u32 scale = 1);
+
+  void Update(u32 value);
+
+protected:
+  void OnConfigChanged() override;
+
+private:
+  const Config::Info<u32> m_setting;
+
+  u32 m_scale = 1;
 };
 
 class ConfigSliderLabel final : public QLabel

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -12,7 +12,6 @@
 #include <QLabel>
 #include <QRadioButton>
 #include <QSignalBlocker>
-#include <QSlider>
 #include <QVBoxLayout>
 #include <cmath>
 
@@ -25,6 +24,8 @@
 #include "Core/System.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
+#include "DolphinQt/Config/ConfigControls/ConfigFloatSlider.h"
+#include "DolphinQt/Config/ConfigControls/ConfigSlider.h"
 #include "DolphinQt/QtUtils/QtUtils.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
@@ -103,12 +104,24 @@ void AdvancedPane::CreateLayout()
   cpu_clock_override_slider_layout->setContentsMargins(0, 0, 0, 0);
   clock_override_layout->addLayout(cpu_clock_override_slider_layout);
 
-  m_cpu_clock_override_slider = new QSlider(Qt::Horizontal);
-  m_cpu_clock_override_slider->setRange(1, 400);
+  m_cpu_clock_override_slider = new ConfigFloatSlider(0.01f, 4.0f, Config::MAIN_OVERCLOCK, 0.01f);
   cpu_clock_override_slider_layout->addWidget(m_cpu_clock_override_slider);
 
-  m_cpu_clock_override_slider_label = new QLabel();
-  cpu_clock_override_slider_layout->addWidget(m_cpu_clock_override_slider_label);
+  m_cpu_label = new QLabel();
+  cpu_clock_override_slider_layout->addWidget(m_cpu_label);
+
+  std::function<void()> cpu_text = [this]() {
+    const float multi = Config::Get(Config::MAIN_OVERCLOCK);
+    const int percent = static_cast<int>(std::round(multi * 100.f));
+    const int core_clock =
+        Core::System::GetInstance().GetSystemTimers().GetTicksPerSecond() / std::pow(10, 6);
+    const int clock = static_cast<int>(std::round(multi * core_clock));
+    m_cpu_label->setText(tr("%1% (%2 MHz)").arg(QString::number(percent), QString::number(clock)));
+  };
+
+  cpu_text();
+  connect(m_cpu_clock_override_slider, &QSlider::valueChanged, this,
+          [this, cpu_text]() { cpu_text(); });
 
   m_cpu_clock_override_checkbox->SetDescription(
       tr("Adjusts the emulated CPU's clock rate.<br><br>"
@@ -135,12 +148,25 @@ void AdvancedPane::CreateLayout()
   vi_rate_override_slider_layout->setContentsMargins(0, 0, 0, 0);
   vi_rate_override_layout->addLayout(vi_rate_override_slider_layout);
 
-  m_vi_rate_override_slider = new QSlider(Qt::Horizontal);
-  m_vi_rate_override_slider->setRange(1, 500);
+  m_vi_rate_override_slider = new ConfigFloatSlider(0.01f, 5.0f, Config::MAIN_VI_OVERCLOCK, 0.01f);
   vi_rate_override_slider_layout->addWidget(m_vi_rate_override_slider);
 
-  m_vi_rate_override_slider_label = new QLabel();
-  vi_rate_override_slider_layout->addWidget(m_vi_rate_override_slider_label);
+  m_vi_label = new QLabel();
+  vi_rate_override_slider_layout->addWidget(m_vi_label);
+  std::function<void()> vi_text = [this]() {
+    const int percent =
+        static_cast<int>(std::round(Config::Get(Config::MAIN_VI_OVERCLOCK) * 100.f));
+    float vps =
+        static_cast<float>(Core::System::GetInstance().GetVideoInterface().GetTargetRefreshRate());
+    if (vps == 0.0f || !Config::Get(Config::MAIN_VI_OVERCLOCK_ENABLE))
+      vps = 59.94f * Config::Get(Config::MAIN_VI_OVERCLOCK);
+    m_vi_label->setText(
+        tr("%1% (%2 VPS)").arg(QString::number(percent), QString::number(vps, 'f', 2)));
+  };
+
+  vi_text();
+  connect(m_vi_rate_override_slider, &QSlider::valueChanged, this,
+          [this, vi_text]() { vi_text(); });
 
   m_vi_rate_override_checkbox->SetDescription(
       tr("Adjusts the VBI frequency. Also adjusts the emulated CPU's "
@@ -167,27 +193,34 @@ void AdvancedPane::CreateLayout()
   mem1_override_slider_layout->setContentsMargins(0, 0, 0, 0);
   ram_override_layout->addLayout(mem1_override_slider_layout);
 
-  m_mem1_override_slider = new QSlider(Qt::Horizontal);
-  m_mem1_override_slider->setRange(24, 64);
+  m_mem1_override_slider = new ConfigSliderU32(24, 64, Config::MAIN_MEM1_SIZE, 0x100000);
   mem1_override_slider_layout->addWidget(m_mem1_override_slider);
 
-  m_mem1_override_slider_label = new QLabel();
-  mem1_override_slider_layout->addWidget(m_mem1_override_slider_label);
+  m_mem1_label =
+      new QLabel(tr("%1 MB (MEM1)").arg(QString::number(m_mem1_override_slider->value())));
+  mem1_override_slider_layout->addWidget(m_mem1_label);
+  connect(m_mem1_override_slider, &QSlider::valueChanged, this, [this](int value) {
+    m_mem1_label->setText(tr("%1 MB (MEM1)").arg(QString::number(value)));
+  });
 
   auto* mem2_override_slider_layout = new QHBoxLayout();
   mem2_override_slider_layout->setContentsMargins(0, 0, 0, 0);
   ram_override_layout->addLayout(mem2_override_slider_layout);
 
-  m_mem2_override_slider = new QSlider(Qt::Horizontal);
-  m_mem2_override_slider->setRange(64, 128);
+  m_mem2_override_slider = new ConfigSliderU32(64, 128, Config::MAIN_MEM2_SIZE, 0x100000);
   mem2_override_slider_layout->addWidget(m_mem2_override_slider);
 
-  m_mem2_override_slider_label = new QLabel();
-  mem2_override_slider_layout->addWidget(m_mem2_override_slider_label);
+  m_mem2_label =
+      new QLabel(tr("%1 MB (MEM2)").arg(QString::number(m_mem2_override_slider->value())));
+  mem2_override_slider_layout->addWidget(m_mem2_label);
+  connect(m_mem2_override_slider, &QSlider::valueChanged, this, [this](int value) {
+    m_mem2_label->setText(tr("%1 MB (MEM2)").arg(QString::number(value)));
+  });
 
   m_ram_override_checkbox->SetDescription(
       tr("Adjusts the amount of RAM in the emulated console.<br><br>"
-         "<b>WARNING</b>: Enabling this will completely break many games.<br>Only a small number "
+         "<b>WARNING</b>: Enabling this will completely break many games.<br>Only a small "
+         "number "
          "of games can benefit from this."
          "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
 
@@ -227,33 +260,9 @@ void AdvancedPane::ConnectLayout()
       Config::SetBaseOrCurrent(Config::MAIN_CPU_CORE, cpu_cores[index]);
   });
 
-  connect(m_cpu_clock_override_slider, &QSlider::valueChanged, [this](int oc_factor) {
-    const float factor = m_cpu_clock_override_slider->value() / 100.f;
-    Config::SetBaseOrCurrent(Config::MAIN_OVERCLOCK, factor);
-    Update();
-  });
-
-  connect(m_vi_rate_override_slider, &QSlider::valueChanged, [this](int oc_factor) {
-    const float factor = m_vi_rate_override_slider->value() / 100.f;
-    Config::SetBaseOrCurrent(Config::MAIN_VI_OVERCLOCK, factor);
-    Update();
-  });
-
   m_ram_override_checkbox->setChecked(Config::Get(Config::MAIN_RAM_OVERRIDE_ENABLE));
   connect(m_ram_override_checkbox, &QCheckBox::toggled, [this](bool enable_ram_override) {
     Config::SetBaseOrCurrent(Config::MAIN_RAM_OVERRIDE_ENABLE, enable_ram_override);
-    Update();
-  });
-
-  connect(m_mem1_override_slider, &QSlider::valueChanged, [this](int slider_value) {
-    const u32 mem1_size = m_mem1_override_slider->value() * 0x100000;
-    Config::SetBaseOrCurrent(Config::MAIN_MEM1_SIZE, mem1_size);
-    Update();
-  });
-
-  connect(m_mem2_override_slider, &QSlider::valueChanged, [this](int slider_value) {
-    const u32 mem2_size = m_mem2_override_slider->value() * 0x100000;
-    Config::SetBaseOrCurrent(Config::MAIN_MEM2_SIZE, mem2_size);
     Update();
   });
 
@@ -295,21 +304,7 @@ void AdvancedPane::Update()
   }
 
   m_cpu_clock_override_slider->setEnabled(enable_cpu_clock_override_widgets);
-  m_cpu_clock_override_slider_label->setEnabled(enable_cpu_clock_override_widgets);
-
-  {
-    const QSignalBlocker blocker(m_cpu_clock_override_slider);
-    m_cpu_clock_override_slider->setValue(
-        static_cast<int>(std::round(Config::Get(Config::MAIN_OVERCLOCK) * 100.f)));
-  }
-
-  m_cpu_clock_override_slider_label->setText([] {
-    int core_clock =
-        Core::System::GetInstance().GetSystemTimers().GetTicksPerSecond() / std::pow(10, 6);
-    int percent = static_cast<int>(std::round(Config::Get(Config::MAIN_OVERCLOCK) * 100.f));
-    int clock = static_cast<int>(std::round(Config::Get(Config::MAIN_OVERCLOCK) * core_clock));
-    return tr("%1% (%2 MHz)").arg(QString::number(percent), QString::number(clock));
-  }());
+  m_cpu_label->setEnabled(enable_cpu_clock_override_widgets);
 
   QFont vi_bf = font();
   vi_bf.setBold(Config::GetActiveLayerForConfig(Config::MAIN_VI_OVERCLOCK_ENABLE) !=
@@ -318,53 +313,16 @@ void AdvancedPane::Update()
   m_vi_rate_override_checkbox->setChecked(enable_vi_rate_override_widgets);
 
   m_vi_rate_override_slider->setEnabled(enable_vi_rate_override_widgets);
-  m_vi_rate_override_slider_label->setEnabled(enable_vi_rate_override_widgets);
-
-  {
-    const QSignalBlocker blocker(m_vi_rate_override_slider);
-    m_vi_rate_override_slider->setValue(
-        static_cast<int>(std::round(Config::Get(Config::MAIN_VI_OVERCLOCK) * 100.f)));
-  }
-
-  m_vi_rate_override_slider_label->setText([] {
-    int percent = static_cast<int>(std::round(Config::Get(Config::MAIN_VI_OVERCLOCK) * 100.f));
-    float vps =
-        static_cast<float>(Core::System::GetInstance().GetVideoInterface().GetTargetRefreshRate());
-    if (vps == 0.0f || !Config::Get(Config::MAIN_VI_OVERCLOCK_ENABLE))
-      vps = 59.94f * Config::Get(Config::MAIN_VI_OVERCLOCK);
-    return tr("%1% (%2 VPS)").arg(QString::number(percent), QString::number(vps, 'f', 2));
-  }());
+  m_vi_label->setEnabled(enable_vi_rate_override_widgets);
 
   m_ram_override_checkbox->setEnabled(is_uninitialized);
   SignalBlocking(m_ram_override_checkbox)->setChecked(enable_ram_override_widgets);
 
   m_mem1_override_slider->setEnabled(enable_ram_override_widgets && is_uninitialized);
-  m_mem1_override_slider_label->setEnabled(enable_ram_override_widgets && is_uninitialized);
-
-  {
-    const QSignalBlocker blocker(m_mem1_override_slider);
-    const u32 mem1_size = Config::Get(Config::MAIN_MEM1_SIZE) / 0x100000;
-    m_mem1_override_slider->setValue(mem1_size);
-  }
-
-  m_mem1_override_slider_label->setText([] {
-    const u32 mem1_size = Config::Get(Config::MAIN_MEM1_SIZE) / 0x100000;
-    return tr("%1 MB (MEM1)").arg(QString::number(mem1_size));
-  }());
+  m_mem1_label->setEnabled(enable_ram_override_widgets && is_uninitialized);
 
   m_mem2_override_slider->setEnabled(enable_ram_override_widgets && is_uninitialized);
-  m_mem2_override_slider_label->setEnabled(enable_ram_override_widgets && is_uninitialized);
-
-  {
-    const QSignalBlocker blocker(m_mem2_override_slider);
-    const u32 mem2_size = Config::Get(Config::MAIN_MEM2_SIZE) / 0x100000;
-    m_mem2_override_slider->setValue(mem2_size);
-  }
-
-  m_mem2_override_slider_label->setText([] {
-    const u32 mem2_size = Config::Get(Config::MAIN_MEM2_SIZE) / 0x100000;
-    return tr("%1 MB (MEM2)").arg(QString::number(mem2_size));
-  }());
+  m_mem2_label->setEnabled(enable_ram_override_widgets && is_uninitialized);
 
   m_custom_rtc_checkbox->setEnabled(is_uninitialized);
   SignalBlocking(m_custom_rtc_checkbox)->setChecked(Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE));

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -8,6 +8,9 @@
 #include <QWidget>
 
 class ConfigBool;
+class ConfigFloatSlider;
+class ConfigSlider;
+class ConfigSliderU32;
 class QCheckBox;
 class QComboBox;
 class QLabel;
@@ -36,19 +39,19 @@ private:
   ConfigBool* m_pause_on_panic_checkbox;
   ConfigBool* m_accurate_cpu_cache_checkbox;
   ConfigBool* m_cpu_clock_override_checkbox;
-  QSlider* m_cpu_clock_override_slider;
-  QLabel* m_cpu_clock_override_slider_label;
+  ConfigFloatSlider* m_cpu_clock_override_slider;
+  QLabel* m_cpu_label;
 
   ConfigBool* m_vi_rate_override_checkbox;
-  QSlider* m_vi_rate_override_slider;
-  QLabel* m_vi_rate_override_slider_label;
+  ConfigFloatSlider* m_vi_rate_override_slider;
+  QLabel* m_vi_label;
 
   ConfigBool* m_custom_rtc_checkbox;
   QDateTimeEdit* m_custom_rtc_datetime;
 
   ConfigBool* m_ram_override_checkbox;
-  QSlider* m_mem1_override_slider;
-  QLabel* m_mem1_override_slider_label;
-  QSlider* m_mem2_override_slider;
-  QLabel* m_mem2_override_slider_label;
+  ConfigSliderU32* m_mem1_override_slider;
+  QLabel* m_mem1_label;
+  ConfigSliderU32* m_mem2_override_slider;
+  QLabel* m_mem2_label;
 };


### PR DESCRIPTION
Part of refactoring things into the config system.  Sliders are especially important because they feel laggy as you drag them due to spamming updates.  Once they are under the Config system we could reduce the update interval, which should make things more responsive.

I had to add a new ConfigSliderU32 class to deal with the unsigned and their extra scale factor.

No visual changes.