### PR TITLE
DolphinQt: Adjust PostProcessingConfigWindow size on creation.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
@@ -46,6 +46,8 @@ PostProcessingConfigWindow::PostProcessingConfigWindow(EnhancementsWidget* paren
   PopulateGroups();
   Create();
   ConnectWidgets();
+
+  adjustSize();
 }
 
 PostProcessingConfigWindow::~PostProcessingConfigWindow()


### PR DESCRIPTION
Fixes the default undersized window with unusable slider widgets.

Before:
![image](https://github.com/user-attachments/assets/13b6a9ee-bc60-4330-b927-b5be12aa1ab4)

After:
![image](https://github.com/user-attachments/assets/8ef89cbf-0e37-40eb-8f99-e2e06721a7d0)
