### PR TITLE
ActionReplay/PatchEngine: Make writes invalidate cache

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -3,12 +3,15 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstddef>
 #include <memory>
+#include <span>
 #include <string>
 
 #include "Common/Debug/MemoryPatches.h"
 #include "Common/Debug/Watches.h"
+#include "Common/Swap.h"
 #include "Core/Debugger/DebugInterface.h"
 #include "Core/NetworkCaptureLogger.h"
 
@@ -19,8 +22,17 @@ class System;
 }  // namespace Core
 class PPCSymbolDB;
 
-void ApplyMemoryPatch(const Core::CPUThreadGuard&, Common::Debug::MemoryPatch& patch,
+void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, std::span<u8> value, const u32 address,
                       bool store_existing_value = true);
+
+template <std::unsigned_integral T>
+void ApplyMemoryPatch(const Core::CPUThreadGuard& guard, T value, const u32 address)
+{
+  Common::BigEndianValue<T> big_endian{value};
+  auto data =
+      std::span<u8, sizeof(T)>{reinterpret_cast<u8*>(std::addressof(big_endian)), sizeof(T)};
+  ApplyMemoryPatch(guard, data, address);
+}
 
 class PPCPatches final : public Common::Debug::MemoryPatches
 {

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -219,19 +219,19 @@ static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Pa
           if (!entry.conditional ||
               PowerPC::MMU::HostRead_U8(guard, addr) == static_cast<u8>(comparand))
           {
-            PowerPC::MMU::HostWrite_U8(guard, static_cast<u8>(value), addr);
+            ApplyMemoryPatch<u8>(guard, static_cast<u8>(value), addr);
           }
           break;
         case PatchType::Patch16Bit:
           if (!entry.conditional ||
               PowerPC::MMU::HostRead_U16(guard, addr) == static_cast<u16>(comparand))
           {
-            PowerPC::MMU::HostWrite_U16(guard, static_cast<u16>(value), addr);
+            ApplyMemoryPatch<u16>(guard, static_cast<u16>(value), addr);
           }
           break;
         case PatchType::Patch32Bit:
           if (!entry.conditional || PowerPC::MMU::HostRead_U32(guard, addr) == comparand)
-            PowerPC::MMU::HostWrite_U32(guard, value, addr);
+            ApplyMemoryPatch<u32>(guard, value, addr);
           break;
         default:
           // unknown patchtype


### PR DESCRIPTION
Previously, applying a patch while the game was running had no effect, since the icache wasn't invalidated.
This PR fixes it.