### PR TITLE
GameSettings: increase SyncGpuOverclock for Homeland

### DIFF
--- a/Data/Sys/GameSettings/GHEJ91.ini
+++ b/Data/Sys/GameSettings/GHEJ91.ini
@@ -1,0 +1,5 @@
+# GHEJ91 - Homeland
+
+[Core]
+# Workaround for https://bugs.dolphin-emu.org/issues/13830
+SyncGpuOverclock = 5


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/13830

Workaround for graphical bug introduced in #3490