### PR TITLE
fmt: Replace deprecated `fmt::localtime` usage with `Common::LocalTime`

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -16,6 +16,7 @@
 #include "AudioCommon/WASAPIStream.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
+#include "Common/TimeUtil.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/System.h"
@@ -218,8 +219,11 @@ void StartAudioDump(Core::System& system)
 
   std::string path_prefix = File::GetUserPath(D_DUMPAUDIO_IDX) + SConfig::GetInstance().GetGameID();
 
-  std::string base_name =
-      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}", path_prefix, fmt::localtime(start_time));
+  const auto local_time = Common::LocalTime(start_time);
+  if (!local_time)
+    return;
+
+  std::string base_name = fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}", path_prefix, *local_time);
 
   const std::string audio_file_name_dtk = fmt::format("{}_dtkdump.wav", base_name);
   const std::string audio_file_name_dsp = fmt::format("{}_dspdump.wav", base_name);

--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -25,6 +25,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
+#include "Common/TimeUtil.h"
 
 #include "Core/Config/MainSettings.h"
 
@@ -95,12 +96,7 @@ int SDCardDiskIOCtl(File::IOFile* image, u8 pdrv, u8 cmd, void* buff)
 u32 GetSystemTimeFAT()
 {
   const std::time_t time = std::time(nullptr);
-  std::tm tm;
-#ifdef _WIN32
-  localtime_s(&tm, &time);
-#else
-  localtime_r(&time, &tm);
-#endif
+  std::tm tm = *Common::LocalTime(time);
 
   DWORD fattime = 0;
   fattime |= (tm.tm_year - 80) << 25;

--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -122,7 +122,6 @@ std::string SettingsWriter::GenerateSerialNumber()
 
   // Must be 9 characters at most; otherwise the serial number will be rejected by SDK libraries,
   // as there is a check to ensure the string length is strictly lower than 10.
-  // 3 for %j, 2 for %H, 2 for %M, 2 for %S.
-  return fmt::format("{:%j%H%M%S}", fmt::localtime(t));
+  return fmt::format("{:09}", t % 1000000000);
 }
 }  // namespace Common

--- a/Source/Core/Common/TimeUtil.cpp
+++ b/Source/Core/Common/TimeUtil.cpp
@@ -2,23 +2,25 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Common/TimeUtil.h"
+#include "Common/Logging/Log.h"
 
 #include <ctime>
 #include <optional>
 
 namespace Common
 {
-std::optional<std::tm> Localtime(std::time_t time)
+std::optional<std::tm> LocalTime(std::time_t time)
 {
   std::tm local_time;
 #ifdef _MSC_VER
   if (localtime_s(&local_time, &time) != 0)
-    return std::nullopt;
 #else
-  std::tm* result = localtime_r(&time, &local_time);
-  if (result != &local_time)
-    return std::nullopt;
+  if (localtime_r(&time, &local_time) == NULL)
 #endif
+  {
+    ERROR_LOG_FMT(COMMON, "Failed to convert time to local time: {}", std::strerror(errno));
+    return std::nullopt;
+  }
   return local_time;
 }
 }  // Namespace Common

--- a/Source/Core/Common/TimeUtil.h
+++ b/Source/Core/Common/TimeUtil.h
@@ -9,5 +9,5 @@
 namespace Common
 {
 // Threadsafe and error-checking variant of std::localtime()
-std::optional<std::tm> Localtime(std::time_t time);
+std::optional<std::tm> LocalTime(std::time_t time);
 }  // Namespace Common

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -16,6 +16,7 @@
 #include "Common/Network.h"
 #include "Common/PcapFile.h"
 #include "Common/ScopeGuard.h"
+#include "Common/TimeUtil.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 
@@ -82,7 +83,7 @@ PCAPSSLCaptureLogger::PCAPSSLCaptureLogger()
 {
   const std::string filepath =
       fmt::format("{}{} {:%Y-%m-%d %Hh%Mm%Ss}.pcap", File::GetUserPath(D_DUMPSSL_IDX),
-                  SConfig::GetInstance().GetGameID(), fmt::localtime(std::time(nullptr)));
+                  SConfig::GetInstance().GetGameID(), *Common::LocalTime(std::time(nullptr)));
   m_file = std::make_unique<Common::PCAP>(
       new File::IOFile(filepath, "wb", File::SharedAccess::Read), Common::PCAP::LinkType::Ethernet);
 }

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -281,7 +281,7 @@ static std::string SystemTimeAsDoubleToString(double time)
 {
   // revert adjustments from GetSystemTimeAsDouble() to get a normal Unix timestamp again
   const time_t seconds = static_cast<time_t>(time) + DOUBLE_TIME_OFFSET;
-  const auto local_time = Common::Localtime(seconds);
+  const auto local_time = Common::LocalTime(seconds);
   if (!local_time)
     return "";
 

--- a/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
+++ b/Source/Core/VideoCommon/FrameDumpFFMpeg.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "VideoCommon/FrameDumpFFMpeg.h"
+#include "Common/TimeUtil.h"
 
 #if defined(__FreeBSD__)
 #define __STDC_CONSTANT_MACROS 1
@@ -124,11 +125,15 @@ std::string GetDumpPath(const std::string& extension, std::time_t time, u32 inde
   if (!dump_path.empty())
     return dump_path;
 
+  const auto local_time = Common::LocalTime(time);
+  if (!local_time)
+    return "";
+
   const std::string path_prefix =
       File::GetUserPath(D_DUMPFRAMES_IDX) + SConfig::GetInstance().GetGameID();
 
   const std::string base_name =
-      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}_{}", path_prefix, fmt::localtime(time), index);
+      fmt::format("{}_{:%Y-%m-%d_%H-%M-%S}_{}", path_prefix, *local_time, index);
 
   const std::string path = fmt::format("{}.{}", base_name, extension);
 


### PR DESCRIPTION
[fmt 11.2.0](https://github.com/fmtlib/fmt/releases/tag/11.2.0) deprecates `fmt::localtime` in favor of `std::localtime`.

This PR follows this recommendation.