### PR TITLE
DolphinQt: Remove redundant window hints

### DIFF
--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -15,7 +15,6 @@
 AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("About Dolphin"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QString branch_str = QString::fromStdString(Common::GetScmBranchStr());
   const int commits_ahead = Common::GetScmCommitsAheadMaster();

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -27,7 +27,6 @@
 AchievementsWindow::AchievementsWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Achievements"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateMainLayout();
   ConnectWidgets();

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -26,7 +26,6 @@ CheatsManager::CheatsManager(Core::System& system, QWidget* parent)
     : QDialog(parent), m_system(system)
 {
   setWindowTitle(tr("Cheats Manager"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &CheatsManager::OnStateChanged);

--- a/Source/Core/DolphinQt/Config/CheatCodeEditor.cpp
+++ b/Source/Core/DolphinQt/Config/CheatCodeEditor.cpp
@@ -23,7 +23,6 @@
 
 CheatCodeEditor::CheatCodeEditor(QWidget* parent) : QDialog(parent)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Cheat Code Editor"));
 
   CreateWidgets();

--- a/Source/Core/DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.cpp
@@ -17,7 +17,6 @@ ControllerInterfaceWindow::ControllerInterfaceWindow(QWidget* parent) : QDialog(
   CreateMainLayout();
 
   setWindowTitle(tr("Alternate Input Sources"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 void ControllerInterfaceWindow::CreateMainLayout()

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
@@ -29,7 +29,6 @@ DualShockUDPClientAddServerDialog::DualShockUDPClientAddServerDialog(QWidget* pa
 void DualShockUDPClientAddServerDialog::CreateWidgets()
 {
   setWindowTitle(tr("Add New DSU Server"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   m_main_layout = new QGridLayout;
 

--- a/Source/Core/DolphinQt/Config/FreeLookWindow.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWindow.cpp
@@ -17,7 +17,6 @@ FreeLookWindow::FreeLookWindow(QWidget* parent) : QDialog(parent)
   ConnectWidgets();
 
   setWindowTitle(tr("Free Look Settings"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 void FreeLookWindow::CreateMainLayout()

--- a/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/ColorCorrectionConfigWindow.cpp
@@ -22,7 +22,6 @@
 ColorCorrectionConfigWindow::ColorCorrectionConfigWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Color Correction Configuration"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   Create();
   ConnectWidgets();

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
@@ -28,7 +28,6 @@ GraphicsWindow::GraphicsWindow(MainWindow* parent) : QDialog(parent), m_main_win
   CreateMainLayout();
 
   setWindowTitle(tr("Graphics"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   OnBackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
 

--- a/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
@@ -42,7 +42,6 @@ PostProcessingConfigWindow::PostProcessingConfigWindow(EnhancementsWidget* paren
   }
 
   setWindowTitle(tr("Post-Processing Shader Configuration"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   PopulateGroups();
   Create();

--- a/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.cpp
@@ -17,8 +17,6 @@
 GCPadWiiUConfigDialog::GCPadWiiUConfigDialog(int port, QWidget* parent)
     : QDialog(parent), m_port{port}
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-
   CreateLayout();
 
   LoadSettings();

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -268,7 +268,6 @@ IOWindow::IOWindow(MappingWindow* window, ControllerEmu::EmulatedController* con
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, &IOWindow::ConfigChanged);
 
   setWindowTitle(type == IOWindow::Type::Input ? tr("Configure Input") : tr("Configure Output"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   ConfigChanged();
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -65,7 +65,6 @@ MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
     : QDialog(parent), m_port(port_num)
 {
   setWindowTitle(tr("Port %1").arg(port_num + 1));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateDevicesLayout();
   CreateProfilesLayout();

--- a/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
+++ b/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
@@ -38,7 +38,6 @@ NewPatchDialog::NewPatchDialog(QWidget* parent, PatchEngine::Patch& patch)
     : QDialog(parent), m_patch(patch)
 {
   setWindowTitle(tr("Patch Editor"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateWidgets();
   ConnectWidgets();

--- a/Source/Core/DolphinQt/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.cpp
@@ -24,8 +24,6 @@
 
 StackedSettingsWindow::StackedSettingsWindow(QWidget* parent) : QDialog{parent}
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-
   // This eliminates the ugly line between the title bar and window contents with KDE Plasma.
   setStyleSheet(QStringLiteral("QDialog { border: none; }"));
 

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -42,7 +42,6 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
   ASSERT(!m_files.empty());
 
   setWindowTitle(tr("Convert"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QGridLayout* grid_layout = new QGridLayout;
   grid_layout->setColumnStretch(1, 1);

--- a/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/AssembleInstructionDialog.cpp
@@ -41,7 +41,6 @@ QString HtmlFormatErrorLine(const Common::GekkoAssembler::AssemblerError& err)
 AssembleInstructionDialog::AssembleInstructionDialog(QWidget* parent, u32 address, u32 value)
     : QDialog(parent), m_code(value), m_address(address)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowModality(Qt::WindowModal);
   setWindowTitle(tr("Instruction"));
 

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -200,7 +200,7 @@ BranchWatchDialog::BranchWatchDialog(Core::System& system, Core::BranchWatch& br
     : QDialog(parent), m_system(system), m_branch_watch(branch_watch), m_code_widget(code_widget)
 {
   setWindowTitle(tr("Branch Watch Tool"));
-  setWindowFlags((windowFlags() | Qt::WindowMinMaxButtonsHint) & ~Qt::WindowContextHelpButtonHint);
+  setWindowFlags(windowFlags() | Qt::WindowMinMaxButtonsHint);
 
   // Branch Watch Table
   m_table_view = new QTableView(nullptr);

--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
@@ -24,7 +24,6 @@
 BreakpointDialog::BreakpointDialog(BreakpointWidget* parent)
     : QDialog(parent), m_parent(parent), m_open_mode(OpenMode::New)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("New Breakpoint"));
   CreateWidgets();
   ConnectWidgets();
@@ -36,7 +35,6 @@ BreakpointDialog::BreakpointDialog(BreakpointWidget* parent)
 BreakpointDialog::BreakpointDialog(BreakpointWidget* parent, const TBreakPoint* breakpoint)
     : QDialog(parent), m_parent(parent), m_open_mode(OpenMode::EditBreakPoint)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Edit Breakpoint"));
   CreateWidgets();
   ConnectWidgets();
@@ -56,7 +54,6 @@ BreakpointDialog::BreakpointDialog(BreakpointWidget* parent, const TBreakPoint* 
 BreakpointDialog::BreakpointDialog(BreakpointWidget* parent, const TMemCheck* memcheck)
     : QDialog(parent), m_parent(parent), m_open_mode(OpenMode::EditMemCheck)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Edit Breakpoint"));
 
   CreateWidgets();

--- a/Source/Core/DolphinQt/Debugger/PatchInstructionDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/PatchInstructionDialog.cpp
@@ -14,7 +14,6 @@
 PatchInstructionDialog::PatchInstructionDialog(QWidget* parent, u32 address, u32 value)
     : QDialog(parent), m_address(address)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowModality(Qt::WindowModal);
   setWindowTitle(tr("Instruction"));
 

--- a/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
+++ b/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
@@ -21,7 +21,6 @@ DiscordJoinRequestDialog::DiscordJoinRequestDialog(QWidget* parent, const std::s
     : QDialog(parent), m_user_id(id), m_close_timestamp(std::time(nullptr) + s_max_lifetime_seconds)
 {
   setWindowTitle(tr("Request to Join Your Party"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QPixmap avatar_pixmap;
 

--- a/Source/Core/DolphinQt/GCMemcardCreateNewDialog.cpp
+++ b/Source/Core/DolphinQt/GCMemcardCreateNewDialog.cpp
@@ -60,7 +60,6 @@ GCMemcardCreateNewDialog::GCMemcardCreateNewDialog(QWidget* parent) : QDialog(pa
   });
 
   setWindowTitle(tr("Create New Memory Card"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 GCMemcardCreateNewDialog::~GCMemcardCreateNewDialog() = default;

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -98,7 +98,6 @@ GCMemcardManager::GCMemcardManager(QWidget* parent) : QDialog(parent)
   resize(650, 500);
 
   setWindowTitle(tr("GameCube Memory Card Manager"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 GCMemcardManager::~GCMemcardManager() = default;

--- a/Source/Core/DolphinQt/NANDRepairDialog.cpp
+++ b/Source/Core/DolphinQt/NANDRepairDialog.cpp
@@ -27,7 +27,6 @@ NANDRepairDialog::NANDRepairDialog(const WiiUtils::NANDCheckResult& result, QWid
     : QDialog(parent)
 {
   setWindowTitle(tr("NAND Check"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowIcon(Resources::GetAppIcon());
 
   QVBoxLayout* main_layout = new QVBoxLayout();

--- a/Source/Core/DolphinQt/NKitWarningDialog.cpp
+++ b/Source/Core/DolphinQt/NKitWarningDialog.cpp
@@ -30,7 +30,6 @@ bool NKitWarningDialog::ShowUnlessDisabled(QWidget* parent)
 NKitWarningDialog::NKitWarningDialog(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("NKit Warning"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowIcon(Resources::GetAppIcon());
 
   QVBoxLayout* main_layout = new QVBoxLayout;

--- a/Source/Core/DolphinQt/NetPlay/ChunkedProgressDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/ChunkedProgressDialog.cpp
@@ -45,7 +45,6 @@ ChunkedProgressDialog::ChunkedProgressDialog(QWidget* parent) : QDialog(parent)
   CreateWidgets();
   ConnectWidgets();
   setWindowTitle(tr("Data Transfer"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 void ChunkedProgressDialog::CreateWidgets()

--- a/Source/Core/DolphinQt/NetPlay/GameListDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/GameListDialog.cpp
@@ -14,7 +14,6 @@
 GameListDialog::GameListDialog(const GameListModel& game_list_model, QWidget* parent)
     : QDialog(parent), m_game_list_model(game_list_model)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Select a game"));
 
   CreateWidgets();

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -32,7 +32,6 @@
 NetPlayBrowser::NetPlayBrowser(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("NetPlay Session Browser"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateWidgets();
   RestoreSettings();
@@ -297,7 +296,6 @@ void NetPlayBrowser::accept()
   {
     QInputDialog dialog(this);
 
-    dialog.setWindowFlags(dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
     dialog.setWindowTitle(tr("Enter password"));
     dialog.setLabelText(tr("This session requires a password:"));
     dialog.setWindowModality(Qt::WindowModal);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -97,8 +97,6 @@ NetPlayDialog::NetPlayDialog(const GameListModel& game_list_model,
     : QDialog(parent), m_game_list_model(game_list_model),
       m_start_game_callback(std::move(start_game_callback))
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-
   setWindowTitle(tr("NetPlay"));
   setWindowIcon(Resources::GetAppIcon());
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -32,7 +32,6 @@ NetPlaySetupDialog::NetPlaySetupDialog(const GameListModel& game_list_model, QWi
     : QDialog(parent), m_game_list_model(game_list_model)
 {
   setWindowTitle(tr("NetPlay Setup"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateMainLayout();
 

--- a/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
@@ -17,7 +17,6 @@
 
 PadMappingDialog::PadMappingDialog(QWidget* parent) : QDialog(parent)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Assign Controllers"));
 
   CreateWidgets();

--- a/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
+++ b/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
@@ -26,7 +26,6 @@ public:
   ParallelProgressDialog(Args&&... args) : m_dialog{std::forward<Args>(args)...}
   {
     setParent(m_dialog.parent());
-    m_dialog.setWindowFlags(m_dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
     ConnectSignalsAndSlots();
   }
 

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -24,7 +24,6 @@ ResourcePackManager::ResourcePackManager(QWidget* widget) : QDialog(widget)
   RepopulateTable();
 
   setWindowTitle(tr("Resource Pack Manager"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   resize(QSize(900, 600));
 }

--- a/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
+++ b/Source/Core/DolphinQt/RiivolutionBootWidget.cpp
@@ -46,7 +46,6 @@ RiivolutionBootWidget::RiivolutionBootWidget(std::string game_id, std::optional<
       m_base_game_path(std::move(base_game_path))
 {
   setWindowTitle(tr("Start with Riivolution Patches"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateWidgets();
   ConnectWidgets();

--- a/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/BroadbandAdapterSettingsDialog.cpp
@@ -95,7 +95,6 @@ void BroadbandAdapterSettingsDialog::InitControls()
   }
 
   setWindowTitle(window_title);
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   m_address_input = new QLineEdit(current_address);
   m_address_input->setPlaceholderText(address_placeholder);

--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -42,7 +42,6 @@ USBDeviceAddToWhitelistDialog::USBDeviceAddToWhitelistDialog(QWidget* parent) : 
 void USBDeviceAddToWhitelistDialog::InitControls()
 {
   setWindowTitle(tr("Add New USB Device"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   m_whitelist_buttonbox = new QDialogButtonBox();
   auto* add_button = new QPushButton(tr("Add"));

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -45,7 +45,6 @@ ControllerEmu::InputOverrideFunction InputOverrider::GetInputOverrideFunction() 
 
 TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowIcon(Resources::GetAppIcon());
 
   QGridLayout* settings_layout = new QGridLayout;

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -59,7 +59,6 @@ void Updater::OnUpdateAvailable(const NewVersionInformation& info)
     QDialog* dialog = new QDialog(m_parent);
     dialog->setAttribute(Qt::WA_DeleteOnClose, true);
     dialog->setWindowTitle(tr("Update available"));
-    dialog->setWindowFlags(dialog->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
     auto* label = new QLabel(
         tr("<h2>A new version of Dolphin is available!</h2>Dolphin %1 is available for "

--- a/Source/Core/DolphinQt/WiiUpdate.cpp
+++ b/Source/Core/DolphinQt/WiiUpdate.cpp
@@ -96,7 +96,6 @@ static WiiUtils::UpdateResult ShowProgress(QWidget* parent, Callable function, A
   UpdateProgressDialog dialog{parent};
   dialog.setLabelText(QObject::tr("Preparing to update...\nThis can take a while."));
   dialog.setWindowTitle(QObject::tr("Updating"));
-  dialog.setWindowFlags(dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
   // QProgressDialog doesn't set its minimum size correctly.
   dialog.setMinimumSize(360, 150);
 


### PR DESCRIPTION
Remove window hints clearing the flag `Qt::WindowContextHelpButtonHint`, which is already off by default in Qt 6.

In Qt 5 (which we no longer support) this flag was set by default for `QDialog`, and on Windows put a `?` button in the corner of the title bar allowing users to activate Qt's `QWhatsThis` help system for a given widget. Since we don't set that text the `?` button was useless and so we hid it manually.