### PR TITLE
CodeWidget: Add button that locks the view's address

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -181,11 +181,13 @@ CodeViewWidget::CodeViewWidget()
           &CodeViewWidget::OnDebugFontChanged);
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this] {
-    m_address = m_system.GetPPCState().pc;
+    if (!m_lock_address && Core::GetState(m_system) == Core::State::Paused)
+      m_address = m_system.GetPPCState().pc;
     Update();
   });
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, [this] {
-    m_address = m_system.GetPPCState().pc;
+    if (!m_lock_address && Core::GetState(m_system) == Core::State::Paused)
+      m_address = m_system.GetPPCState().pc;
     Update();
   });
   connect(Host::GetInstance(), &Host::PPCSymbolsChanged, this,
@@ -536,6 +538,11 @@ void CodeViewWidget::CalculateBranchIndentation()
 u32 CodeViewWidget::GetAddress() const
 {
   return m_address;
+}
+
+void CodeViewWidget::OnLockAddress(bool lock)
+{
+  m_lock_address = lock;
 }
 
 void CodeViewWidget::SetAddress(u32 address, SetAddressUpdate update)

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -41,6 +41,7 @@ public:
   ~CodeViewWidget() override;
 
   u32 GetAddress() const;
+  void OnLockAddress(bool lock);
   u32 GetContextAddress() const;
   void SetAddress(u32 address, SetAddressUpdate update);
 
@@ -111,6 +112,7 @@ private:
   bool m_updating = false;
 
   u32 m_address = 0;
+  bool m_lock_address = false;
   u32 m_context_address = 0;
 
   std::vector<CodeViewBranch> m_branches;

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -18,6 +18,7 @@
 #include <QStyleHints>
 #include <QTabWidget>
 #include <QTableWidget>
+#include <QToolButton>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -31,6 +32,7 @@
 #include "Core/System.h"
 #include "DolphinQt/Debugger/BranchWatchDialog.h"
 #include "DolphinQt/Host.h"
+#include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
 static const QString BOX_SPLITTER_STYLESHEET = QStringLiteral(
@@ -61,7 +63,7 @@ CodeWidget::CodeWidget(QWidget* parent)
           [this](bool visible) { setHidden(!visible); });
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, [this] {
-    if (Core::GetState(m_system) == Core::State::Paused)
+    if (!m_lock_btn->isChecked() && Core::GetState(m_system) == Core::State::Paused)
       SetAddress(m_system.GetPPCState().pc, CodeViewWidget::SetAddressUpdate::WithoutUpdate);
     Update();
   });
@@ -109,8 +111,16 @@ void CodeWidget::CreateWidgets()
   auto* top_layout = new QHBoxLayout;
   m_search_address = new QLineEdit;
   m_search_address->setPlaceholderText(tr("Search Address"));
+
+  m_lock_btn = new QToolButton();
+  m_lock_btn->setIcon(Resources::GetThemeIcon("pause"));
+  m_lock_btn->setCheckable(true);
+  m_lock_btn->setMinimumSize(24, 24);
+
   m_branch_watch = new QPushButton(tr("Branch Watch"));
+
   top_layout->addWidget(m_search_address);
+  top_layout->addWidget(m_lock_btn);
   top_layout->addWidget(m_branch_watch);
 
   auto* right_layout = new QVBoxLayout;
@@ -191,6 +201,8 @@ void CodeWidget::ConnectWidgets()
 
   connect(m_search_address, &QLineEdit::textChanged, this, &CodeWidget::OnSearchAddress);
   connect(m_search_address, &QLineEdit::returnPressed, this, &CodeWidget::OnSearchAddress);
+  connect(m_lock_btn, &QPushButton::toggled, this,
+          [this](bool checked) { m_code_view->OnLockAddress(checked); });
   connect(m_search_symbols, &QLineEdit::textChanged, this, &CodeWidget::OnSearchSymbols);
   connect(m_search_calls, &QLineEdit::textChanged, this, [this] {
     if (const Common::Symbol* symbol = m_ppc_symbol_db.GetSymbolFromAddr(m_code_view->GetAddress()))

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -17,6 +17,7 @@ class QSplitter;
 class QListWidget;
 class QPushButton;
 class QTableWidget;
+class QToolButton;
 
 namespace Common
 {
@@ -80,6 +81,7 @@ private:
 
   BranchWatchDialog* m_branch_watch_dialog = nullptr;
   QLineEdit* m_search_address;
+  QToolButton* m_lock_btn;
   QPushButton* m_branch_watch;
 
   QLineEdit* m_search_callstack;


### PR DESCRIPTION
Prevents signals such as pausing automatically navigating the view to the PC.

Currently the workflow can be: you nop something, copy the address, press play to see what happens, pause, paste the address to return to the code, continue working.

With this change, you just lock the view, nop, play, pause, continue working.

@sepalani This is a short one if you want to look at it.