### PR TITLE
DolphinQt: Put RenderWidget within another QWidget to fix OpenGL window focus detection.

### DIFF
--- a/Source/Core/Core/HotkeyManager.h
+++ b/Source/Core/Core/HotkeyManager.h
@@ -12,7 +12,6 @@
 
 namespace ControllerEmu
 {
-class ControllerEmu;
 class Buttons;
 }  // namespace ControllerEmu
 

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -199,7 +199,6 @@ void GeneralWidget::BackendWarning()
 void GeneralWidget::OnEmulationStateChanged(bool running)
 {
   m_backend_combo->setEnabled(!running);
-  m_render_main_window->setEnabled(!running);
   m_enable_fullscreen->setEnabled(!running);
 
   const bool supports_adapters = !g_backend_info.Adapters.empty();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1566,8 +1566,7 @@ void MainWindow::NetPlayInit()
   Discord::InitNetPlayFunctionality(*m_netplay_discord);
   m_netplay_discord->Start();
 #endif
-  connect(&Settings::Instance(), &Settings::ConfigChanged, this,
-          &MainWindow::UpdateScreenSaverInhibition);
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, &MainWindow::OnConfigChanged);
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &MainWindow::UpdateScreenSaverInhibition);
 }
@@ -1698,6 +1697,18 @@ void MainWindow::NetPlayQuit()
 #ifdef USE_DISCORD_PRESENCE
   Discord::UpdateDiscordPresence();
 #endif
+}
+
+void MainWindow::OnConfigChanged()
+{
+  UpdateScreenSaverInhibition();
+
+  if (m_render_widget->isVisible())
+  {
+    // Handle potential change of "Render to Main Window":
+    if (m_render_window == nullptr || !m_render_window->isFullScreen())
+      ShowRenderWidget();
+  }
 }
 
 void MainWindow::UpdateScreenSaverInhibition()

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -47,6 +47,7 @@ class NetPlaySetupDialog;
 class NetworkWidget;
 class RegisterWidget;
 class RenderWidget;
+class RenderWindow;
 class SearchBar;
 class SettingsWindow;
 class SkylanderPortalWindow;
@@ -126,7 +127,7 @@ private:
 
   void SetFullScreenResolution(bool fullscreen);
 
-  void FullScreen();
+  void ToggleFullScreen();
   void UnlockCursor();
   void ScreenShot();
 
@@ -160,8 +161,15 @@ private:
   void StartGame(const std::vector<std::string>& paths,
                  std::unique_ptr<BootSessionData> boot_session_data = nullptr);
   void StartGame(std::unique_ptr<BootParameters>&& parameters);
+
+  void ShowRenderWidgetOnMainWindow();
+  void ShowRenderWidgetOnSeparateWindow();
+
+  // Show the render widget either on main or separate window, as configured.
   void ShowRenderWidget();
-  void HideRenderWidget(bool reinit = true, bool is_exit = false);
+
+  void HideRenderWidget();
+  void RecreateRenderWidget();
 
   void ShowSettingsWindow();
   void ShowGeneralWindow();
@@ -236,7 +244,7 @@ private:
   SearchBar* m_search_bar;
   GameList* m_game_list;
   RenderWidget* m_render_widget = nullptr;
-  bool m_rendering_to_main;
+  RenderWindow* m_render_window = nullptr;
   bool m_stop_confirm_showing = false;
   bool m_stop_requested = false;
   bool m_exit_requested = false;

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -225,6 +225,7 @@ private:
 
   QStringList PromptFileNames();
 
+  void OnConfigChanged();
   void UpdateScreenSaverInhibition();
 
   void OnStopComplete();

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -17,7 +17,6 @@ public:
   explicit RenderWidget(QWidget* parent = nullptr);
 
   bool event(QEvent* event) override;
-  void showFullScreen();
   QPaintEngine* paintEngine() const override;
   bool IsCursorLocked() const { return m_cursor_locked; }
   void SetCursorLockedOnNextActivation(bool locked = true);
@@ -26,7 +25,6 @@ public:
 
 signals:
   void EscapePressed();
-  void Closed();
   void HandleChanged(void* handle);
   void StateChanged(bool fullscreen);
   void SizeChanged(int new_width, int new_height);
@@ -56,4 +54,10 @@ private:
   bool m_dont_lock_cursor_on_show = false;
   bool m_waiting_for_message_box = false;
   bool m_should_unpause_on_focus = false;
+};
+
+class RenderWindow final : public QWidget
+{
+public:
+  RenderWindow(QWidget* parent, RenderWidget* render_widget, const QString& title);
 };

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -29,7 +29,7 @@ public:
 
   // Modifies the state
   StateData GetState(bool adjusted);
-  StateData GetState(bool adjusted, const ControllerEmu::InputOverrideFunction& override_func);
+  StateData GetState(bool adjusted, const InputOverrideFunction& override_func);
 
   // Yaw movement in radians.
   ControlState GetTotalYaw() const;

--- a/Source/Core/VideoCommon/Present.cpp
+++ b/Source/Core/VideoCommon/Present.cpp
@@ -551,6 +551,12 @@ u32 Presenter::AutoIntegralScale() const
 
 void Presenter::SetSuggestedWindowSize(int width, int height)
 {
+  // "Internal Resolution" == "Auto" with "Auto-Adjust Window Size" will create a feedback loop.
+  // Perhaps IR:Auto could instead use the display resolution when "Auto-Adjust" is enabled ?
+  // For now, these features are incompatible and "Auto-Adjust Window Size" is stopped here.
+  if (g_ActiveConfig.iEFBScale == EFB_SCALE_AUTO_INTEGRAL)
+    return;
+
   // While trying to guess the best window resolution, we can't allow it to use the
   // "AspectMode::Stretch" setting because that would self influence the output result,
   // given it would be based on the previous frame resolution


### PR DESCRIPTION
This fixes the OpenGL window focus issue for me: https://bugs.dolphin-emu.org/issues/13354

For reasons I was unable to figure out, when the `RenderWidget` is its own window with OpenGL +  Wayland, Qt acts like it never has focus.
e.g. `QApplication::activeWindow()` would return `nullptr`.
I tried a bunch of other ways to detect focus, but I couldn't make it work.

Embedding `RenderWidget` within another `QWidget` makes focus detection work properly for me.
It also makes things a tiny bit cleaner since being able to just delete the `RenderWindow` eliminates some `disconnect` and `removeEventFilter` calls.

Cleaning up the includes in `MainWindow.cpp` exposed an invalid `class ControllerEmu` declaration so I've also fixed that in this PR.

This also fixes: https://bugs.dolphin-emu.org/issues/11839

"Render to Main Window" can now be toggled during emulation since fullscreen toggle now effectively requires that functionality.

I still need to verify that I haven't broken some Windows-only features (exclusive fullscreen and cursor locking).

TODO:
 - [x] Fix Fullscreen toggling.
 - [x] Fix out of date window title when render window is dynamically created.
 - [ ] Unbreak window focus on Windows.
 - [ ] Verify that exclusive fullscreen still works.
 - [ ] Verify that resolution changes still work.
 - [ ] Verify that cursor locking still works.