### PR TITLE
[DO NOT MERGE] CoreTiming: Throttle only once after presentation for potentially better input latency.

### DIFF
--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/HookableEvent.h"
 #include "Common/SPSCQueue.h"
 #include "Common/Timer.h"
 #include "Core/CPUThreadConfigCallback.h"
@@ -225,6 +226,9 @@ private:
   std::atomic_bool m_use_precision_timer = false;
   Common::PrecisionTimer m_precision_cpu_timer;
   Common::PrecisionTimer m_precision_gpu_timer;
+
+  Common::EventHook m_frame_hook;
+  std::atomic<bool> m_throttled_since_presentation = false;
 };
 
 }  // namespace CoreTiming

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -97,7 +97,9 @@ void VideoBackendBase::Video_OutputXFB(u32 xfb_addr, u32 fb_width, u32 fb_stride
     auto& system = Core::System::GetInstance();
     system.GetFifo().SyncGPU(Fifo::SyncGPUReason::Swap);
 
-    const TimePoint presentation_time = system.GetCoreTiming().GetTargetHostTime(ticks);
+    // HAX: Present immediately.
+    const TimePoint presentation_time = Clock::now();
+
     AsyncRequests::GetInstance()->PushEvent([=] {
       g_presenter->ViSwap(xfb_addr, fb_width, fb_stride, fb_height, ticks, presentation_time);
     });


### PR DESCRIPTION
This is a version of #13449 which is always enabled.

I'm curious if it could improve input latency even without immediate XFB.

Hopefully someone has the means to test this.