### PR TITLE
Common/Timer: Add a SteadyAwakeClock class to make play time tracking ignore time while suspended.

### DIFF
--- a/Source/Core/Common/Timer.h
+++ b/Source/Core/Common/Timer.h
@@ -50,4 +50,19 @@ private:
 #endif
 };
 
+// Similar to std::chrono::steady_clock except this clock
+// specifically does *not* count time while the system is suspended.
+class SteadyAwakeClock
+{
+public:
+  using rep = s64;
+  using period = std::nano;
+  using duration = std::chrono::duration<rep, period>;
+  using time_point = std::chrono::time_point<SteadyAwakeClock>;
+
+  static constexpr bool is_steady = true;
+
+  static time_point now();
+};
+
 }  // Namespace Common

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -72,8 +72,8 @@ void CPUManager::StartTimePlayedTimer()
 {
   Common::SetCurrentThreadName("Play Time Tracker");
 
-  // Steady clock for greater accuracy of timing
-  std::chrono::steady_clock timer;
+  // Use a clock that will appropriately ignore suspended system time.
+  Common::SteadyAwakeClock timer;
   auto prev_time = timer.now();
 
   while (true)


### PR DESCRIPTION
Fixes: https://bugs.dolphin-emu.org/issues/13844

Linux and Windows are tested.

FreeBSD and macOS are untested, but documentation implies they will function appropriately.