### PR TITLE
BTReal: Throttle before sending ACL data for better bluetooth packet timing.

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -286,6 +286,13 @@ std::optional<IPCReply> BluetoothRealDevice::IOCtlV(const IOCtlVRequest& request
         return std::nullopt;
       }
     }
+    else if (request.request == USB::IOCTLV_USBV0_BLKMSG && cmd->endpoint == ACL_DATA_OUT)
+    {
+      // Throttle for Bluetooth packet timing, especially for Wii remote speaker data.
+      auto& core_timing = Core::System::GetInstance().GetCoreTiming();
+      core_timing.Throttle(core_timing.GetTicks());
+    }
+
     auto buffer = cmd->MakeBuffer(cmd->length);
     libusb_transfer* transfer = libusb_alloc_transfer(0);
     transfer->buffer = buffer.get();


### PR DESCRIPTION
Since dolphin now "speeds through" emulation until user input or presentation, I suppose we should `Throttle` here for proper "Bluetooth Passthrough" Wii remote speaker data timing.

I can't tell if this is actually reducing the desynchronization of the speaker decoder or improving playback in practice, but it seems like the right thing to do.

This `Throttle` (and the libusb transfer) would probably ideally happen on a separate thread, but I think that can be saved for another PR.

"Emulated Bluetooth" should probably get a similar fix (in another PR), but doing that cleanly looks like it will need some refactoring, and it doesn't seem to help the terrible sound playback there anyways..