### PR TITLE
Qt: Use NonAutodismissibleMenu in more places

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -66,6 +66,7 @@
 #include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/QtUtils/DoubleClickEventFilter.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include "DolphinQt/QtUtils/NonAutodismissibleMenu.h"
 #include "DolphinQt/QtUtils/ParallelProgressDialog.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
@@ -519,7 +520,8 @@ void GameList::ShowContextMenu(const QPoint&)
 
     menu->addSeparator();
 
-    auto* tags_menu = menu->addMenu(tr("Tags"));
+    auto* const tags_menu{new QtUtils::NonAutodismissibleMenu(tr("Tags"), menu)};
+    menu->addMenu(tags_menu);
 
     auto path = game->GetFilePath();
     auto game_tags = m_model.GetGameTags(path);

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -470,6 +470,13 @@ void GameListModel::AddGameTag(const std::string& path, const QString& name)
 
   m_game_tags[QString::fromStdString(path)] = tags;
   Settings::GetQSettings().setValue(QStringLiteral("gamelist/game_tags"), m_game_tags);
+
+  const int row = FindGameIndex(path);
+  if (row >= 0)
+  {
+    const QModelIndex index = createIndex(row, static_cast<int>(Column::Tags));
+    emit dataChanged(index, index);
+  }
 }
 
 void GameListModel::RemoveGameTag(const std::string& path, const QString& name)
@@ -481,6 +488,13 @@ void GameListModel::RemoveGameTag(const std::string& path, const QString& name)
   m_game_tags[QString::fromStdString(path)] = tags;
 
   Settings::GetQSettings().setValue(QStringLiteral("gamelist/game_tags"), m_game_tags);
+
+  const int row = FindGameIndex(path);
+  if (row >= 0)
+  {
+    const QModelIndex index = createIndex(row, static_cast<int>(Column::Tags));
+    emit dataChanged(index, index);
+  }
 }
 
 void GameListModel::NewTag(const QString& name)

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -352,7 +352,8 @@ void MenuBar::AddToolsMenu()
   m_export_wii_saves =
       tools_menu->addAction(tr("Export All Wii Saves"), this, &MenuBar::ExportWiiSaves);
 
-  QMenu* connect_wii_remotes_menu = new QMenu(tr("Connect Wii Remotes"), tools_menu);
+  auto* const connect_wii_remotes_menu{
+      new QtUtils::NonAutodismissibleMenu(tr("Connect Wii Remotes"), tools_menu)};
 
   tools_menu->addSeparator();
   tools_menu->addMenu(connect_wii_remotes_menu);
@@ -601,7 +602,8 @@ void MenuBar::AddViewMenu()
 
 void MenuBar::AddOptionsMenu()
 {
-  QMenu* options_menu = addMenu(tr("&Options"));
+  auto* const options_menu{new QtUtils::NonAutodismissibleMenu(tr("&Options"), this)};
+  addMenu(options_menu);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
   options_menu->addAction(tr("Co&nfiguration"), QKeySequence::Preferences, this,
                           &MenuBar::Configure);
@@ -892,7 +894,8 @@ void MenuBar::AddMovieMenu()
 
 void MenuBar::AddJITMenu()
 {
-  m_jit = addMenu(tr("JIT"));
+  m_jit = new QtUtils::NonAutodismissibleMenu(tr("JIT"), this);
+  addMenu(m_jit);
 
   m_jit_interpreter_core = m_jit->addAction(tr("Interpreter Core"));
   m_jit_interpreter_core->setCheckable(true);

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -352,22 +352,22 @@ void MenuBar::AddToolsMenu()
   m_export_wii_saves =
       tools_menu->addAction(tr("Export All Wii Saves"), this, &MenuBar::ExportWiiSaves);
 
-  QMenu* menu = new QMenu(tr("Connect Wii Remotes"), tools_menu);
+  QMenu* connect_wii_remotes_menu = new QMenu(tr("Connect Wii Remotes"), tools_menu);
 
   tools_menu->addSeparator();
-  tools_menu->addMenu(menu);
+  tools_menu->addMenu(connect_wii_remotes_menu);
 
   for (int i = 0; i < 4; i++)
   {
-    m_wii_remotes[i] = menu->addAction(tr("Connect Wii Remote %1").arg(i + 1), this,
-                                       [this, i] { emit ConnectWiiRemote(i); });
+    m_wii_remotes[i] = connect_wii_remotes_menu->addAction(
+        tr("Connect Wii Remote %1").arg(i + 1), this, [this, i] { emit ConnectWiiRemote(i); });
     m_wii_remotes[i]->setCheckable(true);
   }
 
-  menu->addSeparator();
+  connect_wii_remotes_menu->addSeparator();
 
-  m_wii_remotes[4] =
-      menu->addAction(tr("Connect Balance Board"), this, [this] { emit ConnectWiiRemote(4); });
+  m_wii_remotes[4] = connect_wii_remotes_menu->addAction(tr("Connect Balance Board"), this,
+                                                         [this] { emit ConnectWiiRemote(4); });
   m_wii_remotes[4]->setCheckable(true);
 }
 


### PR DESCRIPTION
#13508 added the NonAutodismissibleMenu class, which allows users to toggle multiple checkable menu items without having to reopen the menu after each item.

This PR uses that class in several other places:
* MenuBar ->`JIT`
* MenuBar ->`Options` (The only checkable item here is `Boot to Pause`, but it helps maintain consistency with other checkable menu items)
* MenuBar ->`Tools`->`Connect Wii Remotes`
* GameList -> context menu -> `Tags`
