### PR TITLE
DolphinQt: Always enable the "Skip Main Menu" checkbox when "SkipIPL" is disabled.

### DIFF
--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -726,7 +726,7 @@ void GameCubePane::LoadSettings()
     }
   }
 
-  m_skip_main_menu->setEnabled(have_menu);
+  m_skip_main_menu->setEnabled(have_menu || !m_skip_main_menu->isChecked());
   m_skip_main_menu->setToolTip(have_menu ? QString{} : tr("Put IPL ROMs in User/GC/<region>."));
 
   // Device Settings


### PR DESCRIPTION
Fixes: https://bugs.dolphin-emu.org/issues/13822