### PR TITLE
AutoUpdateChecker: Delete old Updater.log file

### DIFF
--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -79,9 +79,9 @@ std::string MakeUpdaterCommandLine(const std::map<std::string, std::string>& fla
   return cmdline;
 }
 
-#ifdef __APPLE__
 void CleanupFromPreviousUpdate()
 {
+#ifdef __APPLE__
   // Remove the relocated updater file.
   File::DeleteDirRecursively(UpdaterPath(true));
 
@@ -90,9 +90,12 @@ void CleanupFromPreviousUpdate()
   // version with an embedded updater, it won't delete the folder structure of the bundle, so
   // we should clean those leftovers up.
   File::DeleteDirRecursively(File::GetExeDirectory() + DIR_SEP + "Dolphin Updater.app");
-}
 #endif
 
+  // Updater.log was moved from GetExeDirectory() to GetUserPath(D_LOGS_IDX) in 5.0-14529.
+  File::Delete(File::GetExeDirectory() + DIR_SEP + "Updater.log",
+               File::IfAbsentBehavior::NoConsoleWarning);
+}
 #endif
 
 // This ignores i18n because most of the text in there (change descriptions) is only going to be
@@ -190,7 +193,7 @@ void AutoUpdateChecker::CheckForUpdate(std::string_view update_track,
   if (!SystemSupportsAutoUpdates() || update_track.empty())
     return;
 
-#ifdef __APPLE__
+#ifdef OS_SUPPORTS_UPDATER
   CleanupFromPreviousUpdate();
 #endif
 


### PR DESCRIPTION
Delete the old Updater.log file from GetExeDirectory().

The log was moved to GetUserPath(D_LOGS_IDX) in 5.0-14529, but users looking to make a bug report might find the old one instead (from the last time they updated before that version) so let's delete it to prevent any confusion.