### PR TITLE
MemoryWidget: Fix hex input validation errors

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -620,10 +620,17 @@ void MemoryWidget::ValidateAndPreviewInputValue()
 
   if (m_base_check->isChecked())
   {
+    // Add 0x to the front of the input (after the '-', if present), but only if the user didn't
+    // already do so.
     if (input_text.startsWith(QLatin1Char('-')))
-      input_text.insert(1, QStringLiteral("0x"));
-    else
+    {
+      if (!input_text.startsWith(QStringLiteral("-0x"), Qt::CaseInsensitive))
+        input_text.insert(1, QStringLiteral("0x"));
+    }
+    else if (!input_text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
+    {
       input_text.prepend(QStringLiteral("0x"));
+    }
   }
 
   QFont font;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -618,7 +618,14 @@ void MemoryWidget::ValidateAndPreviewInputValue()
   if (input_type != Type::ASCII)
     input_text.remove(QLatin1Char(' '));
 
-  if (m_base_check->isChecked())
+  if (input_type == Type::HexString)
+  {
+    // Hex strings are parsed using QByteArray::fromHex which doesn't expect a 0x prefix. If the
+    // user has inserted one, remove it.
+    if (input_text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
+      input_text.remove(0, 2);
+  }
+  else if (m_base_check->isChecked())
   {
     // Add 0x to the front of the input (after the '-', if present), but only if the user didn't
     // already do so.


### PR DESCRIPTION
Fix two similar errors in the validation logic of MemoryWidget's hex input that caused some inputs to fail unnecessarily.

* When the `Hex` box was checked `0x` was added to the front of the input, but if the user also typed `0x` (or `-0x`) that would result in a double prefix that failed validation. This PR skips adding the prefix again in that case.
* When the `Hex Byte String` input type was selected, adding a `0x` prefix or having the `Hex` box checked (or both) would cause validation to fail. This happened because the validation regex doesn't allow for a `0x` prefix, which in turn is because the `QByteArray::fromHex` function which actually parses the input doesn't expect any prefix and would end up adding an extra `00` byte to the front of the output. When `Hex Byte String` is selected this PR skips adding the prefix and removes it from the user's input if present.

The `Hex Byte String` failure when the `Hex` box was checked was particularly troublesome because the checkbox is disabled for that input type; to fix it the user would have to switch to a type that allowed toggling the box, toggle it, then switch back to `Hex Byte String`.