### PR TITLE
CEXIAgp: Don't create save file if path is empty

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceAGP.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceAGP.cpp
@@ -41,7 +41,8 @@ CEXIAgp::~CEXIAgp()
   SplitPath(Config::Get(Config::GetInfoForAGPCartPath(m_slot)), &path, &filename, &ext);
   gbapath = path + filename;
 
-  SaveFileFromEEPROM(gbapath + ".sav");
+  if (!gbapath.empty())
+    SaveFileFromEEPROM(gbapath + ".sav");
 }
 
 void CEXIAgp::CRC8(const u8* data, u32 size)


### PR DESCRIPTION
Fix creation of a `.sav` file in the current working directory on emulation shutdown when a GameCube device slot is set to `Advance Game Port` and the `GBA Cartridge Path` is empty.

Fixes https://bugs.dolphin-emu.org/issues/12975.