### PR TITLE
PPCSymbolDB: Improve locking

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -80,7 +80,7 @@ void SymbolDB::Index(XFuncMap* functions)
   }
 }
 
-Symbol* SymbolDB::GetSymbolFromName(std::string_view name)
+const Symbol* SymbolDB::GetSymbolFromName(std::string_view name) const
 {
   std::lock_guard lock(m_mutex);
 
@@ -93,10 +93,10 @@ Symbol* SymbolDB::GetSymbolFromName(std::string_view name)
   return nullptr;
 }
 
-std::vector<Symbol*> SymbolDB::GetSymbolsFromName(std::string_view name)
+std::vector<const Symbol*> SymbolDB::GetSymbolsFromName(std::string_view name) const
 {
   std::lock_guard lock(m_mutex);
-  std::vector<Symbol*> symbols;
+  std::vector<const Symbol*> symbols;
 
   for (auto& func : m_functions)
   {
@@ -107,7 +107,7 @@ std::vector<Symbol*> SymbolDB::GetSymbolsFromName(std::string_view name)
   return symbols;
 }
 
-Symbol* SymbolDB::GetSymbolFromHash(u32 hash)
+const Symbol* SymbolDB::GetSymbolFromHash(u32 hash) const
 {
   std::lock_guard lock(m_mutex);
 
@@ -118,7 +118,7 @@ Symbol* SymbolDB::GetSymbolFromHash(u32 hash)
   return *iter->second.begin();
 }
 
-std::vector<Symbol*> SymbolDB::GetSymbolsFromHash(u32 hash)
+std::vector<const Symbol*> SymbolDB::GetSymbolsFromHash(u32 hash) const
 {
   std::lock_guard lock(m_mutex);
 
@@ -133,6 +133,33 @@ std::vector<Symbol*> SymbolDB::GetSymbolsFromHash(u32 hash)
 void SymbolDB::AddCompleteSymbol(const Symbol& symbol)
 {
   std::lock_guard lock(m_mutex);
-  m_functions.emplace(symbol.address, symbol);
+  m_functions[symbol.address] = symbol;
 }
+
+bool SymbolDB::RenameSymbol(const Symbol& symbol, const std::string& symbol_name)
+{
+  std::lock_guard lock(m_mutex);
+
+  auto it = m_functions.find(symbol.address);
+  if (it == m_functions.end())
+    return false;
+
+  it->second.Rename(symbol_name);
+  return true;
+}
+
+bool SymbolDB::RenameSymbol(const Symbol& symbol, const std::string& symbol_name,
+                            const std::string& object_name)
+{
+  std::lock_guard lock(m_mutex);
+
+  auto it = m_functions.find(symbol.address);
+  if (it == m_functions.end())
+    return false;
+
+  it->second.Rename(symbol_name);
+  it->second.object_name = object_name;
+  return true;
+}
+
 }  // namespace Common

--- a/Source/Core/Core/Debugger/DebugInterface.h
+++ b/Source/Core/Core/Debugger/DebugInterface.h
@@ -6,7 +6,6 @@
 #include <cstddef>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -104,7 +103,7 @@ public:
   {
     return 0xFFFFFFFF;
   }
-  virtual std::string_view GetDescription(u32 /*address*/) const = 0;
+  virtual std::string GetDescription(u32 /*address*/) const = 0;
   virtual void Clear(const CPUThreadGuard& guard) = 0;
 };
 }  // namespace Core

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -80,7 +80,7 @@ bool GetCallstack(const Core::CPUThreadGuard& guard, std::vector<CallstackEntry>
   });
 
   WalkTheStack(guard, [&output, &ppc_symbol_db](u32 func_addr) {
-    std::string_view func_desc = ppc_symbol_db.GetDescription(func_addr);
+    std::string func_desc = ppc_symbol_db.GetDescription(func_addr);
     if (func_desc.empty() || func_desc == "Invalid")
       func_desc = "(unknown)";
 
@@ -107,14 +107,14 @@ void PrintCallstack(const Core::CPUThreadGuard& guard, Common::Log::LogType type
     GENERIC_LOG_FMT(type, level, " LR = 0 - this is bad");
   }
 
-  if (const std::string_view lr_desc = ppc_symbol_db.GetDescription(LR(ppc_state));
+  if (const std::string lr_desc = ppc_symbol_db.GetDescription(LR(ppc_state));
       lr_desc != ppc_symbol_db.GetDescription(ppc_state.pc))
   {
     GENERIC_LOG_FMT(type, level, " * {}  [ LR = {:08x} ]", lr_desc, LR(ppc_state));
   }
 
   WalkTheStack(guard, [type, level, &ppc_symbol_db](u32 func_addr) {
-    std::string_view func_desc = ppc_symbol_db.GetDescription(func_addr);
+    std::string func_desc = ppc_symbol_db.GetDescription(func_addr);
     if (func_desc.empty() || func_desc == "Invalid")
       func_desc = "(unknown)";
     GENERIC_LOG_FMT(type, level, " * {} [ addr = {:08x} ]", func_desc, func_addr);

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -439,7 +439,7 @@ u32 PPCDebugInterface::GetColor(const Core::CPUThreadGuard* guard, u32 address) 
 }
 // =============
 
-std::string_view PPCDebugInterface::GetDescription(u32 address) const
+std::string PPCDebugInterface::GetDescription(u32 address) const
 {
   return m_ppc_symbol_db.GetDescription(address);
 }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -102,7 +102,7 @@ public:
   void Step() override {}
   void RunTo(u32 address) override;
   u32 GetColor(const Core::CPUThreadGuard* guard, u32 address) const override;
-  std::string_view GetDescription(u32 address) const override;
+  std::string GetDescription(u32 address) const override;
 
   std::shared_ptr<Core::NetworkCaptureLogger> NetworkLogger();
 

--- a/Source/Core/Core/Debugger/RSO.cpp
+++ b/Source/Core/Core/Debugger/RSO.cpp
@@ -381,7 +381,7 @@ void RSOView::Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) c
     u32 address = GetExportAddress(rso_export);
     if (address != 0)
     {
-      Common::Symbol* symbol = symbol_db->AddFunction(guard, address);
+      const Common::Symbol* symbol = symbol_db->AddFunction(guard, address);
       if (!symbol)
         symbol = symbol_db->GetSymbolFromAddr(address);
 
@@ -389,8 +389,7 @@ void RSOView::Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) c
       if (symbol)
       {
         // Function symbol
-        symbol->Rename(export_name);
-        symbol->object_name = rso_name;
+        symbol_db->RenameSymbol(*symbol, export_name, rso_name);
       }
       else
       {

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -187,7 +187,7 @@ void JitBaseBlockCache::FinalizeBlock(JitBlock& block, bool block_link,
     LinkBlock(block);
   }
 
-  Common::Symbol* symbol = nullptr;
+  const Common::Symbol* symbol = nullptr;
   if (Common::JitRegister::IsEnabled() &&
       (symbol = m_jit.m_ppc_symbol_db.GetSymbolFromAddr(block.effectiveAddress)) != nullptr)
   {

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -35,7 +35,7 @@ PPCSymbolDB::PPCSymbolDB() = default;
 PPCSymbolDB::~PPCSymbolDB() = default;
 
 // Adds the function to the list, unless it's already there
-Common::Symbol* PPCSymbolDB::AddFunction(const Core::CPUThreadGuard& guard, u32 start_addr)
+const Common::Symbol* PPCSymbolDB::AddFunction(const Core::CPUThreadGuard& guard, u32 start_addr)
 {
   std::lock_guard lock(m_mutex);
 
@@ -158,7 +158,7 @@ void PPCSymbolDB::DetermineNoteLayers(XNoteMap* notes)
   }
 }
 
-Common::Symbol* PPCSymbolDB::GetSymbolFromAddr(u32 addr)
+const Common::Symbol* PPCSymbolDB::GetSymbolFromAddr(u32 addr) const
 {
   std::lock_guard lock(m_mutex);
   if (m_functions.empty())
@@ -183,7 +183,7 @@ Common::Symbol* PPCSymbolDB::GetSymbolFromAddr(u32 addr)
   return nullptr;
 }
 
-Common::Note* PPCSymbolDB::GetNoteFromAddr(u32 addr)
+const Common::Note* PPCSymbolDB::GetNoteFromAddr(u32 addr) const
 {
   std::lock_guard lock(m_mutex);
   if (m_notes.empty())
@@ -226,7 +226,7 @@ void PPCSymbolDB::DeleteNote(u32 start_address)
   m_notes.erase(start_address);
 }
 
-std::string_view PPCSymbolDB::GetDescription(u32 addr)
+std::string PPCSymbolDB::GetDescription(u32 addr) const
 {
   if (const Common::Symbol* const symbol = GetSymbolFromAddr(addr))
     return symbol->name;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -21,20 +21,20 @@ public:
   PPCSymbolDB();
   ~PPCSymbolDB() override;
 
-  Common::Symbol* AddFunction(const Core::CPUThreadGuard& guard, u32 start_addr) override;
+  const Common::Symbol* AddFunction(const Core::CPUThreadGuard& guard, u32 start_addr) override;
   void AddKnownSymbol(const Core::CPUThreadGuard& guard, u32 startAddr, u32 size,
                       const std::string& name, const std::string& object_name,
                       Common::Symbol::Type type = Common::Symbol::Type::Function);
   void AddKnownNote(u32 start_addr, u32 size, const std::string& name);
 
-  Common::Symbol* GetSymbolFromAddr(u32 addr) override;
+  const Common::Symbol* GetSymbolFromAddr(u32 addr) const override;
   bool NoteExists() const { return !m_notes.empty(); }
-  Common::Note* GetNoteFromAddr(u32 addr);
+  const Common::Note* GetNoteFromAddr(u32 addr) const;
   void DetermineNoteLayers();
   void DeleteFunction(u32 start_address);
   void DeleteNote(u32 start_address);
 
-  std::string_view GetDescription(u32 addr);
+  std::string GetDescription(u32 addr) const;
 
   void FillInCallers();
 

--- a/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
@@ -160,20 +160,18 @@ bool MEGASignatureDB::Save(const std::string& file_path) const
 
 void MEGASignatureDB::Apply(const Core::CPUThreadGuard& guard, PPCSymbolDB* symbol_db) const
 {
-  for (auto& it : symbol_db->AccessSymbols())
-  {
-    auto& symbol = it.second;
+  symbol_db->ForEachSymbol([&](const Common::Symbol& symbol) {
     for (const auto& sig : m_signatures)
     {
       if (Compare(guard, symbol.address, symbol.size, sig))
       {
-        symbol.name = sig.name;
+        symbol_db->RenameSymbol(symbol, sig.name);
         INFO_LOG_FMT(SYMBOLS, "Found {} at {:08x} (size: {:08x})!", sig.name, symbol.address,
                      symbol.size);
         break;
       }
     }
-  }
+  });
   symbol_db->Index();
 }
 

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -335,7 +335,7 @@ void CodeViewWidget::Update(const Core::CPUThreadGuard* guard)
 
     std::string ins = (split == std::string::npos ? disas : disas.substr(0, split));
     std::string param = (split == std::string::npos ? "" : disas.substr(split + 1));
-    const std::string_view desc = debug_interface.GetDescription(addr);
+    const std::string desc = debug_interface.GetDescription(addr);
 
     const Common::Note* note = m_ppc_symbol_db.GetNoteFromAddr(addr);
     std::string note_string;
@@ -950,7 +950,7 @@ void CodeViewWidget::OnFollowBranch()
 void CodeViewWidget::OnEditSymbol()
 {
   const u32 addr = GetContextAddress();
-  Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
+  const Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
 
   if (symbol == nullptr)
   {
@@ -974,12 +974,14 @@ void CodeViewWidget::OnEditSymbol()
   }
 
   if (symbol->name != name)
-    symbol->Rename(name);
+    m_ppc_symbol_db.RenameSymbol(*symbol, name);
 
   if (symbol->size != size)
   {
     Core::CPUThreadGuard guard(m_system);
-    PPCAnalyst::ReanalyzeFunction(guard, symbol->address, *symbol, size);
+    Common::Symbol new_symbol = *symbol;
+    PPCAnalyst::ReanalyzeFunction(guard, symbol->address, new_symbol, size);
+    m_ppc_symbol_db.AddCompleteSymbol(new_symbol);
   }
 
   emit Host::GetInstance()->PPCSymbolsChanged();
@@ -988,7 +990,7 @@ void CodeViewWidget::OnEditSymbol()
 void CodeViewWidget::OnDeleteSymbol()
 {
   const u32 addr = GetContextAddress();
-  Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
+  const Common::Symbol* const symbol = m_ppc_symbol_db.GetSymbolFromAddr(addr);
 
   if (symbol == nullptr)
     return;
@@ -1039,7 +1041,7 @@ void CodeViewWidget::OnSelectionChanged()
 void CodeViewWidget::OnEditNote()
 {
   const u32 context_address = GetContextAddress();
-  Common::Note* const note = m_ppc_symbol_db.GetNoteFromAddr(context_address);
+  const Common::Note* const note = m_ppc_symbol_db.GetNoteFromAddr(context_address);
 
   if (note == nullptr)
     return;
@@ -1071,7 +1073,7 @@ void CodeViewWidget::OnEditNote()
 void CodeViewWidget::OnDeleteNote()
 {
   const u32 context_address = GetContextAddress();
-  Common::Note* const note = m_ppc_symbol_db.GetNoteFromAddr(context_address);
+  const Common::Note* const note = m_ppc_symbol_db.GetNoteFromAddr(context_address);
 
   if (note == nullptr)
     return;

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -423,14 +423,13 @@ void CodeWidget::UpdateSymbols()
                                 m_symbols_list->selectedItems()[0]->text();
   m_symbols_list->clear();
 
-  for (const auto& symbol : m_ppc_symbol_db.Symbols())
-  {
-    QString name = QString::fromStdString(symbol.second.name);
+  m_ppc_symbol_db.ForEachSymbol([&](const Common::Symbol& symbol) {
+    QString name = QString::fromStdString(symbol.name);
 
     // If the symbol has an object name, add it to the entry name.
-    if (!symbol.second.object_name.empty())
+    if (!symbol.object_name.empty())
     {
-      name += QString::fromStdString(fmt::format(" ({})", symbol.second.object_name));
+      name += QString::fromStdString(fmt::format(" ({})", symbol.object_name));
     }
 
     auto* item = new QListWidgetItem(name);
@@ -438,14 +437,14 @@ void CodeWidget::UpdateSymbols()
       item->setSelected(true);
 
     // Disable non-function symbols as you can't do anything with them.
-    if (symbol.second.type != Common::Symbol::Type::Function)
+    if (symbol.type != Common::Symbol::Type::Function)
       item->setFlags(Qt::NoItemFlags);
 
-    item->setData(Qt::UserRole, symbol.second.address);
+    item->setData(Qt::UserRole, symbol.address);
 
     if (name.contains(m_symbol_filter, Qt::CaseInsensitive))
       m_symbols_list->addItem(item);
-  }
+  });
 
   m_symbols_list->sortItems();
 }
@@ -457,19 +456,18 @@ void CodeWidget::UpdateNotes()
                                 m_note_list->selectedItems()[0]->text();
   m_note_list->clear();
 
-  for (const auto& note : m_ppc_symbol_db.Notes())
-  {
-    const QString name = QString::fromStdString(note.second.name);
+  m_ppc_symbol_db.ForEachNote([&](const Common::Note& note) {
+    const QString name = QString::fromStdString(note.name);
 
     auto* item = new QListWidgetItem(name);
     if (name == selection)
       item->setSelected(true);
 
-    item->setData(Qt::UserRole, note.second.address);
+    item->setData(Qt::UserRole, note.address);
 
     if (name.toUpper().indexOf(m_symbol_filter.toUpper()) != -1)
       m_note_list->addItem(item);
-  }
+  });
 
   m_note_list->sortItems();
 }


### PR DESCRIPTION
https://github.com/dolphin-emu/dolphin/commit/93952381599a791710b21fb3d29d64d05cc635f3 added locking to PPCSymbolDB, but it didn't add locking to all relevant functions, and the way it uses try_lock introduces potential reliability problems. This PR improves seeks to improve the situation, as described further in the commit descriptions.

@TryTwo You probably know the use cases better than me, so could I ask for your help in testing this? I did some basic tests of loading symbol maps, and that seemed to work fine.