### PR TITLE
GameList: Prevent opening Properties multiple times for the same game

### DIFF
--- a/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
@@ -25,7 +25,7 @@
 #include "UICommon/GameFile.h"
 
 PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& game)
-    : StackedSettingsWindow{parent}
+    : StackedSettingsWindow{parent}, m_filepath(game.GetFilePath())
 {
   setWindowTitle(QStringLiteral("%1: %2 - %3")
                      .arg(QString::fromStdString(game.GetFileName()),

--- a/Source/Core/DolphinQt/Config/PropertiesDialog.h
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.h
@@ -17,6 +17,7 @@ class PropertiesDialog final : public StackedSettingsWindow
   Q_OBJECT
 public:
   explicit PropertiesDialog(QWidget* parent, const UICommon::GameFile& game);
+  const std::string& GetFilePath() const { return m_filepath; }
 
 signals:
   void OpenGeneralSettings();
@@ -24,4 +25,7 @@ signals:
 #ifdef USE_RETRO_ACHIEVEMENTS
   void OpenAchievementSettings();
 #endif  // USE_RETRO_ACHIEVEMENTS
+
+private:
+  const std::string m_filepath;
 };

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -566,6 +566,15 @@ void GameList::OpenProperties()
   if (!game)
     return;
 
+  auto property_windows = this->findChildren<PropertiesDialog*>();
+  auto it =
+      std::ranges::find(property_windows, game->GetFilePath(), &PropertiesDialog::GetFilePath);
+  if (it != property_windows.end())
+  {
+    (*it)->raise();
+    return;
+  }
+
   PropertiesDialog* properties = new PropertiesDialog(this, *game);
 
   connect(properties, &PropertiesDialog::OpenGeneralSettings, this, &GameList::OpenGeneralSettings);


### PR DESCRIPTION
Previously, if you right-click a game, select Properties, and then do it again on the same game, you'd get multiple property windows for the same game, which is... a mess.

With this change, attempting to do so will instead raise the already-existing window.

(Is it fine to just raise, or would it be preferable to do other things as well?
I'm asking because with the current PR, if the property window is minimized, then nothing visibly happens when clicking properties, which may be poor UX.)

Note that in order to check whether the properties window is already opened for the game, only the ~~GameID~~ filepath is compared.