### PR TITLE
HW/EXI_DeviceEthernet: Make interrupt state atomic.

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -269,7 +269,7 @@ private:
 
     u8 revision_id = 0;  // 0xf0
     u8 interrupt_mask = 0;
-    u8 interrupt = 0;
+    std::atomic<u8> interrupt = 0;
     u16 device_id = 0xD107;
     u8 acstart = 0x4E;
     u32 hash_challenge = 0;


### PR DESCRIPTION
`exi_status.interrupt` is read and written from the core thread, but also a worker thread function,`BuiltInBBAInterface::ReadThreadHandler` calls `CEXIETHERNET::RecvHandlePacket` to set a bit when data is received.
https://github.com/dolphin-emu/dolphin/blob/4d0cf1315e599bbeed67ef9eca993874869e3e85/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp#L637

I have only just begun to look at the EXI_DeviceEthernet code, and other parts are potentially questionable, but I think this addresses a particularly egregious case of thread unsafety.

I figure explicit memory orders can be specified in another PR.