### PR TITLE
BTReal: bugfix - BT passthrough uses selected device rather than first compatible device in list

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -73,6 +73,13 @@ BluetoothRealDevice::~BluetoothRealDevice()
   SaveLinkKeys();
 }
 
+bool BluetoothRealDevice::HasConfiguredBluetoothDevice()
+{
+  const int configured_vid = Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_VID);
+  const int configured_pid = Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_PID);
+  return configured_vid != -1 && configured_pid != -1;
+}
+
 bool BluetoothRealDevice::IsConfiguredBluetoothDevice(u16 vid, u16 pid)
 {
   const int configured_vid = Config::Get(Config::MAIN_BLUETOOTH_PASSTHROUGH_VID);
@@ -99,6 +106,11 @@ std::optional<IPCReply> BluetoothRealDevice::Open(const OpenRequest& request)
       return true;
     }
 
+    if (HasConfiguredBluetoothDevice() &&
+        !IsConfiguredBluetoothDevice(device_descriptor.idVendor, device_descriptor.idProduct))
+    {
+      return true;
+    }
     if (IsBluetoothDevice(device_descriptor) && OpenDevice(device_descriptor, device))
     {
       unsigned char manufacturer[50] = {}, product[50] = {}, serial_number[50] = {};

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -59,6 +59,7 @@ public:
   void HandleBulkOrIntrTransfer(libusb_transfer* finished_transfer);
 
   static bool IsConfiguredBluetoothDevice(u16 vid, u16 pid);
+  static bool HasConfiguredBluetoothDevice();
 
   struct BluetoothDeviceInfo
   {


### PR DESCRIPTION
I noticed when pairing a genuine adapter (57e:305) with my Steam Deck on build 2506a that if I selected the adapter via the configuration menu or specified it via Dolphin.ini, that the software would still go on to select the internal bluetooth adapter for passthrough. 

This led to a black screen, as expected when using an incompatible bluetooth device for passthrough. 

It looks like the recent changes made to BTReal `IsBluetoothDevice()` allowed the device list loop in `BluetoothRealDevice::Open`  to select the first device that reported back as a bluetooth device whether or not there was a user selection.

SteamOS Holo 3.7.8 build 20250522.2
Kernel 6.11.11-valve14-1-neptune-611-g96885212a919 
Dolphin x86_64 flatpak 2506a, also occurs in master at time of writing
