### PR TITLE
VideoCommon: Fix "Force Nearest" texture filter setting.

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1030,6 +1030,11 @@ SamplerState TextureCacheBase::GetSamplerState(u32 index, float custom_tex_scale
   if (g_ActiveConfig.iMaxAnisotropy != AnisotropicFilteringMode::Default &&
       IsAnisostropicEnhancementSafe(tm0))
   {
+    state.tm0.anisotropic_filtering = Common::ToUnderlying(g_ActiveConfig.iMaxAnisotropy);
+  }
+
+  if (state.tm0.anisotropic_filtering != 0)
+  {
     // https://www.opengl.org/registry/specs/EXT/texture_filter_anisotropic.txt
     // For predictable results on all hardware/drivers, only use one of:
     //	GL_LINEAR + GL_LINEAR (No Mipmaps [Bilinear])
@@ -1041,7 +1046,6 @@ SamplerState TextureCacheBase::GetSamplerState(u32 index, float custom_tex_scale
     state.tm0.mag_filter = FilterMode::Linear;
     if (tm0.mipmap_filter != MipMode::None)
       state.tm0.mipmap_filter = FilterMode::Linear;
-    state.tm0.anisotropic_filtering = Common::ToUnderlying(g_ActiveConfig.iMaxAnisotropy);
   }
 
   if (has_arbitrary_mips && tm0.mipmap_filter != MipMode::None)


### PR DESCRIPTION
Non-default anisotropy was always forcing linear filtering.

I broke this in #13368

Before:
![image](https://github.com/user-attachments/assets/f6982cca-4e4d-41e9-b59e-7b3e2c715f10)

After:
![image](https://github.com/user-attachments/assets/a3af6d3d-9223-4d44-bdce-4786316fe984)
