### PR TITLE
Qt ConfigSliders: Fix lag. Add a delay to saving the value when dragging

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "DolphinQt/Config/ConfigControls/ConfigFloatSlider.h"
+#include "QTimer"
 
 ConfigFloatSlider::ConfigFloatSlider(float minimum, float maximum,
                                      const Config::Info<float>& setting, float step,
@@ -20,13 +21,26 @@ ConfigFloatSlider::ConfigFloatSlider(float minimum, float maximum,
   setValue(current_value);
 
   connect(this, &ConfigFloatSlider::valueChanged, this, &ConfigFloatSlider::Update);
+
+  m_timer = new QTimer(this);
+  m_timer->setSingleShot(true);
+  connect(m_timer, &QTimer::timeout, this, [this]() {
+    if (m_last_value != this->value())
+      Update(this->value());
+  });
 }
 
 void ConfigFloatSlider::Update(int value)
 {
+  if (m_timer->isActive())
+    return;
+
+  m_last_value = value;
   const float current_value = (m_step * value) + m_minimum;
 
   SaveValue(m_setting, current_value);
+
+  m_timer->start(100);
 }
 
 float ConfigFloatSlider::GetValue() const

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigFloatSlider.h
@@ -8,6 +8,8 @@
 
 #include "Common/Config/ConfigInfo.h"
 
+class QTimer;
+
 // Automatically converts an int slider into a float one.
 // Do not read the int values or ranges directly from it.
 class ConfigFloatSlider final : public ConfigControl<ToolTipSlider>
@@ -28,4 +30,7 @@ private:
   float m_minimum;
   float m_step;
   const Config::Info<float> m_setting;
+
+  QTimer* m_timer;
+  int m_last_value;
 };

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigSlider.h
@@ -14,6 +14,8 @@
 #include "Common/CommonTypes.h"
 #include "Common/Config/ConfigInfo.h"
 
+class QTimer;
+
 class ConfigSlider final : public ConfigControl<ToolTipSlider>
 {
   Q_OBJECT
@@ -37,6 +39,9 @@ private:
 
   // Mappings for slider ticks to config values. Identity mapping is assumed if this is empty.
   std::vector<int> m_tick_values;
+
+  QTimer* m_timer;
+  int m_last_value;
 };
 
 class ConfigSliderU32 final : public ConfigControl<ToolTipSlider>
@@ -47,15 +52,17 @@ public:
   ConfigSliderU32(u32 minimum, u32 maximum, const Config::Info<u32>& setting, Config ::Layer* layer,
                   u32 scale = 1);
 
-  void Update(u32 value);
+  void Update(int value);
 
 protected:
   void OnConfigChanged() override;
 
 private:
   const Config::Info<u32> m_setting;
-
   u32 m_scale = 1;
+
+  QTimer* m_timer;
+  int m_last_value;
 };
 
 class ConfigSliderLabel final : public QLabel


### PR DESCRIPTION
Dragging a ConfigSliders is fairly laggy due to calling ConfigChanged continuously.  The slider values do need to update when dragging so that the change can be seen/heard, but the lag from doing it continuously is too high.  Therefore I'm trying to add a small delay between the updates.

I'm not sure what the best value is. I set it to 100ms, but there may be some options where that's too slow.

I forgot to convert Settings -> Wii -> Remote settings to ConfigSliders, as they call ConfigChanged.  They can be used as a quick comparison between the delayed updates on the other sliders and their continuous updates.

If a game settings window is closed before the QTimer activates the last save, it would miss saving the most recent value.  I'm not sure if that is a real issue for a 100ms timer.