### PR TITLE
Android: Bump SDK to 36 and Gradle to 8.13

### DIFF
--- a/Source/Android/app/build.gradle.kts
+++ b/Source/Android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 @Suppress("UnstableApiUsage")
 android {
-    compileSdkVersion = "android-34"
+    compileSdkVersion = "android-36"
     ndkVersion = "27.0.12077973"
 
     buildFeatures {
@@ -40,7 +40,7 @@ android {
     defaultConfig {
         applicationId = "org.dolphinemu.dolphinemu"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 36
 
         versionCode = getBuildVersionCode()
 

--- a/Source/Android/build.gradle.kts
+++ b/Source/Android/build.gradle.kts
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.9.0" apply false
-    id("com.android.library") version "8.9.0" apply false
+    id("com.android.application") version "8.11.0" apply false
+    id("com.android.library") version "8.11.0" apply false
     id("org.jetbrains.kotlin.android") version "1.8.21" apply false
-    id("com.android.test") version "8.9.0" apply false
+    id("com.android.test") version "8.11.0" apply false
     id("androidx.baselineprofile") version "1.3.3" apply false
 }
 

--- a/Source/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Starting August 30, 2025, targeting at least Android 14 (API level 34) will be [required](https://support.google.com/googleplay/android-developer/answer/11926878).
This update sets the target SDK to API level 36 (Android 16), the latest available version.

Dolphin compiles successfully and runs without issues on my Android 16 virtual device.