### PR TITLE
Fix PauseAndLock deadlock

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -244,7 +244,7 @@ void CPUManager::Stop()
   m_state = State::PowerDown;
   m_state_cpu_cvar.notify_one();
 
-  while (m_state_cpu_thread_active)
+  if (m_state_cpu_thread_active)
   {
     m_state_cpu_idle_cvar.wait(state_lock);
   }
@@ -312,7 +312,7 @@ void CPUManager::SetStepping(bool stepping)
   {
     SetStateLocked(State::Stepping);
 
-    while (m_state_cpu_thread_active)
+    if (m_state_cpu_thread_active)
     {
       m_state_cpu_idle_cvar.wait(state_lock);
     }
@@ -367,7 +367,7 @@ bool CPUManager::PauseAndLock(bool do_lock, bool unpause_on_unlock, bool control
     was_unpaused = m_state == State::Running;
     SetStateLocked(State::Stepping);
 
-    while (m_state_cpu_thread_active)
+    if (m_state_cpu_thread_active)
     {
       m_state_cpu_idle_cvar.wait(state_lock);
     }


### PR DESCRIPTION
If CPU needs to be interrupted while it is running (usually with the Debug UI) there is a semi-rare race condition that would deadlock the main thread. If the CPU thread resumes too fast, `m_state_cpu_thread_active` will be `true` again before the main thread returns from the wait. That will cause it to wait for the CPU thread to send an idle notification agian. Since it deadlocks the main thread, there is no way to get it to sent the notification again. It seems the `m_state_cpu_thread_active check` was a while loop because the wait had a 100ms timeout before.