### PR TITLE
Android: Don't let RetroAchievements override onPause

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -362,7 +362,7 @@ public final class NativeLibrary
   /**
    * Pauses emulation.
    */
-  public static native void PauseEmulation();
+  public static native void PauseEmulation(boolean overrideAchievementRestrictions);
 
   /**
    * Stops emulation.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
@@ -455,7 +455,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             MENU_ACTION_REFRESH_WIIMOTES -> NativeLibrary.RefreshWiimotes()
             MENU_ACTION_PAUSE_EMULATION -> {
                 hasUserPausedEmulation = true
-                NativeLibrary.PauseEmulation()
+                NativeLibrary.PauseEmulation(false)
             }
 
             MENU_ACTION_UNPAUSE_EMULATION -> {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
@@ -109,7 +109,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     override fun onPause() {
         if (NativeLibrary.IsRunningAndUnpaused() && !NativeLibrary.IsShowingAlertMessage()) {
             Log.debug("[EmulationFragment] Pausing emulation.")
-            NativeLibrary.PauseEmulation()
+            NativeLibrary.PauseEmulation(true)
         }
         super.onPause()
     }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -271,10 +271,12 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_UnPauseEmula
   Core::SetState(Core::System::GetInstance(), Core::State::Running);
 }
 
-JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulation(JNIEnv*, jclass)
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulation(
+    JNIEnv*, jclass, bool override_achievement_restrictions)
 {
   HostThreadLock guard;
-  Core::SetState(Core::System::GetInstance(), Core::State::Paused);
+  Core::SetState(Core::System::GetInstance(), Core::State::Paused, true,
+                 override_achievement_restrictions);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulation(JNIEnv*, jclass)

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -672,7 +672,7 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
 // Set or get the running state
 
 void SetState(Core::System& system, State state, bool report_state_change,
-              bool initial_execution_state)
+              bool override_achievement_restrictions)
 {
   // State cannot be controlled until the CPU Thread is operational
   if (s_state.load() != State::Running)
@@ -682,7 +682,7 @@ void SetState(Core::System& system, State state, bool report_state_change,
   {
   case State::Paused:
 #ifdef USE_RETRO_ACHIEVEMENTS
-    if (!initial_execution_state && !AchievementManager::GetInstance().CanPause())
+    if (!override_achievement_restrictions && !AchievementManager::GetInstance().CanPause())
       return;
 #endif  // USE_RETRO_ACHIEVEMENTS
     // NOTE: GetState() will return State::Paused immediately, even before anything has

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -146,7 +146,7 @@ bool WantsDeterminism();
 
 // [NOT THREADSAFE] For use by Host only
 void SetState(Core::System& system, State state, bool report_state_change = true,
-              bool initial_execution_state = false);
+              bool override_achievement_restrictions = false);
 State GetState(Core::System& system);
 
 void SaveScreenShot();


### PR DESCRIPTION
When Android sends Dolphin to the background, emulation *must* pause, otherwise emulation continues running and continues outputting audio to the user. RetroAchievements mustn't be allowed to override it.