### PR TITLE
Android: Add android.hardware.microphone to manifest

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,9 @@
         android:name="android.hardware.gamepad"
         android:required="false"/>
     <uses-feature
+        android:name="android.hardware.microphone"
+        android:required="false"/>
+    <uses-feature
         android:name="android.software.leanback"
         android:required="false"/>
 
@@ -25,12 +28,8 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA"/>
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA"/>
-    <uses-permission
-        android:name="android.permission.VIBRATE"
-        android:required="false"/>
-    <uses-permission
-        android:name="android.permission.RECORD_AUDIO"
-        android:required="false"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 
     <application
         android:name=".DolphinApplication"


### PR DESCRIPTION
Google Play is now blocking distribution for Android TV unless we explicitly set the android.hardware.microphone hardware feature as `android:required="false"`, because it's inferring `android.hardware.microphone` from the `android.permission.RECORD_AUDIO` we added for Wii Speak emulation, with `android:required` defaulting to true. I was under the belief that setting `android:required="false"` on `android.permission.RECORD_AUDIO` would solve this, but looking closer at the definition of `<uses-permission>`, it doesn't actually support `android:required` attributes, so that presumably has no effect.