### PR TITLE
MemoryWidget: Add Symbols and Notes.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -29,8 +29,10 @@
 #include "Core/Core.h"
 #include "Core/HW/AddressSpace.h"
 #include "Core/PowerPC/BreakPoints.h"
+#include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
+#include "DolphinQt/Debugger/EditSymbolDialog.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
@@ -196,7 +198,7 @@ private:
 };
 
 MemoryViewWidget::MemoryViewWidget(Core::System& system, QWidget* parent)
-    : QWidget(parent), m_system(system)
+    : QWidget(parent), m_system(system), m_ppc_symbol_db(m_system.GetPPCSymbolDB())
 {
   auto* layout = new QHBoxLayout();
   layout->setContentsMargins(0, 0, 0, 0);
@@ -371,7 +373,7 @@ void MemoryViewWidget::CreateTable()
   // Span is the number of unique memory values covered in one row.
   const int data_span = m_bytes_per_row / GetTypeSize(m_type);
   m_data_columns = m_dual_view ? data_span * 2 : data_span;
-  const int total_columns = MISC_COLUMNS + m_data_columns;
+  const int total_columns = MISC_COLUMNS + m_data_columns + (m_show_symbols ? 1 : 0);
 
   const int rows =
       std::round((m_table->height() / static_cast<float>(m_table->rowHeight(0))) - 0.25);
@@ -440,6 +442,17 @@ void MemoryViewWidget::CreateTable()
 
       m_table->setItem(i, c + MISC_COLUMNS, item.clone());
     }
+
+    if (!m_show_symbols)
+      continue;
+
+    // Symbols
+    auto* description_item = new QTableWidgetItem(QStringLiteral("-"));
+    description_item->setBackground(QColor(0xFFFFFF));
+    description_item->setForeground(Qt::blue);
+    description_item->setFlags(Qt::ItemIsEnabled);
+
+    m_table->setItem(i, m_table->columnCount() - 1, description_item);
   }
 
   // Update column width
@@ -500,7 +513,27 @@ void MemoryViewWidget::Update()
       item->setBackground(Qt::transparent);
       item->setData(USER_ROLE_VALID_ADDRESS, false);
     }
+
+    if (!m_show_symbols)
+      continue;
+
+    // Fill symbols
+    auto& debug_interface = m_system.GetPowerPC().GetDebugInterface();
+    auto* description_item = m_table->item(i, m_table->columnCount() - 1);
+    std::string desc;
+    const Common::Note* note = m_ppc_symbol_db.GetNoteFromAddr(row_address);
+
+    if (note == nullptr)
+      desc = debug_interface.GetDescription(row_address);
+    else
+      desc = note->name;
+
+    description_item->setText(QString::fromStdString(" " + desc));
+    description_item->setData(USER_ROLE_CELL_ADDRESS, row_address);
   }
+
+  if (m_show_symbols)
+    m_table->resizeColumnToContents(m_table->columnCount() - 1);
 
   UpdateBreakpointTags();
 }
@@ -1055,6 +1088,67 @@ void MemoryViewWidget::OnCopyHex(u32 addr)
       QStringLiteral("%1").arg(value, sizeof(u64) * 2, 16, QLatin1Char('0')).left(length * 2));
 }
 
+void MemoryViewWidget::OnAddNote(u32 addr)
+{
+  std::string name = "";
+  u32 size = 4;
+
+  EditSymbolDialog dialog(this, addr, &size, &name, EditSymbolDialog::Type::Note);
+
+  if (dialog.exec() != QDialog::Accepted)
+    return;
+
+  m_ppc_symbol_db.AddKnownNote(addr, size, name);
+  m_ppc_symbol_db.DetermineNoteLayers();
+  emit Host::GetInstance()->PPCSymbolsChanged();
+  Update();
+}
+
+void MemoryViewWidget::OnEditNote(u32 addr)
+{
+  Common::Note* note = m_ppc_symbol_db.GetNoteFromAddr(addr);
+
+  if (note == nullptr)
+    return;
+
+  std::string name = note->name;
+  u32 size = note->size;
+  const u32 note_address = note->address;
+
+  EditSymbolDialog dialog(this, note_address, &size, &name, EditSymbolDialog::Type::Note);
+
+  if (dialog.exec() != QDialog::Accepted)
+    return;
+
+  if (note->name == name && note->size == size)
+    return;
+
+  m_ppc_symbol_db.AddKnownNote(note_address, size, name);
+  m_ppc_symbol_db.DetermineNoteLayers();
+
+  emit Host::GetInstance()->PPCSymbolsChanged();
+  Update();
+}
+
+void MemoryViewWidget::OnDeleteNote(u32 addr)
+{
+  Common::Note* note = m_ppc_symbol_db.GetNoteFromAddr(addr);
+
+  if (note == nullptr)
+    return;
+
+  m_ppc_symbol_db.DeleteNote(note->address);
+
+  emit Host::GetInstance()->PPCSymbolsChanged();
+  Update();
+}
+
+void MemoryViewWidget::ShowSymbols(bool enable)
+{
+  m_show_symbols = enable;
+  UpdateDispatcher(UpdateType::Full);
+}
+
 void MemoryViewWidget::OnContextMenu(const QPoint& pos)
 {
   auto* item_selected = m_table->itemAt(pos);
@@ -1082,6 +1176,18 @@ void MemoryViewWidget::OnContextMenu(const QPoint& pos)
     QApplication::clipboard()->setText(item_selected->text());
   });
   copy_value->setEnabled(item_has_value);
+
+  menu->addSeparator();
+
+  auto* add_note = menu->addAction(tr("Add Note"), this, [this, addr] { OnAddNote(addr); });
+  auto* edit_note = menu->addAction(tr("Edit Note"), this, [this, addr] { OnEditNote(addr); });
+  auto* delete_note =
+      menu->addAction(tr("Delete Note"), this, [this, addr] { OnDeleteNote(addr); });
+
+  const bool has_note = m_ppc_symbol_db.GetNoteFromAddr(addr) != nullptr;
+  add_note->setEnabled(!has_note);
+  edit_note->setEnabled(has_note);
+  delete_note->setEnabled(has_note);
 
   menu->addSeparator();
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -24,6 +24,8 @@ class CPUThreadGuard;
 class System;
 }  // namespace Core
 
+class PPCSymbolDB;
+
 // Captures direct editing of the table.
 class TableEditDelegate : public QStyledItemDelegate
 {
@@ -98,6 +100,7 @@ public:
   void SetBPType(BPType type);
   void SetAddress(u32 address);
   void SetFocus() const;
+  void ShowSymbols(bool enable);
 
   void SetBPLoggingEnabled(bool enabled);
 
@@ -119,7 +122,11 @@ private:
   std::optional<QString> ValueToString(const Core::CPUThreadGuard& guard, u32 address, Type type);
 
   Core::System& m_system;
+  PPCSymbolDB& m_ppc_symbol_db;
 
+  void OnAddNote(u32 addr);
+  void OnEditNote(u32 addr);
+  void OnDeleteNote(u32 addr);
   MemoryViewTable* m_table;
   QScrollBar* m_scrollbar;
   AddressSpace::Type m_address_space{};
@@ -137,6 +144,7 @@ private:
   int m_alignment = 16;
   int m_data_columns;
   bool m_dual_view = false;
+  bool m_show_symbols = true;
   std::mutex m_updating;
   QColor m_highlight_color = QColor(120, 255, 255, 100);
 

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -17,6 +17,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QListWidget>
 #include <QMenuBar>
 #include <QPushButton>
 #include <QRegularExpression>
@@ -32,6 +33,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/AddressSpace.h"
+#include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/System.h"
 #include "DolphinQt/Debugger/MemoryViewWidget.h"
 #include "DolphinQt/Host.h"
@@ -41,7 +43,7 @@
 using Type = MemoryViewWidget::Type;
 
 MemoryWidget::MemoryWidget(Core::System& system, QWidget* parent)
-    : QDockWidget(parent), m_system(system)
+    : QDockWidget(parent), m_system(system), m_ppc_symbol_db(system.GetPPCSymbolDB())
 {
   setWindowTitle(tr("Memory"));
   setObjectName(QStringLiteral("memory"));
@@ -247,6 +249,17 @@ void MemoryWidget::CreateWidgets()
   bp_layout->addWidget(m_bp_log_check);
   bp_layout->setSpacing(1);
 
+  // Notes
+  m_note_group = new QGroupBox(tr("Notes"));
+  auto* note_layout = new QVBoxLayout;
+  m_note_list = new QListWidget;
+  m_search_notes = new QLineEdit;
+  m_search_notes->setPlaceholderText(tr("Filter Note List"));
+
+  m_note_group->setLayout(note_layout);
+  note_layout->addWidget(m_note_list);
+  note_layout->addWidget(m_search_notes);
+
   // Sidebar
   auto* sidebar = new QWidget;
   auto* sidebar_layout = new QVBoxLayout;
@@ -262,8 +275,9 @@ void MemoryWidget::CreateWidgets()
                          &MemoryWidget::OnSetValueFromFile);
   menubar->addMenu(menu_import);
 
+  // View Menu
   auto* auto_update_action =
-      menu_views->addAction(tr("Auto update memory values"), this, [this](bool checked) {
+      menu_views->addAction(tr("&Auto update memory values"), this, [this](bool checked) {
         m_auto_update_enabled = checked;
         if (checked)
           RegisterAfterFrameEventCallback();
@@ -274,13 +288,22 @@ void MemoryWidget::CreateWidgets()
   auto_update_action->setChecked(true);
 
   auto* highlight_update_action =
-      menu_views->addAction(tr("Highlight recently changed values"), this,
+      menu_views->addAction(tr("&Highlight recently changed values"), this,
                             [this](bool checked) { m_memory_view->ToggleHighlights(checked); });
   highlight_update_action->setCheckable(true);
   highlight_update_action->setChecked(true);
 
-  menu_views->addAction(tr("Highlight color"), this,
+  menu_views->addAction(tr("Highlight &color"), this,
                         [this] { m_memory_view->SetHighlightColor(); });
+
+  auto* show_notes =
+      menu_views->addAction(tr("&Show symbols and notes"), this, [this](bool checked) {
+        m_notes_visible = checked;
+        m_memory_view->ShowSymbols(checked);
+        UpdateNotes();
+      });
+  show_notes->setCheckable(true);
+  show_notes->setChecked(true);
 
   QMenu* menu_export = new QMenu(tr("&Export"), menubar);
   menu_export->addAction(tr("Dump &MRAM"), this, &MemoryWidget::OnDumpMRAM);
@@ -306,6 +329,7 @@ void MemoryWidget::CreateWidgets()
   sidebar_layout->addWidget(address_space_group);
   sidebar_layout->addItem(new QSpacerItem(1, 10));
   sidebar_layout->addWidget(bp_group);
+  sidebar_layout->addWidget(m_note_group);
   sidebar_layout->addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Expanding));
 
   // Splitter
@@ -327,6 +351,7 @@ void MemoryWidget::CreateWidgets()
   auto* widget = new QWidget;
   widget->setLayout(layout);
   setWidget(widget);
+  UpdateNotes();
 }
 
 void MemoryWidget::ConnectWidgets()
@@ -359,6 +384,9 @@ void MemoryWidget::ConnectWidgets()
 
   connect(m_base_check, &QCheckBox::toggled, this, &MemoryWidget::ValidateAndPreviewInputValue);
   connect(m_bp_log_check, &QCheckBox::toggled, this, &MemoryWidget::OnBPLogChanged);
+  connect(m_note_list, &QListWidget::itemClicked, this, &MemoryWidget::OnSelectNote);
+  connect(Host::GetInstance(), &Host::PPCSymbolsChanged, this, &MemoryWidget::UpdateNotes);
+  connect(m_search_notes, &QLineEdit::textChanged, this, &MemoryWidget::OnSearchNotes);
   connect(m_memory_view, &MemoryViewWidget::ShowCode, this, &MemoryWidget::ShowCode);
   connect(m_memory_view, &MemoryViewWidget::RequestWatch, this, &MemoryWidget::RequestWatch);
   connect(m_memory_view, &MemoryViewWidget::ActivateSearch, this,
@@ -779,6 +807,57 @@ void MemoryWidget::OnSetValueFromFile()
     accessors->WriteU8(guard, target_addr.address++, b);
 
   Update();
+}
+
+void MemoryWidget::OnSearchNotes()
+{
+  m_note_filter = m_search_notes->text();
+  UpdateNotes();
+}
+
+void MemoryWidget::OnSelectNote()
+{
+  const auto items = m_note_list->selectedItems();
+  if (items.isEmpty())
+    return;
+
+  const u32 address = items[0]->data(Qt::UserRole).toUInt();
+
+  SetAddress(address);
+}
+
+void MemoryWidget::UpdateNotes()
+{
+  if (!m_notes_visible || m_ppc_symbol_db.Notes().empty())
+  {
+    m_note_group->hide();
+    return;
+  }
+
+  m_note_group->show();
+
+  // Save selection to re-apply.
+  const QString selection = m_note_list->selectedItems().isEmpty() ?
+                                QStringLiteral("") :
+                                m_note_list->selectedItems()[0]->text();
+  m_note_list->clear();
+
+  for (const auto& note : m_ppc_symbol_db.Notes())
+  {
+    const QString name = QString::fromStdString(note.second.name);
+
+    auto* item = new QListWidgetItem(name);
+    if (name == selection)
+      item->setSelected(true);
+
+    item->setData(Qt::UserRole, note.second.address);
+
+    // Filter notes based on the search text.
+    if (name.toUpper().indexOf(m_note_filter.toUpper()) != -1)
+      m_note_list->addItem(item);
+  }
+
+  m_note_list->sortItems();
 }
 
 static void DumpArray(const std::string& filename, const u8* data, size_t length)

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -14,8 +14,11 @@
 class MemoryViewWidget;
 class QCheckBox;
 class QComboBox;
+class QGroupBox;
+class QHideEvent;
 class QLabel;
 class QLineEdit;
+class QListWidget;
 class QPushButton;
 class QRadioButton;
 class QShowEvent;
@@ -26,6 +29,8 @@ namespace Core
 class System;
 class CPUThreadGuard;
 }  // namespace Core
+
+class PPCSymbolDB;
 
 class MemoryWidget : public QDockWidget
 {
@@ -66,6 +71,10 @@ private:
   void OnSetValue();
   void OnSetValueFromFile();
 
+  void OnSearchNotes();
+  void OnSelectNote();
+  void UpdateNotes();
+
   void OnDumpMRAM();
   void OnDumpExRAM();
   void OnDumpARAM();
@@ -85,6 +94,7 @@ private:
   void ActivateSearchAddress();
 
   Core::System& m_system;
+  PPCSymbolDB& m_ppc_symbol_db;
 
   MemoryViewWidget* m_memory_view;
   QSplitter* m_splitter;
@@ -115,6 +125,13 @@ private:
   QRadioButton* m_bp_read_only;
   QRadioButton* m_bp_write_only;
   QCheckBox* m_bp_log_check;
+
+  QGroupBox* m_note_group;
+  QLineEdit* m_search_notes;
+  QListWidget* m_note_list;
+  QString m_note_filter;
+  bool m_notes_visible = true;
+
   Common::EventHook m_vi_end_field_event;
 
   bool m_auto_update_enabled = true;


### PR DESCRIPTION
Adds a note search box to memory widget
Adds a symbols/notes column to MemoryView
Adds option to hide all that in the memory widget views menu.

I'm not sure how interactable normal symbols should be.  Should they be mostly managed in CodeView?  I don't currently have them searchable and editable in the MemoryView, but they will be displayed if no Note is at that address.

![image](https://github.com/user-attachments/assets/eb9a47c5-57b8-4de1-8614-d2e3acb9d73a)



