### PR TITLE
GameSettings: auto-disable immediate XFB for Dokapon Kingdom

### DIFF
--- a/Data/Sys/GameSettings/R2D.ini
+++ b/Data/Sys/GameSettings/R2D.ini
@@ -1,0 +1,5 @@
+# R2DJEP, R2DEEB, R2DPJW - Dokapon Kingdom
+
+[Video_Hacks]
+# Prevents flickering throughout the game.
+ImmediateXFBEnable = False


### PR DESCRIPTION
This avoids flickering throughout the game.

Reported in [issue 13802](https://bugs.dolphin-emu.org/issues/13802).