### PR TITLE
GameINI: Disable Dual Core for Rally Championship

### DIFF
--- a/Data/Sys/GameSettings/GRA.ini
+++ b/Data/Sys/GameSettings/GRA.ini
@@ -1,0 +1,11 @@
+# GRAE5Z, GRAP75 - Rally Championship
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.


### PR DESCRIPTION
When selecting cars, this game crashes with GFX FIFO: Unknown Opcode. This is solved by disabling Dual Core, as the error message suggests.

There is no information about this on the Wiki, just a link to a gameplay on YouTube.

This is my first PR here and one of the first ones on GitHub. Due to personal issues I don't have much free time to dedicate to this, but I'm doing my best to get everything right.

https://github.com/user-attachments/assets/24912473-510d-4a53-afa7-dc804d35c574

I've been a Dolphin user since (probably) before Dolphin v3.0, when my hardware could barely run the lightest games at half speed. I can't thank enough everyone who helped build this amazing emulator.