### PR TITLE
MemoryWidget: Fix splitter state restoration

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -58,7 +58,7 @@ MemoryWidget::MemoryWidget(Core::System& system, QWidget* parent)
   // macOS: setHidden() needs to be evaluated before setFloating() for proper window presentation
   // according to Settings
   setFloating(settings.value(QStringLiteral("memorywidget/floating")).toBool());
-  m_splitter->restoreState(settings.value(QStringLiteral("codewidget/splitter")).toByteArray());
+  m_splitter->restoreState(settings.value(QStringLiteral("memorywidget/splitter")).toByteArray());
 
   connect(&Settings::Instance(), &Settings::MemoryVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });


### PR DESCRIPTION
Fix a copy-paste error causing `MemoryWidget`'s splitter to load the wrong state data when creating the `MemoryWidget`.

For me this caused the side panel to be scrunched up every time I started Dolphin, but the exact effects probably depend on the state of your `MemoryWidget` and `CodeWidget`.