### PR TITLE
Common: Move GetDeviceProperty() into its own header

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -309,6 +309,8 @@ if(WIN32)
     CompatPatches.cpp
     GL/GLInterface/WGL.cpp
     GL/GLInterface/WGL.h
+    WindowsDevice.cpp
+    WindowsDevice.h
     WindowsRegistry.cpp
   )
 elseif(APPLE)

--- a/Source/Core/Common/CommonFuncs.cpp
+++ b/Source/Core/Common/CommonFuncs.cpp
@@ -92,28 +92,5 @@ std::optional<std::wstring> GetModuleName(void* hInstance)
   name.resize(size);
   return name;
 }
-
-std::wstring GetDeviceProperty(const HDEVINFO& device_info, const PSP_DEVINFO_DATA device_data,
-                               const DEVPROPKEY* requested_property)
-{
-  DWORD required_size = 0;
-  DEVPROPTYPE device_property_type;
-  BOOL result;
-
-  result = SetupDiGetDeviceProperty(device_info, device_data, requested_property,
-                                    &device_property_type, nullptr, 0, &required_size, 0);
-  if (!result && GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-    return std::wstring();
-
-  std::vector<TCHAR> unicode_buffer(required_size / sizeof(TCHAR));
-
-  result = SetupDiGetDeviceProperty(
-      device_info, device_data, requested_property, &device_property_type,
-      reinterpret_cast<PBYTE>(unicode_buffer.data()), required_size, nullptr, 0);
-  if (!result)
-    return std::wstring();
-
-  return std::wstring(unicode_buffer.data());
-}
 #endif
 }  // namespace Common

--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -5,11 +5,6 @@
 
 #include <optional>
 #include <string>
-#ifdef _WIN32
-#include <SetupAPI.h>
-#include <cfgmgr32.h>
-#include <devpropdef.h>
-#endif
 
 #include "Common/CommonTypes.h"
 
@@ -64,9 +59,5 @@ std::string GetWin32ErrorString(unsigned long error_code);
 
 // Obtains a full path to the specified module.
 std::optional<std::wstring> GetModuleName(void* hInstance);
-
-// Obtains a device property and returns it as a wide string.
-std::wstring GetDeviceProperty(const HANDLE& device_info, const PSP_DEVINFO_DATA device_data,
-                               const DEVPROPKEY* requested_property);
 #endif
 }  // namespace Common

--- a/Source/Core/Common/WindowsDevice.cpp
+++ b/Source/Core/Common/WindowsDevice.cpp
@@ -1,0 +1,38 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifdef _WIN32
+
+#include "Common/WindowsDevice.h"
+
+#include <string>
+
+#include "Common/CommonFuncs.h"
+
+namespace Common
+{
+std::wstring GetDeviceProperty(const HDEVINFO& device_info, const PSP_DEVINFO_DATA device_data,
+                               const DEVPROPKEY* requested_property)
+{
+  DWORD required_size = 0;
+  DEVPROPTYPE device_property_type;
+  BOOL result;
+
+  result = SetupDiGetDeviceProperty(device_info, device_data, requested_property,
+                                    &device_property_type, nullptr, 0, &required_size, 0);
+  if (!result && GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    return std::wstring();
+
+  std::vector<TCHAR> unicode_buffer(required_size / sizeof(TCHAR));
+
+  result = SetupDiGetDeviceProperty(
+      device_info, device_data, requested_property, &device_property_type,
+      reinterpret_cast<PBYTE>(unicode_buffer.data()), required_size, nullptr, 0);
+  if (!result)
+    return std::wstring();
+
+  return std::wstring(unicode_buffer.data());
+}
+}  // namespace Common
+
+#endif

--- a/Source/Core/Common/WindowsDevice.h
+++ b/Source/Core/Common/WindowsDevice.h
@@ -1,0 +1,29 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#ifdef _WIN32
+
+#include <string>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+
+#include <SetupAPI.h>
+#include <cfgmgr32.h>
+#include <devpropdef.h>
+
+namespace Common
+{
+// Obtains a device property and returns it as a wide string.
+std::wstring GetDeviceProperty(const HANDLE& device_info, const PSP_DEVINFO_DATA device_data,
+                               const DEVPROPKEY* requested_property);
+}  // namespace Common
+
+#endif

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -30,6 +30,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
 #include "Common/Thread.h"
+#include "Common/WindowsDevice.h"
 #include "Core/HW/WiimoteCommon/DataReport.h"
 #include "Core/HW/WiimoteCommon/WiimoteConstants.h"
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -19,12 +19,11 @@
 #ifdef __LIBUSB__
 #include <libusb.h>
 #endif
+
 #ifdef _WIN32
 #include <SetupAPI.h>
 #include <cfgmgr32.h>
 #include <devpkey.h>
-
-#include "Common/CommonFuncs.h"
 #endif
 
 #include "Common/ChunkFile.h"
@@ -34,6 +33,10 @@
 #include "Core/IOS/USB/Common.h"
 #include "Core/IOS/USB/USBScanner.h"
 #include "Core/System.h"
+
+#ifdef _WIN32
+#include "Common/WindowsDevice.h"
+#endif
 
 namespace IOS::HLE
 {

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -178,6 +178,7 @@
     <ClInclude Include="Common\VariantUtil.h" />
     <ClInclude Include="Common\Version.h" />
     <ClInclude Include="Common\WaitableFlag.h" />
+    <ClInclude Include="Common\WindowsDevice.h" />
     <ClInclude Include="Common\WindowsRegistry.h" />
     <ClInclude Include="Common\WindowSystemInfo.h" />
     <ClInclude Include="Common\WorkQueueThread.h" />
@@ -861,6 +862,7 @@
     <ClCompile Include="Common\TimeUtil.cpp" />
     <ClCompile Include="Common\TraversalClient.cpp" />
     <ClCompile Include="Common\UPnP.cpp" />
+    <ClCompile Include="Common\WindowsDevice.cpp" />
     <ClCompile Include="Common\WindowsRegistry.cpp" />
     <ClCompile Include="Common\Version.cpp" />
     <ClCompile Include="Core\AchievementManager.cpp" />


### PR DESCRIPTION
Otherwise we include the notoriously finnicky and define-filled Windows headers in the entire codebase through CommonFuncs.h

(note: this was needed for me to compile on Windows with CMake, the tests would fail to compile otherwise)