### PR TITLE
ThreadWidget: Fix line edit margins

### DIFF
--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -137,8 +137,10 @@ QLineEdit* ThreadWidget::CreateLineEdit() const
 {
   QLineEdit* line_edit = new QLineEdit(QStringLiteral("00000000"));
   line_edit->setReadOnly(true);
-  line_edit->setFixedWidth(
-      line_edit->fontMetrics().boundingRect(QStringLiteral(" 00000000 ")).width());
+  // Calculate width using 10 digits instead of 8 to add space for margins.
+  const int width = line_edit->fontMetrics().boundingRect(QStringLiteral("0000000000")).width();
+  line_edit->setFixedWidth(width);
+  line_edit->setAlignment(Qt::AlignCenter);
   return line_edit;
 }
 


### PR DESCRIPTION
At least on Windows they look like this on master:
![Before](https://github.com/user-attachments/assets/45c6a204-31ab-4cfe-b878-f6b2e7a4e144)
With this PR:
![After](https://github.com/user-attachments/assets/d1c343c7-6634-42c0-8c53-d3ac857c7bd4)

The two spaces that were previously in the string literal only added 5 pixels combined to the width, so I've replaced them with `0` which adds a combined 12 pixels.

I tried fixing the spacing in more proper ways but:
* `sizeHint()` is too big since it makes space for 17 characters.
* `minimumSizeHint()` is too small since it only leaves room for 1 character.
* `contentsMargins()` are actually just some extra margins you can add on top of the private built-in margins, and are 0 by default.

... so anything trying to use those would end up hackier than doing it this way.

I'm not sure what this looks like on master for Linux and macOS, so this needs checking for those platforms.