### PR TITLE
Android: Opt out of back invoked callback

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true"
         android:preserveLegacyExternalStorage="true"
+        android:enableOnBackInvokedCallback="false"
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_rules"
         android:dataExtractionRules="@xml/backup_rules_api_31"


### PR DESCRIPTION
When PR #13789 changed our target SDK version to Android 16, it made Android 16 stop calling `onBackPressed` and stop delivering `KEYCODE_BACK` events. Dolphin's code isn't ready for that yet.

Android lets us opt out of this new behavior for now, so let's do so. But the opt-out will presumably stop working once we start targeting Android 17, so we're going to have to update Dolphin's code within the next one or two years to support the replacement API.