### PR TITLE
InputCommon/ControllerEmu: Fix saving of Wii Remote "MotionPlus Attached" setting.

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
@@ -77,6 +77,8 @@ void Attachments::LoadConfig(Common::IniFile::Section* sec, const std::string& b
 
 void Attachments::SaveConfig(Common::IniFile::Section* sec, const std::string& base)
 {
+  ControlGroup::SaveConfig(sec, base);
+
   if (GetSelectionSetting().IsSimpleValue())
   {
     sec->Set(base + name, GetAttachmentList()[GetSelectedAttachment()]->GetName(), "None");


### PR DESCRIPTION
It appears I broke this in #13295

I missed a `ControlGroup::SaveConfig` call in `Attachments::SaveConfig`.
The only base class functionality is the "Attach MotionPlus" setting so this went unnoticed.