### PR TITLE
GameSettings: add bean menu patch for A Boy and His Blob

### DIFF
--- a/Data/Sys/GameSettings/SBLE5G.ini
+++ b/Data/Sys/GameSettings/SBLE5G.ini
@@ -1,0 +1,8 @@
+# SBLE5G - A Boy and His Blob
+
+[OnFrame]
+$Fix selecting right-most bean
+0x800BD308:dword:0x4181000C
+
+[OnFrame_Enabled]
+$Fix selecting right-most bean

--- a/Data/Sys/GameSettings/SBLP5G.ini
+++ b/Data/Sys/GameSettings/SBLP5G.ini
@@ -1,0 +1,8 @@
+# SBLP5G - A Boy and His Blob
+
+[OnFrame]
+$Fix selecting right-most bean
+0x800BE268:dword:0x4181000C
+
+[OnFrame_Enabled]
+$Fix selecting right-most bean


### PR DESCRIPTION
The bean menu in this game does not react when the analog control stick is moved perfectly to the right (0 degress). This happens when the analog stick is mapped to digital inputs.

Currently, Dolphin contains a hardcoded controller hack to work around this issue. With this patch, it should no longer be needed; see #13177.