### PR TITLE
GameINI: Misc updates

### DIFF
--- a/Data/Sys/GameSettings/GMN.ini
+++ b/Data/Sys/GameSettings/GMN.ini
@@ -12,4 +12,7 @@
 [Video_Settings]
 
 [Video_Hacks]
+# Fixes FMVs tearing.
+EarlyXFBOutput = False
+# Fixes FMVs not showing.
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GTR.ini
+++ b/Data/Sys/GameSettings/GTR.ini
@@ -1,8 +1,16 @@
-# GTRE78, GTRP78 - Tetris Worlds
+# GTRE78, GTRJ8N, GTRP78 - Tetris Worlds
+
 [Core]
+# Values set here will override the main Dolphin settings.
+
 [OnFrame]
+# Add memory patches to be applied every frame here.
+
 [ActionReplay]
-[Video_Settings]
+# Add action replay cheats here.
+
 [Video_Hacks]
+# Fixes FMVs tearing.
+EarlyXFBOutput = False
+# Fixes FMVs not showing.
 ImmediateXFBEnable = False
-[Gecko]

--- a/Data/Sys/GameSettings/R22.ini
+++ b/Data/Sys/GameSettings/R22.ini
@@ -11,7 +11,3 @@
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-EFBEmulateFormatChanges = True
-

--- a/Data/Sys/GameSettings/R7X.ini
+++ b/Data/Sys/GameSettings/R7X.ini
@@ -10,8 +10,11 @@
 # Add action replay cheats here.
 
 [Video_Settings]
+# Responsive car painting.
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
+# Functional pointing while car painting.
+EFBAccessEnable = True
+# Customizable cars load as completely black otherwise (even in their default state), sun bloom.
 EFBToTextureEnable = False
-

--- a/Data/Sys/GameSettings/S75.ini
+++ b/Data/Sys/GameSettings/S75.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnFrame]
 # Add memory patches to be applied every frame here.

--- a/Data/Sys/GameSettings/SCA.ini
+++ b/Data/Sys/GameSettings/SCA.ini
@@ -11,7 +11,3 @@
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-EFBEmulateFormatChanges = True
-

--- a/Data/Sys/GameSettings/SDW.ini
+++ b/Data/Sys/GameSettings/SDW.ini
@@ -8,7 +8,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-

--- a/Data/Sys/GameSettings/SK8.ini
+++ b/Data/Sys/GameSettings/SK8.ini
@@ -10,5 +10,7 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
+# Properly emulate the blur in the backgrounds.
 EFBEmulateFormatChanges = True
+# Prevent epilepsy-inducing FMVs.
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/SKY.ini
+++ b/Data/Sys/GameSettings/SKY.ini
@@ -10,5 +10,7 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
+# Properly emulates the blur in the pause screen.
 EFBEmulateFormatChanges = True
+# Prevent epilepsy-inducing FMVs and menus.
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/SSP.ini
+++ b/Data/Sys/GameSettings/SSP.ini
@@ -10,5 +10,7 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
+# Properly emulates the blur in the pause screen.
 EFBEmulateFormatChanges = True
+# Prevent epilepsy-inducing FMVs and menus.
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/SVX.ini
+++ b/Data/Sys/GameSettings/SVX.ini
@@ -10,4 +10,5 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
+# Prevent epilepsy-inducing FMVs.
 ImmediateXFBEnable = False


### PR DESCRIPTION
Don't feel like splitting this in multiple PRs.
Mostly added comments to settings I added in the past.

But also:
- Remove obsolete settings for Lost in Shadow, Calling and FlingSmash (according to [this Discord post](https://discord.com/channels/521709831132807179/521710974827495435/1385341558618062951), can't test any of these games).
- Disable Dual Core for Monopoly Streets (causes crashes according to [the wiki page](https://wiki.dolphin-emu.org/index.php?title=Monopoly_Streets#Dual_Core_Crash), can't test).
- Enable `EFBAccessEnable` for Need for Speed: Nitro. This is only used during car painting, and has no performance impact anywhere else in the game.
- Set `EarlyXFBOutput` to false for Tetris Worlds and Monsters, Inc. Scream Arena. (Maybe other Radical Entertainment games are affected?)