### PR TITLE
DolphinQt: Fix Windows dark theme when using external stylesheets.

### DIFF
--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -175,40 +175,40 @@ void Settings::ApplyStyle()
   }
 
 #ifdef _WIN32
-  if (stylesheet_contents.isEmpty())
+  // Unlike other OSes we don't automatically get a default dark theme on Windows.
+  // We manually load a dark palette for our included "(Dark)" style,
+  //  and for *any* external style when the system is in "Dark" mode.
+  // Unfortunately it doesn't seem trivial to load a palette based on the stylesheet itself.
+  if (style_type == StyleType::Dark || (style_type != StyleType::Light && IsSystemDark()))
   {
-    // No theme selected or found. Usually we would just fallthrough and set an empty stylesheet
-    // which would select Qt's default theme, but unlike other OSes we don't automatically get a
-    // default dark theme on Windows when the user has selected dark mode in the Windows settings.
-    // So manually check if the user wants dark mode and, if yes, load our embedded dark theme.
-    if (style_type == StyleType::Dark || (style_type != StyleType::Light && IsSystemDark()))
+    if (stylesheet_contents.isEmpty())
     {
       QFile file(QStringLiteral(":/dolphin_dark_win/dark.qss"));
       if (file.open(QFile::ReadOnly))
         stylesheet_contents = QString::fromUtf8(file.readAll().data());
+    }
 
-      QPalette palette = qApp->style()->standardPalette();
-      palette.setColor(QPalette::Window, QColor(32, 32, 32));
-      palette.setColor(QPalette::WindowText, QColor(220, 220, 220));
-      palette.setColor(QPalette::Base, QColor(32, 32, 32));
-      palette.setColor(QPalette::AlternateBase, QColor(48, 48, 48));
-      palette.setColor(QPalette::PlaceholderText, QColor(126, 126, 126));
-      palette.setColor(QPalette::Text, QColor(220, 220, 220));
-      palette.setColor(QPalette::Button, QColor(48, 48, 48));
-      palette.setColor(QPalette::ButtonText, QColor(220, 220, 220));
-      palette.setColor(QPalette::BrightText, QColor(255, 255, 255));
-      palette.setColor(QPalette::Highlight, QColor(0, 120, 215));
-      palette.setColor(QPalette::HighlightedText, QColor(255, 255, 255));
-      palette.setColor(QPalette::Link, QColor(100, 160, 220));
-      palette.setColor(QPalette::LinkVisited, QColor(100, 160, 220));
-      qApp->setPalette(palette);
-    }
-    else
-    {
-      // reset any palette changes that may exist from a previously set dark mode
-      if (s_default_palette)
-        qApp->setPalette(*s_default_palette);
-    }
+    QPalette palette = qApp->style()->standardPalette();
+    palette.setColor(QPalette::Window, QColor(32, 32, 32));
+    palette.setColor(QPalette::WindowText, QColor(220, 220, 220));
+    palette.setColor(QPalette::Base, QColor(32, 32, 32));
+    palette.setColor(QPalette::AlternateBase, QColor(48, 48, 48));
+    palette.setColor(QPalette::PlaceholderText, QColor(126, 126, 126));
+    palette.setColor(QPalette::Text, QColor(220, 220, 220));
+    palette.setColor(QPalette::Button, QColor(48, 48, 48));
+    palette.setColor(QPalette::ButtonText, QColor(220, 220, 220));
+    palette.setColor(QPalette::BrightText, QColor(255, 255, 255));
+    palette.setColor(QPalette::Highlight, QColor(0, 120, 215));
+    palette.setColor(QPalette::HighlightedText, QColor(255, 255, 255));
+    palette.setColor(QPalette::Link, QColor(100, 160, 220));
+    palette.setColor(QPalette::LinkVisited, QColor(100, 160, 220));
+    qApp->setPalette(palette);
+  }
+  else
+  {
+    // reset any palette changes that may exist from a previously set dark mode
+    if (s_default_palette)
+      qApp->setPalette(*s_default_palette);
   }
 #endif
 


### PR DESCRIPTION
This PR only affects the Windows build.

External stylesheets now apply our dark palette based on the system "Dark" mode.
Previously, they would always use the light palette on launch (or the already loaded palette on style change).

Before:
![image](https://github.com/user-attachments/assets/182fcbbd-f9e2-4d8e-9870-0cd04113aa26)

After:
![image](https://github.com/user-attachments/assets/1cf8617c-b3c7-4fec-b441-d401648d2347)

Things still look like "Before" if you use an external stylesheet intended for dark mode.. in light mode, but I think that's a less common situation.