### PR TITLE
Dolphin/allow system tinygltf

### DIFF
--- a/CMake/DolphinLibraryTools.cmake
+++ b/CMake/DolphinLibraryTools.cmake
@@ -1,17 +1,6 @@
 include(CheckCXXSourceCompiles)
 include(CheckCXXSymbolExists)
 
-# like add_library(new ALIAS old) but avoids add_library cannot create ALIAS target "new" because target "old" is imported but not globally visible. on older cmake
-# This can be replaced with a direct alias call once our minimum is cmake 3.18
-function(dolphin_alias_library new old)
-  string(REPLACE "::" "" library_no_namespace ${old})
-  if (NOT TARGET _alias_${library_no_namespace})
-    add_library(_alias_${library_no_namespace} INTERFACE)
-    target_link_libraries(_alias_${library_no_namespace} INTERFACE ${old})
-  endif()
-  add_library(${new} ALIAS _alias_${library_no_namespace})
-endfunction()
-
 # Makes an imported target if it doesn't exist.  Useful for when find scripts from older versions of cmake don't make the targets you need
 function(dolphin_make_imported_target_if_missing target lib)
   if(${lib}_FOUND AND NOT TARGET ${target})
@@ -135,7 +124,7 @@ function(dolphin_find_optional_system_library_pkgconfig library search alias bun
   if(${library}_FOUND)
     dolphin_set_library_type(${library} "System")
     message(STATUS "Using system ${library}")
-    dolphin_alias_library(${alias} PkgConfig::${library})
+    add_library(${alias} ALIAS PkgConfig::${library})
   else()
     dolphin_set_library_type(${library} "Bundled")
     dolphin_add_bundled_library(${library} ${use_system} ${bundled_path})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,7 +626,8 @@ dolphin_find_optional_system_library(glslang Externals/glslang DOLPHIN_TRY_VERSI
 if(WIN32 OR APPLE)
   add_subdirectory(Externals/spirv_cross)
 endif()
-add_subdirectory(Externals/tinygltf)
+
+dolphin_find_optional_system_library(TinyGLTF Externals/tinygltf)
 
 if(ENABLE_VULKAN)
   add_definitions(-DHAS_VULKAN)

--- a/Externals/tinygltf/CMakeLists.txt
+++ b/Externals/tinygltf/CMakeLists.txt
@@ -7,5 +7,7 @@ if (NOT MSVC)
 endif()
 target_sources(tinygltf PRIVATE
   tinygltf/tiny_gltf.cc)
-target_include_directories(tinygltf INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(tinygltf INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/tinygltf)
 dolphin_disable_warnings(tinygltf)
+
+add_library(tinygltf::tinygltf ALIAS tinygltf)

--- a/Source/Core/VideoCommon/Assets/MeshAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/MeshAsset.cpp
@@ -6,7 +6,7 @@
 #include <array>
 #include <utility>
 
-#include <tinygltf/tiny_gltf.h>
+#include <tiny_gltf.h>
 
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -247,7 +247,7 @@ PRIVATE
   imgui
   implot
   glslang::SPIRV
-  tinygltf
+  tinygltf::tinygltf
 )
 
 if(_M_X86_64)


### PR DESCRIPTION
This makes it possible to use a system provided tinygltf library instead of the bundled one.