### PR TITLE
GameINI: Disable ImmediateXFB for Pétanque Master

### DIFF
--- a/Data/Sys/GameSettings/SP4.ini
+++ b/Data/Sys/GameSettings/SP4.ini
@@ -1,0 +1,5 @@
+# SP4PJW - Pétanque Master
+
+[Video_Hacks]
+# Immediate XFB causes seizure-inducing flickering
+ImmediateXFBEnable = False


### PR DESCRIPTION
Having ImmediateXFB enabled in _Pétanque Master_ causes the game to lag immensely and have seizure-inducing flickering visuals, so it is disabled by this PR.