### PR TITLE
DolphinQt: Stop re-enabling Code widget when toggling debug mode

### DIFF
--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -518,8 +518,6 @@ void Settings::SetDebugModeEnabled(bool enabled)
   {
     Config::SetBaseOrCurrent(Config::MAIN_ENABLE_DEBUGGING, enabled);
     emit DebugModeToggled(enabled);
-    if (enabled)
-      SetCodeVisible(true);
   }
 }
 
@@ -599,7 +597,7 @@ void Settings::SetCodeVisible(bool enabled)
 
 bool Settings::IsCodeVisible() const
 {
-  return GetQSettings().value(QStringLiteral("debugger/showcode")).toBool();
+  return GetQSettings().value(QStringLiteral("debugger/showcode"), true).toBool();
 }
 
 void Settings::SetMemoryVisible(bool enabled)


### PR DESCRIPTION
It is useful enough for the Code widget to be enabled the first time debugging is enabled, but it should not be re-enabled every time the setting is toggled off and then back on. This also ensures that the interface is consistent if debugging is enabled without using the checkbox.