### PR TITLE
CodeViewWidget: Improve Update performance

### DIFF
--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -622,6 +622,7 @@ bool PPCSymbolDB::LoadMap(const Core::CPUThreadGuard& guard, std::string filenam
 
   Index(&new_functions);
   DetermineNoteLayers(&new_notes);
+  FillInCallers();
 
   std::lock_guard lock(m_mutex);
   std::swap(m_functions, new_functions);

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -433,8 +433,6 @@ void CodeViewWidget::Update(const Core::CPUThreadGuard* guard)
 
   CalculateBranchIndentation();
 
-  m_ppc_symbol_db.FillInCallers();
-
   repaint();
   m_updating = false;
 }


### PR DESCRIPTION
I believe the expensive `FillInCallers` call in `CodeViewWidget::Update` is unnecessary. From what I can see callers will be recalculated in `UpdateFunctionCallers` in `CodeWidget` on demand.

This brings `CodeViewWidget::Update` from ~20ms per update to ~10ms on my machine, making scrolling with the mouse much snappier. Now if only Qt allowed aggregating scroll events...