### PR TITLE
Game List: Fix games not being displayed

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -338,7 +338,8 @@ QSet<QString> GameTracker::FindMissingFiles(const QString& dir)
   while (it->hasNext())
   {
     QString path = QFileInfo(it->next()).canonicalFilePath();
-    m_tracked_files.remove(path);
+    if (m_tracked_files.contains(path))
+      missing_files.remove(path);
   }
 
   return missing_files;


### PR DESCRIPTION
Fix a regression from https://github.com/dolphin-emu/dolphin/pull/13794/ that causes games to not show up in the GameList.  Resolves https://bugs.dolphin-emu.org/issues/13855.

Credit to @Amphitryon0 for pinpointing the cause.