### PR TITLE
Vulkan: Fix present semaphores reuse

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -21,7 +21,7 @@ public:
   explicit CommandBufferManager(bool use_threaded_submission);
   ~CommandBufferManager();
 
-  bool Initialize();
+  bool Initialize(size_t swapchain_image_count);
 
   // These command buffers are allocated per-frame. They are valid until the command buffer
   // is submitted, after that you should call these functions again.
@@ -94,7 +94,7 @@ public:
   void DeferImageViewDestruction(VkImageView object);
 
 private:
-  bool CreateCommandBuffers();
+  bool CreateCommandBuffers(size_t swapchain_image_count);
   void DestroyCommandBuffers();
 
   bool CreateSubmitThread();
@@ -153,7 +153,7 @@ private:
     u32 command_buffer_index;
   };
   Common::WorkQueueThreadSP<PendingCommandBufferSubmit> m_submit_thread;
-  VkSemaphore m_present_semaphore = VK_NULL_HANDLE;
+  std::vector<VkSemaphore> m_present_semaphores = {};
   Common::Flag m_last_present_failed;
   VkResult m_last_present_result = VK_SUCCESS;
   bool m_use_threaded_submission = false;

--- a/Source/Core/VideoBackends/Vulkan/VKMain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKMain.cpp
@@ -187,15 +187,6 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
 
   UpdateActiveConfig();
 
-  // Create command buffers. We do this separately because the other classes depend on it.
-  g_command_buffer_mgr = std::make_unique<CommandBufferManager>(g_Config.bBackendMultithreading);
-  if (!g_command_buffer_mgr->Initialize())
-  {
-    PanicAlertFmt("Failed to create Vulkan command buffers");
-    Shutdown();
-    return false;
-  }
-
   // Remaining classes are also dependent on object cache.
   g_object_cache = std::make_unique<ObjectCache>();
   if (!g_object_cache->Initialize())
@@ -216,6 +207,17 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
       Shutdown();
       return false;
     }
+  }
+
+  // Create command buffers. We do this separately because the other classes depend on it.
+  g_command_buffer_mgr = std::make_unique<CommandBufferManager>(g_Config.bBackendMultithreading);
+  size_t swapchain_image_count =
+      surface != VK_NULL_HANDLE ? swap_chain->GetSwapChainImageCount() : 0;
+  if (!g_command_buffer_mgr->Initialize(swapchain_image_count))
+  {
+    PanicAlertFmt("Failed to create Vulkan command buffers");
+    Shutdown();
+    return false;
   }
 
   if (!StateTracker::CreateInstance())

--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.h
@@ -39,6 +39,7 @@ public:
   u32 GetHeight() const { return m_height; }
   u32 GetCurrentImageIndex() const { return m_current_swap_chain_image_index; }
   bool IsCurrentImageValid() const { return m_current_swap_chain_image_is_valid; }
+  size_t GetSwapChainImageCount() const { return m_swap_chain_images.size(); }
   VkImage GetCurrentImage() const
   {
     return m_swap_chain_images[m_current_swap_chain_image_index].image;


### PR DESCRIPTION
Fixes validation errors.
See https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html

The validation error that is fixed is:
```
45:10:838 VideoBackends/Vulkan/VulkanContext.cpp:860 E[Host GPU]: Vulkan debug message: vkQueueSubmit(): pSubmits[0].pSignalSemaphores[0] (VkSemaphore 0x1b0.000.000.01b) is being signaled by VkQueue 0x7f5.b68.8f8.170, but it may still be in use by VkSwapchainKHR 0x2b0.000.000.02b.
Here are the most recently acquired image indices: [0], 1.
(brackets mark the last use of VkSemaphore 0x1b0.000.000.01b in a presentation operation)
Swapchain image 0 was presented but was not re-acquired, so VkSemaphore 0x1b0.000.000.01b may still be in use and cannot be safely reused with image index 1.
Vulkan insight: One solution is to assign each image its own semaphore. Here are some common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
	a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
	b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: Each binary semaphore element of the pSignalSemaphores member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device (https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html#VUID-vkQueueSubmit-pSignalSemaphores-00067)
```

Briefly tested a few games to see that they were still working.
I only just started studying Vulkan, so maybe this could have been done better.