### PR TITLE
GameINI: Disable Dual Core for more games

### DIFF
--- a/Data/Sys/GameSettings/G97.ini
+++ b/Data/Sys/GameSettings/G97.ini
@@ -1,8 +1,7 @@
-# RNKE69, RNKP69 - NERF N-Strike
+# G97E01, G97P01, G97U01 - Interactive Multi Game Demo Disc v3
 
 [Core]
 # Values set here will override the main Dolphin settings.
-# Dual Core mode causes FIFO error
 CPUThread = False
 
 [OnFrame]

--- a/Data/Sys/GameSettings/RL6.ini
+++ b/Data/Sys/GameSettings/RL6.ini
@@ -1,4 +1,4 @@
-# RNKE69, RNKP69 - NERF N-Strike
+# RL6E69 - NERF N-Strike Elite
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SN2.ini
+++ b/Data/Sys/GameSettings/SN2.ini
@@ -1,4 +1,4 @@
-# RNKE69, RNKP69 - NERF N-Strike
+# SN2E69, SN2P69 - NERF N-Strike Double Blast Bundle
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SR4.ini
+++ b/Data/Sys/GameSettings/SR4.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnFrame]
 # Add memory patches to be applied every frame here.


### PR DESCRIPTION
This PR resolves Dual Core crashes for a few more games I found on the wiki and the bugs tracker:

* Interactive Multi Game Demo Disc v3 - This game comes with Sonic Adventure 2, which is known for crashing with Dual Core enabled.
* NERF N-Strike Elite - This game hangs/freezes with Dual Core enabled. I'm also putting the Double Blast Bundle compilation disc since it has the same issues.
* Raving Rabbids: Travel in Time - This game crashes with Dual Core enabled on startup for me. Also, even with Dual Core disabled, the game still crashes if you try to skip the opening FMV for some weird reason. Probably linked to [this post somehow](https://bugs.dolphin-emu.org/issues/13233#note-4).