### PR TITLE
externals: allow using watcher header library from the system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -786,7 +786,9 @@ if (USE_RETRO_ACHIEVEMENTS)
 	add_subdirectory(Externals/rcheevos)
 endif()
 
-add_subdirectory(Externals/watcher)
+dolphin_find_optional_system_library_pkgconfig(
+  WATCHER watcher watcher Externals/watcher
+)
 
 ########################################
 # Pre-build events: Define configuration variables and write SCM info header


### PR DESCRIPTION
* CMake/DolphinLibraryTools.cmake (dolphin_find_optional_system_library_include): New function.
* CMakeLists.txt: Use it to locate the watcher header-only library.