### PR TITLE
GameConfigWidget: Unify tooltips

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -112,14 +112,16 @@ void GameConfigWidget::CreateWidgets()
   m_deterministic_dual_core =
       new ConfigStringChoice(choice, Config::MAIN_GPU_DETERMINISM_MODE, layer);
 
-  m_enable_mmu->setToolTip(tr(
+  m_enable_mmu->SetDescription(tr(
       "Enables the Memory Management Unit, needed for some games. (ON = Compatible, OFF = Fast)"));
 
-  m_enable_fprf->setToolTip(tr("Enables Floating Point Result Flag calculation, needed for a few "
-                               "games. (ON = Compatible, OFF = Fast)"));
-  m_sync_gpu->setToolTip(tr("Synchronizes the GPU and CPU threads to help prevent random freezes "
-                            "in Dual core mode. (ON = Compatible, OFF = Fast)"));
-  m_emulate_disc_speed->setToolTip(
+  m_enable_fprf->SetDescription(
+      tr("Enables Floating Point Result Flag calculation, needed for a few "
+         "games. (ON = Compatible, OFF = Fast)"));
+  m_sync_gpu->SetDescription(
+      tr("Synchronizes the GPU and CPU threads to help prevent random freezes "
+         "in Dual core mode. (ON = Compatible, OFF = Fast)"));
+  m_emulate_disc_speed->SetDescription(
       tr("Enable emulated disc speed. Disabling this can cause crashes "
          "and other problems in some games. "
          "(ON = Compatible, OFF = Unlocked)"));
@@ -143,11 +145,11 @@ void GameConfigWidget::CreateWidgets()
   m_use_monoscopic_shadows =
       new ConfigBool(tr("Monoscopic Shadows"), Config::GFX_STEREO_EFB_MONO_DEPTH, layer);
 
-  m_depth_slider->setToolTip(
+  m_depth_slider->SetDescription(
       tr("This value is multiplied with the depth set in the graphics configuration."));
-  m_convergence_spin->setToolTip(
+  m_convergence_spin->SetDescription(
       tr("This value is added to the convergence value set in the graphics configuration."));
-  m_use_monoscopic_shadows->setToolTip(
+  m_use_monoscopic_shadows->SetDescription(
       tr("Use a single depth buffer for both eyes. Needed for a few games."));
 
   stereoscopy_layout->addWidget(new ConfigSliderLabel(tr("Depth Percentage:"), m_depth_slider), 0,


### PR DESCRIPTION
The widgets in the `Properties`->`Game Config`->`General` tab currently have their titles appear by themselves in a `BalloonTip` and their descriptions appear in a separate standard tooltip.

Use `ToolTipWidget::SetDescription` insead of `QWidget::setTooltip` to put the description in the `BalloonTip` instead.

Before:
<img width="617" height="125" alt="Before" src="https://github.com/user-attachments/assets/5b04e5e0-cad6-48c2-8082-ed18cf054359" />
After:
<img width="547" height="97" alt="After" src="https://github.com/user-attachments/assets/11e2db84-e01e-40f2-97db-eb4f398a668e" />
