### PR TITLE
DolphinQt: Add DolphinQt.vcxproj ClInclude line

### DIFF
--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -258,6 +258,7 @@
     <ClInclude Include="QtUtils\DolphinFileDialog.h" />
     <ClInclude Include="QtUtils\ImageConverter.h" />
     <ClInclude Include="QtUtils\ModalMessageBox.h" />
+    <ClInclude Include="QtUtils\NonAutodismissibleMenu.h" />
     <ClInclude Include="QtUtils\NonDefaultQPushButton.h" />
     <ClInclude Include="QtUtils\QueueOnObject.h" />
     <ClInclude Include="QtUtils\RunOnObject.h" />


### PR DESCRIPTION
Add a missing ClInclude line in DolphinQt.vcxproj for NonAutodismissibleMenu.h. Missing the ClInclude doesn't break compilation, but prevents various IntelliSense features in Visual Studio from working properly with the file.