### PR TITLE
IOS/KD: Pad Wii Numbers to 16 digits

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -391,7 +391,7 @@ NWC24::ErrorCode NetKDRequestDevice::KDCheckMail(u32* mail_flag, u32* interval)
 
   // On a real Wii, a response to a challenge is expected and would be verified by KD.
   const std::string hmac_message =
-      fmt::format("{}\nw{}\n{}\n{}", random_number, m_config.Id(), str_mail_flag, str_interval);
+      fmt::format("{}\nw{:016}\n{}\n{}", random_number, m_config.Id(), str_mail_flag, str_interval);
   std::array<u8, 20> hashed{};
   Common::HMAC::HMACWithSHA1(
       MAIL_CHECK_KEY,
@@ -533,7 +533,7 @@ NWC24::ErrorCode NetKDRequestDevice::KDSendMail()
 
   m_send_list.ReadSendList();
   const std::string auth =
-      fmt::format("mlid=w{}\r\npasswd={}", m_config.Id(), m_config.GetPassword());
+      fmt::format("mlid=w{:016}\r\npasswd={}", m_config.Id(), m_config.GetPassword());
   std::vector<Common::HttpRequest::Multiform> multiform = {{"mlid", auth}};
 
   std::vector<u32> mails = m_send_list.GetMailToSend();
@@ -932,8 +932,8 @@ IPCReply NetKDRequestDevice::HandleRequestRegisterUserId(const IOS::HLE::IOCtlRe
 
   const Common::SettingsReader settings_reader{data};
   const std::string serno = settings_reader.GetValue("SERNO");
-  const std::string form_data =
-      fmt::format("mlid=w{}&hdid={}&rgncd={}", m_config.Id(), m_ios.GetIOSC().GetDeviceId(), serno);
+  const std::string form_data = fmt::format("mlid=w{:016}&hdid={}&rgncd={}", m_config.Id(),
+                                            m_ios.GetIOSC().GetDeviceId(), serno);
   const Common::HttpRequest::Response response = m_http.Post(m_config.GetAccountURL(), form_data);
 
   if (!response)


### PR DESCRIPTION
Some Wii Numbers numerically are less than 15 digits. In such a case it should be left 0 padded to 16 digits as shown in the Wii Message Board.

KD sends the Wii Number as a 0 padded string rather than integer, meaning Wii numbers that are less than 16 digits may fail to register to Wii Mail or send mail.