### PR TITLE
DolphinQt: Make GameConfigHighlighter better handle large files.

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -7,6 +7,7 @@
 #include <QCompleter>
 #include <QDesktopServices>
 #include <QFile>
+#include <QKeyEvent>
 #include <QMenu>
 #include <QMenuBar>
 #include <QPushButton>

--- a/Source/Core/DolphinQt/Config/GameConfigHighlighter.h
+++ b/Source/Core/DolphinQt/Config/GameConfigHighlighter.h
@@ -5,23 +5,23 @@
 
 #include <vector>
 
-#include <QRegularExpression>
-#include <QSyntaxHighlighter>
-#include <QTextCharFormat>
+#include <QObject>
 
 struct HighlightingRule;
 
-class GameConfigHighlighter : public QSyntaxHighlighter
+class QTextBlock;
+class QTextDocument;
+
+class GameConfigHighlighter : public QObject
 {
   Q_OBJECT
 
 public:
-  explicit GameConfigHighlighter(QTextDocument* parent = nullptr);
+  explicit GameConfigHighlighter(QTextDocument* parent);
   ~GameConfigHighlighter() override;
 
-protected:
-  void highlightBlock(const QString& text) override;
-
 private:
+  void HighlightBlock(const QTextBlock& block);
+
   std::vector<HighlightingRule> m_rules;
 };


### PR DESCRIPTION
This fixes an issue reported on Discord.

To reproduce:
Open the `Properties` for `Monster Hunter Tri`.
Use the `Gecko Codes` `Download Codes` button. (This will create a > 2MB ini file)
Navigate to the `Game Config` `Editor` tab.
The UI will hang.. I think indefinitely..?

`QSyntaxHighlighter` is causing this.. but I don't really know why.
Even just trying to set a format on every block (without regex) inside `highlightBlock` doesn't fix the hang.

This PR manually highlights blocks on `contentsChange`, which works around the issue.