### PR TITLE
GamePatch: Disney Trio of Destruction Pagetable Speedhack.

### DIFF
--- a/Data/Sys/GameSettings/SCYE4Q.ini
+++ b/Data/Sys/GameSettings/SCYE4Q.ini
@@ -1,0 +1,9 @@
+# SCYE4Q - Cars 2
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8019CB1C:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/SCYP4Q.ini
+++ b/Data/Sys/GameSettings/SCYP4Q.ini
@@ -1,0 +1,9 @@
+# SCYP4Q - Cars 2
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8019CB1C:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/SCYR4Q.ini
+++ b/Data/Sys/GameSettings/SCYR4Q.ini
@@ -1,0 +1,9 @@
+# SCYR4Q - Cars 2
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8019B4EC:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/SCYX4Q.ini
+++ b/Data/Sys/GameSettings/SCYX4Q.ini
@@ -1,0 +1,9 @@
+# SCYX4Q - Cars 2
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8019CBBC:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/SCYY4Q.ini
+++ b/Data/Sys/GameSettings/SCYY4Q.ini
@@ -1,0 +1,9 @@
+# SCYY4Q - Cars 2
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8019B55C:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/SCYZ4Q.ini
+++ b/Data/Sys/GameSettings/SCYZ4Q.ini
@@ -1,0 +1,9 @@
+# SCYZ4Q - Cars 2
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8019B55C:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/SQI.ini
+++ b/Data/Sys/GameSettings/SQI.ini
@@ -1,4 +1,4 @@
-# SQIE4Q, SQIP4Q - Disney Infinity
+# SQIE4Q, SQIP4Q, SQIY4Q - Disney Infinity
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SQIE4Q.ini
+++ b/Data/Sys/GameSettings/SQIE4Q.ini
@@ -1,0 +1,9 @@
+# SQIE4Q - Disney Infinity
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8008E60C:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/SQIP4Q.ini
+++ b/Data/Sys/GameSettings/SQIP4Q.ini
@@ -1,0 +1,9 @@
+# SQIP4Q - Disney Infinity
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8008E60C:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/SQIY4Q.ini
+++ b/Data/Sys/GameSettings/SQIY4Q.ini
@@ -1,0 +1,9 @@
+# SQIY4Q - Disney Infinity
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x8008E60C:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/STSE4Q.ini
+++ b/Data/Sys/GameSettings/STSE4Q.ini
@@ -1,0 +1,9 @@
+# STSE4Q - Toy Story 3
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x801FA2E4:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/STSP4Qr1.ini
+++ b/Data/Sys/GameSettings/STSP4Qr1.ini
@@ -1,0 +1,9 @@
+# STSP4Q - Toy Story 3
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x801FA2E4:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/STSP4Qr2.ini
+++ b/Data/Sys/GameSettings/STSP4Qr2.ini
@@ -1,0 +1,9 @@
+# STSP4Q - Toy Story 3
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x801FA354:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/STSX4Q.ini
+++ b/Data/Sys/GameSettings/STSX4Q.ini
@@ -1,0 +1,9 @@
+# STSX4Q - Toy Story 3
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x801FA354:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/STSY4Qr0.ini
+++ b/Data/Sys/GameSettings/STSY4Qr0.ini
@@ -1,0 +1,9 @@
+# STSY4Q - Toy Story 3
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x801FA2E4:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/STSY4Qr1.ini
+++ b/Data/Sys/GameSettings/STSY4Qr1.ini
@@ -1,0 +1,9 @@
+# STSY4Q - Toy Story 3
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x801FA354:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack

--- a/Data/Sys/GameSettings/STSZ4Q.ini
+++ b/Data/Sys/GameSettings/STSZ4Q.ini
@@ -1,0 +1,9 @@
+# STSZ4Q - Toy Story 3 Toy Box Special Edition
+
+[OnFrame]
+#This speedhack modifies the way the game manages memory to run faster in Dolphin.
+$BAT Speedhack
+0x801FA2E4:dword:0x48000180
+
+[OnFrame_Enabled]
+$BAT Speedhack


### PR DESCRIPTION
Adds a (enabled by default) game patch for the Disney Trio of Destruction that repairs their performance by allowing them to use fastmem.  Makes their performance actually decent enough to play, though they are still quite heavy at times.  I'm able to get full speed most of the time in all three titles, outside of a few rough moments.

As I do not have every single revision, I wasn't able to add codes for every revision, but based on cheat code addresses I can find online alongside the revisions I do have, I am fairly confident in all of the patches I added.  If a user with that revision does report a crash, it should be very easy to fix.