### PR TITLE
VideoBackendBase: Remove redundant unique_ptr reset

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -369,7 +369,6 @@ void VideoBackendBase::ShutdownShared()
   g_vertex_manager.reset();
   g_efb_interface.reset();
   g_widescreen.reset();
-  g_presenter.reset();
   g_gfx.reset();
 
   m_initialized = false;


### PR DESCRIPTION
Remove redundant reset of `g_presenter` in `ShutdownShared`, which is already reset earlier in the function.