### PR TITLE
Boot: Fix RetroAchievements for GameCube games launched with IPL

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -632,8 +632,10 @@ bool CBoot::BootUp(Core::System& system, const Core::CPUThreadGuard& guard,
         SetDisc(system.GetDVDInterface(), DiscIO::CreateDisc(ipl.disc->path),
                 ipl.disc->auto_disc_change_paths);
       }
-
-      AchievementManager::GetInstance().LoadGame(nullptr);
+      else
+      {
+        AchievementManager::GetInstance().LoadGame(nullptr);
+      }
 
       SConfig::OnTitleDirectlyBooted(guard);
       return true;


### PR DESCRIPTION
The SetDisc function calls AchievementManager::LoadGame with the game's volume. Calling AchievementManager::LoadGame again afterwards with nullptr prevents RetroAchievements from working.