### PR TITLE
MainWindow - Avoid excessive emulation state changes

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -2010,9 +2010,14 @@ void MainWindow::ShowAchievementSettings()
 
 void MainWindow::OnHardcoreChanged()
 {
-  if (AchievementManager::GetInstance().IsHardcoreModeActive())
+  bool hardcore_active = AchievementManager::GetInstance().IsHardcoreModeActive();
+  if (hardcore_active)
     Settings::Instance().SetDebugModeEnabled(false);
-  emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
+  // EmulationStateChanged causes several dialogs to redraw, including anything affected by hardcore
+  // mode. Every dialog that depends on hardcore mode is redrawn by EmulationStateChanged.
+  if (hardcore_active != m_former_hardcore_setting)
+    emit Settings::Instance().EmulationStateChanged(Core::GetState(Core::System::GetInstance()));
+  m_former_hardcore_setting = hardcore_active;
 }
 #endif  // USE_RETRO_ACHIEVEMENTS
 

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -267,6 +267,7 @@ private:
 #ifdef USE_RETRO_ACHIEVEMENTS
   AchievementsWindow* m_achievements_window = nullptr;
   Config::ConfigChangedCallbackID m_config_changed_callback_id;
+  bool m_former_hardcore_setting = false;
 #endif  // USE_RETRO_ACHIEVEMENTS
 
   AssemblerWidget* m_assembler_widget;


### PR DESCRIPTION
Updates the Hardcore Changed callback to only signal EmulationStateChanged if the new Hardcore Mode setting is different from the previous one.