### PR TITLE
CodeWidget: Clear calls/callers if no symbol exists.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -235,11 +235,10 @@ void CodeWidget::OnPPCSymbolsChanged()
 {
   UpdateSymbols();
   UpdateCallstack();
-  if (const Common::Symbol* symbol = m_ppc_symbol_db.GetSymbolFromAddr(m_code_view->GetAddress()))
-  {
-    UpdateFunctionCalls(symbol);
-    UpdateFunctionCallers(symbol);
-  }
+
+  const Common::Symbol* symbol = m_ppc_symbol_db.GetSymbolFromAddr(m_code_view->GetAddress());
+  UpdateFunctionCalls(symbol);
+  UpdateFunctionCallers(symbol);
 }
 
 void CodeWidget::ActivateSearchAddress()
@@ -354,9 +353,6 @@ void CodeWidget::Update()
   m_code_view->Update();
   m_code_view->setFocus();
 
-  if (!symbol)
-    return;
-
   UpdateFunctionCalls(symbol);
   UpdateFunctionCallers(symbol);
 }
@@ -427,6 +423,9 @@ void CodeWidget::UpdateSymbols()
 void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
 {
   m_function_calls_list->clear();
+  if (symbol == nullptr)
+    return;
+
   const QString filter = m_search_calls->text();
 
   for (const auto& call : symbol->calls)
@@ -461,6 +460,9 @@ void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
 void CodeWidget::UpdateFunctionCallers(const Common::Symbol* symbol)
 {
   m_function_callers_list->clear();
+  if (symbol == nullptr)
+    return;
+
   const QString filter = m_search_callers->text();
 
   for (const auto& caller : symbol->callers)


### PR DESCRIPTION
If it isn't cleared, the old data will persist. Especially bad if a game without symbols is loaded, as it would never get cleared and would show the last valid calls/callers from the previous game.