### PR TITLE
GameINI: Remove NSMBW PAL speed hack

### DIFF
--- a/Data/Sys/GameSettings/SMNP01.ini
+++ b/Data/Sys/GameSettings/SMNP01.ini
@@ -2,9 +2,6 @@
 
 [OnFrame]
 # Add memory patches to be applied every frame here.
-$Speed hack
-0x801D5B10:dword:0x60000000
-0x801D5B14:dword:0x60000000
 
 [ActionReplay]
 # Add action replay cheats here.


### PR DESCRIPTION
It's been there since the very first public commit. And enabling it gives absolutely no difference in performance.
Plus the fact that it's only there for the PAL version, it's probably been forgotten.