### PR TITLE
Host: Remove unnecessary functions

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -163,10 +163,6 @@ void Host_JitProfileDataWiped()
 {
 }
 
-void Host_UpdateMainFrame()
-{
-}
-
 void Host_RequestRenderWindowSize(int width, int height)
 {
   std::thread jnicall(UpdatePointer);

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -110,10 +110,6 @@ void Host_PPCBreakpointsChanged()
 {
 }
 
-void Host_RefreshDSPDebuggerWindow()
-{
-}
-
 bool Host_UIBlocksControllerState()
 {
   return false;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -242,8 +242,6 @@ bool Init(Core::System& system, std::unique_ptr<BootParameters> boot, const Wind
   INFO_LOG_FMT(BOOT, "Starting core = {} mode", system.IsWii() ? "Wii" : "GameCube");
   INFO_LOG_FMT(BOOT, "CPU Thread separate = {}", system.IsDualCoreMode() ? "Yes" : "No");
 
-  Host_UpdateMainFrame();  // Disable any menus or buttons at boot
-
   // Manually reactivate the video backend in case a GameINI overrides the video backend setting.
   VideoBackendBase::PopulateBackendInfo(wsi);
 
@@ -342,7 +340,6 @@ static void CPUSetInitialExecutionState(bool force_paused = false)
     bool paused = SConfig::GetInstance().bBootToPause || force_paused;
     SetState(system, paused ? State::Paused : State::Running, true, true);
     Host_UpdateDisasmDialog();
-    Host_UpdateMainFrame();
     Host_Message(HostMessageID::WMUserCreate);
   });
 }

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -482,8 +482,6 @@ int DSPCore::RunCycles(int cycles)
 
       m_dsp_interpreter->Step();
       cycles--;
-
-      Host::UpdateDebugger();
       break;
     case State::Stopped:
       break;
@@ -519,8 +517,6 @@ void DSPCore::SetState(State new_state)
   // kick the event, in case we are waiting
   if (new_state == State::Running)
     m_step_event.Set();
-
-  Host::UpdateDebugger();
 }
 
 State DSPCore::GetState() const

--- a/Source/Core/Core/DSP/DSPHost.h
+++ b/Source/Core/Core/DSP/DSPHost.h
@@ -29,5 +29,4 @@ bool IsWiiHost();
 void InterruptRequest();
 void CodeLoaded(DSPCore& dsp, u32 addr, size_t size);
 void CodeLoaded(DSPCore& dsp, const u8* ptr, size_t size);
-void UpdateDebugger();
 }  // namespace DSP::Host

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -262,7 +262,6 @@ public:
 
       case CPU::State::Stepping:
         cpu.Break();
-        Host_UpdateMainFrame();
         break;
 
       case CPU::State::Running:

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -96,14 +96,7 @@ void CodeLoaded(DSPCore& dsp, const u8* ptr, size_t size)
   Symbols::AutoDisassembly(state, 0x0, 0x1000);
   Symbols::AutoDisassembly(state, 0x8000, 0x9000);
 
-  UpdateDebugger();
-
   dsp.ClearIRAM();
   state.GetAnalyzer().Analyze(state);
-}
-
-void UpdateDebugger()
-{
-  Host_RefreshDSPDebuggerWindow();
 }
 }  // namespace DSP::Host

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -161,7 +161,6 @@ bool DSPLLE::Initialize(bool wii, bool dsp_thread)
     m_dsp_thread = std::thread(DSPThread, this);
   }
 
-  Host_RefreshDSPDebuggerWindow();
   return true;
 }
 

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -63,7 +63,6 @@ void Host_RequestRenderWindowSize(int width, int height);
 void Host_UpdateDisasmDialog();
 void Host_JitCacheInvalidation();
 void Host_JitProfileDataWiped();
-void Host_UpdateMainFrame();
 void Host_UpdateTitle(const std::string& title);
 void Host_YieldToUI();
 void Host_TitleChanged();

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -58,7 +58,6 @@ bool Host_TASInputHasFocus();
 void Host_Message(HostMessageID id);
 void Host_PPCSymbolsChanged();
 void Host_PPCBreakpointsChanged();
-void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);
 void Host_UpdateDisasmDialog();
 void Host_JitCacheInvalidation();

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -456,8 +456,6 @@ static void CompressAndDumpState(Core::System& system, CompressAndDumpState_args
       Core::DisplayMessage(fmt::format("Saved State to {}", temp_path.filename().string()), 2000);
     }
   }
-
-  Host_UpdateMainFrame();
 }
 
 void SaveAs(Core::System& system, const std::string& filename, bool wait)

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -70,7 +70,6 @@ bool Host_UIBlocksControllerState()
   return false;
 }
 
-static Common::Event s_update_main_frame_event;
 void Host_Message(const HostMessageID id)
 {
   if (id == HostMessageID::WMUserStop)
@@ -92,11 +91,6 @@ void Host_JitCacheInvalidation()
 
 void Host_JitProfileDataWiped()
 {
-}
-
-void Host_UpdateMainFrame()
-{
-  s_update_main_frame_event.Set();
 }
 
 void Host_RequestRenderWindowSize(int width, int height)

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -61,10 +61,6 @@ void Host_PPCBreakpointsChanged()
 {
 }
 
-void Host_RefreshDSPDebuggerWindow()
-{
-}
-
 bool Host_UIBlocksControllerState()
 {
   return false;

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -277,10 +277,6 @@ void Host_PPCBreakpointsChanged()
                 [] { emit Host::GetInstance()->PPCBreakpointsChanged(); });
 }
 
-// We ignore these, and their purpose should be questioned individually.
-// In particular, RequestRenderWindowSize, RequestFullscreen, and
-// UpdateMainFrame should almost certainly be removed.
-
 void Host_RequestRenderWindowSize(int w, int h)
 {
   emit Host::GetInstance()->RequestRenderSize(w, h);

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -280,9 +280,6 @@ void Host_PPCBreakpointsChanged()
 // We ignore these, and their purpose should be questioned individually.
 // In particular, RequestRenderWindowSize, RequestFullscreen, and
 // UpdateMainFrame should almost certainly be removed.
-void Host_UpdateMainFrame()
-{
-}
 
 void Host_RequestRenderWindowSize(int w, int h)
 {

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -293,10 +293,6 @@ bool Host_UIBlocksControllerState()
          Core::GetState(Core::System::GetInstance()) != Core::State::Paused;
 }
 
-void Host_RefreshDSPDebuggerWindow()
-{
-}
-
 void Host_TitleChanged()
 {
 #ifdef USE_DISCORD_PRESENCE

--- a/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
+++ b/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
@@ -29,10 +29,6 @@ void Host_PPCBreakpointsChanged()
 {
 }
 
-void Host_RefreshDSPDebuggerWindow()
-{
-}
-
 bool Host_UIBlocksControllerState()
 {
   return false;

--- a/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
+++ b/Source/Core/DolphinTool/ToolHeadlessPlatform.cpp
@@ -73,10 +73,6 @@ void Host_JitProfileDataWiped()
 {
 }
 
-void Host_UpdateMainFrame()
-{
-}
-
 void Host_RequestRenderWindowSize(int width, int height)
 {
 }

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -49,9 +49,6 @@ void DSP::Host::CodeLoaded(DSPCore& dsp, const u8* ptr, size_t size)
 void DSP::Host::InterruptRequest()
 {
 }
-void DSP::Host::UpdateDebugger()
-{
-}
 
 static std::string CodeToHeader(const std::vector<u16>& code, const std::string& filename)
 {

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -50,9 +50,6 @@ void Host_JitCacheInvalidation()
 void Host_JitProfileDataWiped()
 {
 }
-void Host_UpdateMainFrame()
-{
-}
 void Host_RequestRenderWindowSize(int, int)
 {
 }

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -19,9 +19,6 @@ void Host_PPCSymbolsChanged()
 void Host_PPCBreakpointsChanged()
 {
 }
-void Host_RefreshDSPDebuggerWindow()
-{
-}
 void Host_Message(HostMessageID)
 {
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -50,9 +50,6 @@ void Host_JitCacheInvalidation()
 void Host_JitProfileDataWiped()
 {
 }
-void Host_UpdateMainFrame()
-{
-}
 void Host_RequestRenderWindowSize(int, int)
 {
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -19,9 +19,6 @@ void Host_PPCSymbolsChanged()
 void Host_PPCBreakpointsChanged()
 {
 }
-void Host_RefreshDSPDebuggerWindow()
-{
-}
 void Host_Message(HostMessageID)
 {
 }


### PR DESCRIPTION
Remove the functions `Host_UpdateMainFrame`, `Host_RefreshDSPDebuggerWindow`, and `DSP::Host::UpdateDebugger` because they don't do anything useful (or at all, in most cases).