### PR TITLE
AudioCommon: Re-add missing includes

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
+#include <mutex>
 #include <thread>
 
 #if defined(HAVE_ALSA) && HAVE_ALSA


### PR DESCRIPTION
PR #13697 removed some includes that were in fact in use.