### PR TITLE
CoreTiming: Fix unsafe usage of m_globals.global_timer in ScheduleEvent from non-CPU thread.

### DIFF
--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -186,6 +186,9 @@ private:
   std::vector<Event> m_event_queue;
   u64 m_event_fifo_id = 0;
   std::mutex m_ts_write_lock;
+
+  // Event objects created from other threads.
+  // The time value of each Event here is a cycles_into_future value.
   Common::SPSCQueue<Event> m_ts_queue;
 
   float m_last_oc_factor = 0.0f;

--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -305,17 +305,9 @@ TEST(CoreTiming, ScheduleIntoPast)
 
   AdvanceAndCheck(system, 0, MAX_SLICE_LENGTH, 1000);  // Run cb_chain into late cb_a
 
-  // Schedule late from wrong thread
-  // The problem with scheduling CPU events from outside the CPU Thread is that g_global_timer
-  // is not reliable outside the CPU Thread. It's possible for the other thread to sample the
-  // global timer right before the timer is updated by Advance() then submit a new event using
-  // the stale value, i.e. effectively half-way through the previous slice.
-  // NOTE: We're only testing that the scheduler doesn't break, not whether this makes sense.
+  // Schedule directly into the past from wrong thread.
   Core::UndeclareAsCPUThread();
-  auto& core_timing_globals = core_timing.GetGlobals();
-  core_timing_globals.global_timer -= 1000;
-  core_timing.ScheduleEvent(0, cb_b, CB_IDS[1], CoreTiming::FromThread::NON_CPU);
-  core_timing_globals.global_timer += 1000;
+  core_timing.ScheduleEvent(-1000, cb_b, CB_IDS[1], CoreTiming::FromThread::NON_CPU);
   Core::DeclareAsCPUThread();
   AdvanceAndCheck(system, 1, MAX_SLICE_LENGTH, MAX_SLICE_LENGTH + 1000);
 


### PR DESCRIPTION
When `CoreTimingManager::ScheduleEvent` was called from a non-CPU thread it would read `m_globals.global_timer` which is not thread-safe.

Non-CPU thread scheduled events aren't that frequent, but there are a few instances.
A notable one comes from `DSPManager::GenerateDSPInterruptFromDSPEmu`.

`m_ts_queue` now holds `Event`s with `cycles_into_future` time values and `global_timer` is added later, from the CPU thread in `MoveEvents`.