### PR TITLE
MemoryViewWidget: Fix updates at end of address space

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -473,7 +473,7 @@ void MemoryViewWidget::Update()
   const int data_span = m_bytes_per_row / GetTypeSize(m_type);
 
   m_address_range.first = row_address;
-  m_address_range.second = row_address + m_table->rowCount() * m_bytes_per_row - 1;
+  m_address_range.second = row_address + m_table->rowCount() * m_bytes_per_row;
 
   for (int i = 0; i < m_table->rowCount(); i++, row_address += m_bytes_per_row)
   {
@@ -611,9 +611,13 @@ void MemoryViewWidget::GetValues()
   // Grab memory values as QStrings
   Core::CPUThreadGuard guard(m_system);
 
-  for (u32 address = m_address_range.first; address <= m_address_range.second;
-       address += GetTypeSize(m_type))
+  const u32 type_size = static_cast<u32>(GetTypeSize(m_type));
+  const auto& [range_begin, range_end] = m_address_range;
+  const u32 address_count = (range_end - range_begin) / type_size;
+
+  for (u32 i = 0; i < address_count; ++i)
   {
+    const u32 address = range_begin + i * type_size;
     m_values.insert(std::pair(address, ValueToString(guard, address, m_type)));
 
     if (m_dual_view)


### PR DESCRIPTION
Fix two bugs in the Memory tab that occurred when viewing a memory range starting shortly before `0xffffffff`.

Bug 1: When there was at least one visible memory address at or after `0x0` none of the values would be displayed even when some of the addresses were valid. This happened because the loop condition in `GetValues` immediately returned false since `m_address_range.first > m_address_range.second`, causing `m_values` to be empty. This in turn led every address to be considered `INVALID_MEMORY` in `UpdateColumns`.

Bug 2: When `m_address_range.second` was equal to `0xffffffff` `GetValues` would enter an infinite loop. This happened because `address` would overflow to 0 after printing the last value in the table, causing the loop condition `address <= m_address_range.second` to be true forever.

Bug reproduction common setup:
* In `MemoryWidget`'s `view` menu, check `Auto update memory values` and `Highlight recently changed values`
* Set `Address Space` to `Physical`.
* In `Display Type` select `Fixed Alignment`.
* Start a game. I recommend using a Wii game as they seem to more consistently update certain addresses near 0, making it easier to see when the table is being updated or not. In particular, `0xd8` gets updated pretty much constantly in the games I tested.
* Type 0 in the address field to center the list on address 0.

Bug 1:
* Do the common setup
* Note that there aren't any values shown in the table.
* Scroll down until the top row is at or after `0x0`.
* Note that the table is now filled and updating.
* If you scroll up one row past `0x0` the values will stop updating.
* If you scroll up further the values will be removed.

Bug 2:
* Do the common setup
* Scroll up until the bottom row in the table is `0x0`.
* Not that the game is running normally.
* Scroll up one more row.
* Note that the game is now frozen.
* The CPU thread is now looping forever inside `GetValues`.