### PR TITLE
USBDeviceAddToWhitelistDialog: Remove examples from VID/PID entry placeholder text.

### DIFF
--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -96,9 +96,9 @@ void USBDeviceAddToWhitelistDialog::InitControls()
   main_layout->addWidget(m_whitelist_buttonbox);
 
   // i18n: VID means Vendor ID (in the context of a USB device)
-  device_vid_textbox->setPlaceholderText(tr("Device VID (e.g., 057e)"));
+  device_vid_textbox->setPlaceholderText(tr("Device VID"));
   // i18n: PID means Product ID (in the context of a USB device), not Process ID
-  device_pid_textbox->setPlaceholderText(tr("Device PID (e.g., 0305)"));
+  device_pid_textbox->setPlaceholderText(tr("Device PID"));
 }
 
 void USBDeviceAddToWhitelistDialog::RefreshDeviceList()

--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -99,6 +99,9 @@ void USBDeviceAddToWhitelistDialog::InitControls()
   device_vid_textbox->setPlaceholderText(tr("Device VID"));
   // i18n: PID means Product ID (in the context of a USB device), not Process ID
   device_pid_textbox->setPlaceholderText(tr("Device PID"));
+
+  device_vid_textbox->setMaxLength(4);
+  device_pid_textbox->setMaxLength(4);
 }
 
 void USBDeviceAddToWhitelistDialog::RefreshDeviceList()


### PR DESCRIPTION
I think the examples are unnecessary and they aren't visible without making the dialog unreasonably wide anyways.
Before:
<img width="298" height="262" alt="image" src="https://github.com/user-attachments/assets/9c824a22-e21b-4ebd-bd52-03aa82afa6b5" />

After:
<img width="298" height="262" alt="image" src="https://github.com/user-attachments/assets/f9cabbdf-a867-4628-a824-8b0c22b1988f" />

I've also limited the length of text entry to 4 characters.