### PR TITLE
Avoid map/set double lookups

### DIFF
--- a/Source/Core/Common/Assembler/GekkoIRGen.cpp
+++ b/Source/Core/Common/Assembler/GekkoIRGen.cpp
@@ -356,14 +356,13 @@ void GekkoIRPlugin::OnCloseParen(ParenType type)
 void GekkoIRPlugin::OnLabelDecl(std::string_view name)
 {
   const std::string name_str(name);
-  if (m_symset.contains(name_str))
+  if (const bool inserted = m_symset.insert(name_str).second; !inserted)
   {
     m_owner->EmitErrorHere(fmt::format("Label/Constant {} is already defined", name));
     return;
   }
 
   m_labels[name_str] = m_active_block->BlockEndAddress();
-  m_symset.insert(name_str);
 }
 
 void GekkoIRPlugin::OnNumericLabelDecl(std::string_view, u32 num)
@@ -374,14 +373,13 @@ void GekkoIRPlugin::OnNumericLabelDecl(std::string_view, u32 num)
 void GekkoIRPlugin::OnVarDecl(std::string_view name)
 {
   const std::string name_str(name);
-  if (m_symset.contains(name_str))
+  if (const bool inserted = m_symset.insert(name_str).second; !inserted)
   {
     m_owner->EmitErrorHere(fmt::format("Label/Constant {} is already defined", name));
     return;
   }
 
   m_active_var = &m_constants[name_str];
-  m_symset.insert(name_str);
 }
 
 void GekkoIRPlugin::PostParseAction()

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -192,8 +192,8 @@ void AchievementManager::LoadGame(const DiscIO::Volume* volume)
     std::lock_guard lg{m_lock};
 #ifdef RC_CLIENT_SUPPORTS_RAINTEGRATION
     const auto& names = volume->GetLongNames();
-    if (names.contains(DiscIO::Language::English))
-      m_title_estimate = names.at(DiscIO::Language::English);
+    if (const auto it = names.find(DiscIO::Language::English); it != names.end())
+      m_title_estimate = it->second;
     else if (!names.empty())
       m_title_estimate = names.begin()->second;
     else

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -964,8 +964,9 @@ s32 WiiSockMan::NewSocket(s32 af, s32 type, s32 protocol)
 
 s32 WiiSockMan::GetHostSocket(s32 wii_fd) const
 {
-  if (WiiSockets.contains(wii_fd))
-    return WiiSockets.at(wii_fd).fd;
+  auto socket_entry = WiiSockets.find(wii_fd);
+  if (socket_entry != WiiSockets.end())
+    return socket_entry->second.fd;
   return -EBADF;
 }
 

--- a/Source/Core/Core/IOS/USB/Emulated/Skylanders/SkylanderFigure.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Skylanders/SkylanderFigure.cpp
@@ -186,9 +186,10 @@ FigureData SkylanderFigure::GetData() const
 
   auto filter = std::make_pair(figure_data.figure_id, figure_data.variant_id);
   Type type = Type::Item;
-  if (IOS::HLE::USB::list_skylanders.contains(filter))
+  if (const auto it = IOS::HLE::USB::list_skylanders.find(filter);
+      it != IOS::HLE::USB::list_skylanders.end())
   {
-    auto found = IOS::HLE::USB::list_skylanders.at(filter);
+    auto found = it->second;
     type = found.type;
   }
 

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -176,9 +176,9 @@ std::optional<IPCReply> OH0::RegisterRemovalHook(const u64 device_id, const IOCt
 {
   std::lock_guard lock{m_hooks_mutex};
   // IOS only allows a single device removal hook.
-  if (m_removal_hooks.contains(device_id))
+  const bool inserted = m_removal_hooks.try_emplace(device_id, request.address).second;
+  if (!inserted)
     return IPCReply(IPC_EEXIST);
-  m_removal_hooks.insert({device_id, request.address});
   return std::nullopt;
 }
 

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2392,8 +2392,8 @@ void NetPlayClient::RequestGolfControl()
 std::string NetPlayClient::GetCurrentGolfer()
 {
   std::lock_guard lkp(m_crit.players);
-  if (m_players.contains(m_current_golfer))
-    return m_players[m_current_golfer].name;
+  if (const auto it = m_players.find(m_current_golfer); it != m_players.end())
+    return it->second.name;
   return "";
 }
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -290,8 +290,8 @@ void NetPlayServer::ThreadFunc()
         auto& e = m_async_queue.Front();
         if (e.target_mode == TargetMode::Only)
         {
-          if (m_players.contains(e.target_pid))
-            Send(m_players.at(e.target_pid).socket, e.packet, e.channel_id);
+          if (const auto it = m_players.find(e.target_pid); it != m_players.end())
+            Send(it->second.socket, e.packet, e.channel_id);
         }
         else
         {
@@ -794,9 +794,10 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
     u32 cid;
     packet >> cid;
 
-    if (m_chunked_data_complete_count.contains(cid))
+    if (const auto it = m_chunked_data_complete_count.find(cid);
+        it != m_chunked_data_complete_count.end())
     {
-      m_chunked_data_complete_count[cid]++;
+      it->second++;
       m_chunked_data_complete_event.Set();
     }
   }
@@ -839,8 +840,11 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
     if (m_host_input_authority)
     {
       // Prevent crash before game stop if the golfer disconnects
-      if (m_current_golfer != 0 && m_players.contains(m_current_golfer))
-        Send(m_players.at(m_current_golfer).socket, spac);
+      if (m_current_golfer != 0)
+      {
+        if (const auto it = m_players.find(m_current_golfer); it != m_players.end())
+          Send(it->second.socket, spac);
+      }
     }
     else
     {

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -727,12 +727,12 @@ static bool ValidateHeaders(const StateHeader& header)
   std::string loaded_str = header.version_string;
   const u32 loaded_version = header.version_header.version_cookie - COOKIE_BASE;
 
-  if (s_old_versions.contains(loaded_version))
+  if (const auto it = s_old_versions.find(loaded_version); it != s_old_versions.end())
   {
     // This is a REALLY old version, before we started writing the version string to file
     success = false;
 
-    std::pair<std::string, std::string> version_range = s_old_versions.find(loaded_version)->second;
+    std::pair<std::string, std::string> version_range = it->second;
     std::string oldest_version = version_range.first;
     std::string newest_version = version_range.second;
 

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -251,17 +251,18 @@ static std::unique_ptr<QDirIterator> GetIterator(const QString& dir)
 void GameTracker::RemoveDirectoryInternal(const QString& dir)
 {
   RemovePath(dir);
-  auto it = GetIterator(dir);
-  while (it->hasNext())
+  const auto dir_it = GetIterator(dir);
+  while (dir_it->hasNext())
   {
-    QString path = QFileInfo(it->next()).canonicalFilePath();
-    if (m_tracked_files.contains(path))
+    QString path = QFileInfo(dir_it->next()).canonicalFilePath();
+    if (const auto it = m_tracked_files.find(path); it != m_tracked_files.end())
     {
-      m_tracked_files[path].remove(dir);
-      if (m_tracked_files[path].empty())
+      auto& set = *it;
+      set.remove(dir);
+      if (set.isEmpty())
       {
         RemovePath(path);
-        m_tracked_files.remove(path);
+        m_tracked_files.erase(it);
         if (m_started)
           emit GameRemoved(path.toStdString());
       }
@@ -271,16 +272,14 @@ void GameTracker::RemoveDirectoryInternal(const QString& dir)
 
 void GameTracker::UpdateDirectoryInternal(const QString& dir)
 {
-  auto it = GetIterator(dir);
-  while (it->hasNext() && !m_processing_halted)
+  const auto dir_it = GetIterator(dir);
+  while (dir_it->hasNext() && !m_processing_halted)
   {
-    QString path = QFileInfo(it->next()).canonicalFilePath();
+    QString path = QFileInfo(dir_it->next()).canonicalFilePath();
 
-    if (m_tracked_files.contains(path))
+    if (const auto it = m_tracked_files.find(path); it != m_tracked_files.end())
     {
-      auto& tracked_file = m_tracked_files[path];
-      if (!tracked_file.contains(dir))
-        tracked_file.insert(dir);
+      it->insert(dir);
     }
     else
     {
@@ -339,8 +338,7 @@ QSet<QString> GameTracker::FindMissingFiles(const QString& dir)
   while (it->hasNext())
   {
     QString path = QFileInfo(it->next()).canonicalFilePath();
-    if (m_tracked_files.contains(path))
-      missing_files.remove(path);
+    m_tracked_files.remove(path);
   }
 
   return missing_files;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -655,8 +655,9 @@ void NetPlayDialog::UpdateGUI()
 
     auto* name_item = new QTableWidgetItem(QString::fromStdString(p->name));
     name_item->setToolTip(name_item->text());
-    const auto& status_info = player_status.contains(p->game_status) ?
-                                  player_status.at(p->game_status) :
+    const auto it = player_status.find(p->game_status);
+    const auto& status_info = it != player_status.end() ?
+                                  it->second :
                                   std::make_pair(QStringLiteral("?"), QStringLiteral("?"));
     auto* status_item = new QTableWidgetItem(status_info.first);
     status_item->setToolTip(status_info.second);

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
@@ -197,14 +197,13 @@ void GraphicsModManager::Load(const GraphicsModGroupConfig& config)
   {
     for (const GraphicsTargetGroupConfig& group : mod.m_groups)
     {
-      if (m_groups.contains(group.m_name))
+      if (const bool inserted = m_groups.insert(group.m_name).second; !inserted)
       {
         WARN_LOG_FMT(
             VIDEO,
             "Specified graphics mod group '{}' for mod '{}' is already specified by another mod.",
             group.m_name, mod.m_title);
       }
-      m_groups.insert(group.m_name);
 
       const auto internal_group = fmt::format("{}.{}", mod.m_title, group.m_name);
       for (const GraphicsTargetConfig& target : group.m_targets)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -652,8 +652,8 @@ void TextureCacheBase::DoSaveState(PointerWrap& p)
 
       auto refpair1 = std::make_pair(*id1, *id2);
       auto refpair2 = std::make_pair(*id2, *id1);
-      if (!reference_pairs.contains(refpair1) && !reference_pairs.contains(refpair2))
-        reference_pairs.insert(refpair1);
+      if (!reference_pairs.contains(refpair2))
+        reference_pairs.insert(std::move(refpair1));
     }
   }
 


### PR DESCRIPTION
Fix some common anti-patterns with these data structures.

- You can dereference the iterator returned by `find` to access the underlying value directly, without an extra `operator[]`/`at`.
- Rather than checking for an element before insertion/deletion, you can just do the operation and if needed check the return value to determine if the insertion/deletion succeeded.
