### PR TITLE
Host: Implement a Windows-only implementation of `GetDeviceNameFromVIDPID`

### DIFF
--- a/Source/Core/Common/CommonFuncs.cpp
+++ b/Source/Core/Common/CommonFuncs.cpp
@@ -10,6 +10,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <SetupAPI.h>
 
 #define strerror_r(err, buf, len) strerror_s(buf, len, err)
 
@@ -90,6 +91,29 @@ std::optional<std::wstring> GetModuleName(void* hInstance)
   }
   name.resize(size);
   return name;
+}
+
+std::wstring GetDeviceProperty(const HDEVINFO& device_info, const PSP_DEVINFO_DATA device_data,
+                               const DEVPROPKEY* requested_property)
+{
+  DWORD required_size = 0;
+  DEVPROPTYPE device_property_type;
+  BOOL result;
+
+  result = SetupDiGetDeviceProperty(device_info, device_data, requested_property,
+                                    &device_property_type, nullptr, 0, &required_size, 0);
+  if (!result && GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    return std::wstring();
+
+  std::vector<TCHAR> unicode_buffer(required_size / sizeof(TCHAR));
+
+  result = SetupDiGetDeviceProperty(
+      device_info, device_data, requested_property, &device_property_type,
+      reinterpret_cast<PBYTE>(unicode_buffer.data()), required_size, nullptr, 0);
+  if (!result)
+    return std::wstring();
+
+  return std::wstring(unicode_buffer.data());
 }
 #endif
 }  // namespace Common

--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -5,6 +5,12 @@
 
 #include <optional>
 #include <string>
+#ifdef _WIN32
+#include <SetupAPI.h>
+#include <cfgmgr32.h>
+#include <devpropdef.h>
+#endif
+
 #include "Common/CommonTypes.h"
 
 #ifndef _WIN32
@@ -58,5 +64,9 @@ std::string GetWin32ErrorString(unsigned long error_code);
 
 // Obtains a full path to the specified module.
 std::optional<std::wstring> GetModuleName(void* hInstance);
+
+// Obtains a device property and returns it as a wide string.
+std::wstring GetDeviceProperty(const HANDLE& device_info, const PSP_DEVINFO_DATA device_data,
+                               const DEVPROPKEY* requested_property);
 #endif
 }  // namespace Common

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -210,28 +210,6 @@ bool ForgetWiimote(BLUETOOTH_DEVICE_INFO_STRUCT&);
 
 namespace
 {
-std::wstring GetDeviceProperty(const HDEVINFO& device_info, const PSP_DEVINFO_DATA device_data,
-                               const DEVPROPKEY* requested_property)
-{
-  DWORD required_size = 0;
-  DEVPROPTYPE device_property_type;
-
-  SetupDiGetDeviceProperty(device_info, device_data, requested_property, &device_property_type,
-                           nullptr, 0, &required_size, 0);
-
-  std::vector<BYTE> unicode_buffer(required_size, 0);
-
-  BOOL result =
-      SetupDiGetDeviceProperty(device_info, device_data, requested_property, &device_property_type,
-                               unicode_buffer.data(), required_size, nullptr, 0);
-  if (!result)
-  {
-    return std::wstring();
-  }
-
-  return std::wstring((PWCHAR)unicode_buffer.data());
-}
-
 int IOWritePerSetOutputReport(HANDLE& dev_handle, const u8* buf, size_t len, DWORD* written)
 {
   const BOOLEAN result =
@@ -403,8 +381,8 @@ bool CheckForToshibaStack(const DEVINST& hid_interface_device_instance)
 
   if (GetParentDevice(hid_interface_device_instance, &parent_device_info, &parent_device_data))
   {
-    std::wstring class_driver_provider =
-        GetDeviceProperty(parent_device_info, &parent_device_data, &DEVPKEY_Device_DriverProvider);
+    std::wstring class_driver_provider = Common::GetDeviceProperty(
+        parent_device_info, &parent_device_data, &DEVPKEY_Device_DriverProvider);
 
     SetupDiDestroyDeviceInfoList(parent_device_info);
 


### PR DESCRIPTION
This is confirmed to fix the recently reported BSOD issues certain users experience.