### PR TITLE
JitArm64_Integer: Minor subfe optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -6,18 +6,14 @@
 #include <bit>
 
 #include "Common/Arm64Emitter.h"
-#include "Common/Assert.h"
-#include "Common/BitUtils.h"
+#include "Common/ArmCommon.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 
-#include "Core/Core.h"
-#include "Core/CoreTiming.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/JitArm64/JitArm64_RegCache.h"
 #include "Core/PowerPC/JitCommon/DivUtils.h"
 #include "Core/PowerPC/PPCTables.h"
-#include "Core/PowerPC/PowerPC.h"
 
 using namespace Arm64Gen;
 using namespace JitCommon;


### PR DESCRIPTION
Some cases I missed in #13251.

<details><summary>Constant zero with InHostCarry</summary>

Before:
```
0x5280001a   mov    w26, #0x0                 ; =0
0x1a1f035a   adc    w26, w26, wzr
```
After:
```
0x1a9f37fa   cset   w26, hs
```
</details>

<details><summary>Explicitly handle a == b</summary>

Before:
```
0x7a1b037a   sbcs   w26, w27, w27
```
After:
```
0x5a9f23fa   csetm  w26, lo
```
</details>