### PR TITLE
PPCSymbols: Restructure loading on boot and add a mutex to prevent crashes.

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -44,15 +44,20 @@ void SymbolDB::List()
 
 bool SymbolDB::IsEmpty() const
 {
-  return m_functions.empty();
+  return m_functions.empty() && m_notes.empty();
 }
 
-void SymbolDB::Clear(const char* prefix)
+bool SymbolDB::Clear(const char* prefix)
 {
   // TODO: honor prefix
+  m_map_name.clear();
+  if (IsEmpty())
+    return false;
+
   m_functions.clear();
   m_notes.clear();
   m_checksum_to_function.clear();
+  return true;
 }
 
 void SymbolDB::Index()

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -100,7 +100,7 @@ public:
   const XNoteMap& Notes() const { return m_notes; }
   XFuncMap& AccessSymbols() { return m_functions; }
   bool IsEmpty() const;
-  void Clear(const char* prefix = "");
+  bool Clear(const char* prefix = "");
   void List();
   void Index();
 
@@ -108,5 +108,6 @@ protected:
   XFuncMap m_functions;
   XNoteMap m_notes;
   XFuncPtrMap m_checksum_to_function;
+  std::string m_map_name;
 };
 }  // namespace Common

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -354,30 +354,10 @@ bool CBoot::DVDReadDiscID(Core::System& system, const DiscIO::VolumeDisc& disc, 
   return true;
 }
 
-// Get map file paths for the active title.
-bool CBoot::FindMapFile(std::string* existing_map_file, std::string* writable_map_file)
-{
-  const std::string& game_id = SConfig::GetInstance().m_debugger_game_id;
-  std::string path = File::GetUserPath(D_MAPS_IDX) + game_id + ".map";
-
-  if (writable_map_file)
-    *writable_map_file = path;
-
-  if (File::Exists(path))
-  {
-    if (existing_map_file)
-      *existing_map_file = std::move(path);
-
-    return true;
-  }
-
-  return false;
-}
-
 bool CBoot::LoadMapFromFilename(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db)
 {
   std::string strMapFilename;
-  bool found = FindMapFile(&strMapFilename, nullptr);
+  bool found = ppc_symbol_db.FindMapFile(&strMapFilename, nullptr);
   if (found && ppc_symbol_db.LoadMap(guard, strMapFilename))
   {
     Host_PPCSymbolsChanged();

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -159,17 +159,6 @@ public:
   static bool BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
                      std::unique_ptr<BootParameters> boot);
 
-  // Tries to find a map file for the current game by looking first in the
-  // local user directory, then in the shared user directory.
-  //
-  // If existing_map_file is not nullptr and a map file exists, it is set to the
-  // path to the existing map file.
-  //
-  // If writable_map_file is not nullptr, it is set to the path to where a map
-  // file should be saved.
-  //
-  // Returns true if a map file exists, false if none could be found.
-  static bool LoadMapFromFilename(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db);
 
 private:
   static bool DVDRead(Core::System& system, const DiscIO::VolumeDisc& disc, u64 dvd_offset,

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -169,7 +169,6 @@ public:
   // file should be saved.
   //
   // Returns true if a map file exists, false if none could be found.
-  static bool FindMapFile(std::string* existing_map_file, std::string* writable_map_file);
   static bool LoadMapFromFilename(const Core::CPUThreadGuard& guard, PPCSymbolDB& ppc_symbol_db);
 
 private:

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -159,7 +159,6 @@ public:
   static bool BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
                      std::unique_ptr<BootParameters> boot);
 
-
 private:
   static bool DVDRead(Core::System& system, const DiscIO::VolumeDisc& disc, u64 dvd_offset,
                       u32 output_address, u32 length, const DiscIO::Partition& partition);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -271,12 +271,9 @@ void SConfig::OnTitleDirectlyBooted(const Core::CPUThreadGuard& guard)
     return;
 
   auto& ppc_symbol_db = system.GetPPCSymbolDB();
-  if (!ppc_symbol_db.IsEmpty())
-  {
-    ppc_symbol_db.Clear();
+
+  if (ppc_symbol_db.LoadMapOnBoot(guard))
     Host_PPCSymbolsChanged();
-  }
-  CBoot::LoadMapFromFilename(guard, ppc_symbol_db);
   HLE::Reload(system);
 
   PatchEngine::Reload(system);

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -71,17 +71,17 @@ bool Load(Core::System& system)
   auto& ppc_symbol_db = power_pc.GetSymbolDB();
 
   // Load symbols for the IPL if they exist.
-  if (!ppc_symbol_db.IsEmpty())
-  {
-    ppc_symbol_db.Clear();
-    Host_PPCSymbolsChanged();
-  }
+  bool symbols_changed = ppc_symbol_db.Clear();
+
   if (ppc_symbol_db.LoadMap(guard, File::GetUserPath(D_MAPS_IDX) + "mios-ipl.map"))
   {
     ::HLE::Clear();
     ::HLE::PatchFunctions(system);
-    Host_PPCSymbolsChanged();
+    symbols_changed = true;
   }
+
+  if (symbols_changed)
+    Host_PPCSymbolsChanged();
 
   const PowerPC::CoreMode core_mode = power_pc.GetMode();
   power_pc.SetMode(PowerPC::CoreMode::Interpreter);

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -15,10 +15,12 @@
 #include <fmt/format.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Common/Unreachable.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Debugger/DebugInterface.h"
 #include "Core/PowerPC/MMU.h"
@@ -277,6 +279,26 @@ void PPCSymbolDB::LogFunctionCall(u32 addr)
 
   Common::Symbol& f = iter->second;
   f.num_calls++;
+}
+
+// Get map file paths for the active title.
+bool PPCSymbolDB::FindMapFile(std::string* existing_map_file, std::string* writable_map_file)
+{
+  const std::string& game_id = SConfig::GetInstance().m_debugger_game_id;
+  std::string path = File::GetUserPath(D_MAPS_IDX) + game_id + ".map";
+
+  if (writable_map_file)
+    *writable_map_file = path;
+
+  if (File::Exists(path))
+  {
+    if (existing_map_file)
+      *existing_map_file = std::move(path);
+
+    return true;
+  }
+
+  return false;
 }
 
 // The use case for handling bad map files is when you have a game with a map file on the disc,

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -37,6 +37,8 @@ public:
   std::string_view GetDescription(u32 addr);
 
   void FillInCallers();
+
+  bool LoadMapOnBoot(const Core::CPUThreadGuard& guard);
   bool LoadMap(const Core::CPUThreadGuard& guard, const std::string& filename, bool bad = false);
   bool SaveSymbolMap(const std::string& filename) const;
   bool SaveCodeMap(const Core::CPUThreadGuard& guard, const std::string& filename) const;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -44,4 +44,6 @@ public:
   void PrintCalls(u32 funcAddr) const;
   void PrintCallers(u32 funcAddr) const;
   void LogFunctionCall(u32 addr);
+
+  static bool FindMapFile(std::string* existing_map_file, std::string* writable_map_file);
 };

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <string_view>
 
@@ -48,4 +49,7 @@ public:
   void LogFunctionCall(u32 addr);
 
   static bool FindMapFile(std::string* existing_map_file, std::string* writable_map_file);
+
+private:
+  std::mutex m_write_lock;
 };

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -26,7 +26,6 @@
 #include "Common/StringUtil.h"
 
 #include "Core/AchievementManager.h"
-#include "Core/Boot/Boot.h"
 #include "Core/CommonTitles.h"
 #include "Core/Config/AchievementSettings.h"
 #include "Core/Config/MainSettings.h"
@@ -1714,7 +1713,7 @@ void MenuBar::LoadSymbolMap()
   auto& ppc_symbol_db = system.GetPPCSymbolDB();
 
   std::string existing_map_file, writable_map_file;
-  bool map_exists = CBoot::FindMapFile(&existing_map_file, &writable_map_file);
+  bool map_exists = PPCSymbolDB::FindMapFile(&existing_map_file, &writable_map_file);
 
   if (!map_exists)
   {
@@ -1752,7 +1751,7 @@ void MenuBar::LoadSymbolMap()
 void MenuBar::SaveSymbolMap()
 {
   std::string existing_map_file, writable_map_file;
-  CBoot::FindMapFile(&existing_map_file, &writable_map_file);
+  PPCSymbolDB::FindMapFile(&existing_map_file, &writable_map_file);
 
   TrySaveSymbolMap(QString::fromStdString(writable_map_file));
 }
@@ -1808,7 +1807,7 @@ void MenuBar::SaveSymbolMapAs()
 void MenuBar::SaveCode()
 {
   std::string existing_map_file, writable_map_file;
-  CBoot::FindMapFile(&existing_map_file, &writable_map_file);
+  PPCSymbolDB::FindMapFile(&existing_map_file, &writable_map_file);
 
   const std::string path =
       writable_map_file.substr(0, writable_map_file.find_last_of('.')) + "_code.map";


### PR DESCRIPTION
Fix a potential crash from emuthread and Qt accessing m_functions at the same time.

Guard against checking map file while it is being loaded by emuthread on boot.
Don't clear and reload a map on boot if the correct one is already loaded.
A few cleanups.