### PR TITLE
IOFile: Require trivially copyable types

### DIFF
--- a/Source/Core/Common/IOFile.h
+++ b/Source/Core/Common/IOFile.h
@@ -54,6 +54,7 @@ public:
   IOFile Duplicate(const char openmode[]) const;
 
   template <typename T>
+  requires(std::is_trivially_copyable_v<T>)
   bool ReadArray(T* elements, size_t count, size_t* num_read = nullptr)
   {
     size_t read_count = 0;
@@ -67,6 +68,7 @@ public:
   }
 
   template <typename T>
+  requires(std::is_trivially_copyable_v<T>)
   bool WriteArray(const T* elements, size_t count)
   {
     if (!IsOpen() || count != std::fwrite(elements, sizeof(T), count, m_file))


### PR DESCRIPTION
Require `IOFile::ReadArray` and `IOFile::WriteArray` to be called with a trivially copyable type. These functions call [`std::fread`](https://en.cppreference.com/w/cpp/io/c/fread.html) and [`std::fwrite`](https://en.cppreference.com/w/cpp/io/c/fwrite.html) respectively, which trigger undefined behavior when the objects are not trivially copyable.