### PR TITLE
USBDeviceAddToWhitelistDialog: Use adjustSize for a better default dialog size.

### DIFF
--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -37,6 +37,8 @@ USBDeviceAddToWhitelistDialog::USBDeviceAddToWhitelistDialog(QWidget* parent) : 
 {
   InitControls();
   setLayout(main_layout);
+
+  adjustSize();
 }
 
 void USBDeviceAddToWhitelistDialog::InitControls()


### PR DESCRIPTION
Default size before:
<img width="358" height="336" alt="image" src="https://github.com/user-attachments/assets/51dbda87-d7a8-4ce4-9661-e4102cee87ec" />

After:
<img width="411" height="477" alt="image" src="https://github.com/user-attachments/assets/92f1f590-f794-405b-9b80-f0b067c91fea" />