### PR TITLE
DolphinQt: Make Calibration autocomplete when data is "sensible" and stick is returned to neutral position.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -238,20 +238,15 @@ private:
 
 class CalibrationWidget : public QToolButton
 {
-  Q_OBJECT
 public:
   CalibrationWidget(MappingWidget& mapping_widget, ControllerEmu::ReshapableInput& input,
                     ReshapableInputIndicator& indicator);
-  ~CalibrationWidget() override;
 
   void Update(Common::DVec2 point);
 
   void Draw(QPainter& p, Common::DVec2 point);
 
   bool IsActive() const;
-
-signals:
-  void CalibrationIsSensible();
 
 private:
   void DrawInProgressMapping(QPainter& p);
@@ -262,6 +257,8 @@ private:
 
   void StartMappingAndCalibration();
   void StartCalibration(std::optional<Common::DVec2> center = Common::DVec2{});
+
+  void FinishCalibration();
 
   void ResetActions();
   void DeleteAllActions();
@@ -277,4 +274,8 @@ private:
   void RestartAnimation();
 
   Clock::time_point m_animation_start_time{};
+
+  static constexpr auto STOP_SPINNING_DURATION = std::chrono::seconds{2};
+
+  Clock::time_point m_stop_spinning_time{};
 };

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -277,6 +277,16 @@ bool CalibrationBuilder::IsCalibrationDataSensible() const
   return stats.StandardDeviation() < REASONABLE_DEVIATION;
 }
 
+bool CalibrationBuilder::IsComplete() const
+{
+  if (!IsCalibrationDataSensible())
+    return false;
+
+  const auto half_calibration =
+      0.5 * GetCalibrationRadiusAtAngle(std::atan2(m_prev_point.y, m_prev_point.x) + MathUtil::TAU);
+  return m_prev_point.LengthSquared() < (half_calibration * half_calibration);
+}
+
 ControlState CalibrationBuilder::GetCalibrationRadiusAtAngle(double angle) const
 {
   return ControllerEmu::ReshapableInput::GetCalibrationDataRadiusAtAngle(m_calibration_data, angle);

--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.h
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.h
@@ -85,6 +85,10 @@ public:
   // Used to update the UI to encourage the user to click the "Finish" button.
   bool IsCalibrationDataSensible() const;
 
+  // Returns true when the calibration data seems sensible,
+  //  and the input then approaches the center position.
+  bool IsComplete() const;
+
   // Grabs the calibration value at the provided angle.
   // Used to render the calibration in the UI while it's in progress.
   ControlState GetCalibrationRadiusAtAngle(double angle) const;


### PR DESCRIPTION
The `IsCalibrationDataSensible` check which turned the default action from `Cancel Calibration` to `Finish Calibration` when all calibration points were filled without too much variance now stops the the spinning stick animation and automatically finishes calibration when the stick returns to center.

[Screencast_20250615_160915.webm](https://github.com/user-attachments/assets/e233e7cb-a586-425c-8bbd-0cb1112046c1)
