### PR TITLE
Qt: Better wayland detection to enforce xcb

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -669,6 +669,22 @@ bool CaseInsensitiveEquals(std::string_view a, std::string_view b)
       a, b, [](char ca, char cb) { return Common::ToLower(ca) == Common::ToLower(cb); });
 }
 
+bool CaseInsensitiveContains(std::string_view haystack, std::string_view needle)
+{
+  if (needle.empty())
+    return true;
+
+  for (size_t i = 0; i + needle.size() <= haystack.size(); ++i)
+  {
+    if (std::ranges::equal(needle, haystack.substr(i, needle.size()),
+                           [](char a, char b) { return Common::ToLower(a) == Common::ToLower(b); }))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool CaseInsensitiveLess::operator()(std::string_view a, std::string_view b) const
 {
   return std::ranges::lexicographical_compare(

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -311,6 +311,7 @@ std::string GetEscapedHtml(std::string html);
 void ToLower(std::string* str);
 void ToUpper(std::string* str);
 bool CaseInsensitiveEquals(std::string_view a, std::string_view b);
+bool CaseInsensitiveContains(std::string_view a, std::string_view b);
 
 // 'std::less'-like comparison function object type for case-insensitive strings.
 struct CaseInsensitiveLess

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -23,6 +23,7 @@
 #include "Common/Config/Config.h"
 #include "Common/MsgHandler.h"
 #include "Common/ScopeGuard.h"
+#include "Common/StringUtil.h"
 
 #include "Core/Boot/Boot.h"
 #include "Core/Config/MainSettings.h"
@@ -152,8 +153,8 @@ int main(int argc, char* argv[])
   // from happening.
   // For more information: https://bugs.dolphin-emu.org/issues/11807
   const char* current_qt_platform = getenv("QT_QPA_PLATFORM");
-  const bool replace_qt_platform =
-      (current_qt_platform && strcasecmp(current_qt_platform, "wayland") == 0);
+  const bool replace_qt_platform = current_qt_platform != nullptr &&
+                                   Common::CaseInsensitiveContains(current_qt_platform, "wayland");
   setenv("QT_QPA_PLATFORM", "xcb", replace_qt_platform);
 #endif
 

--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -225,3 +225,34 @@ TEST(StringUtil, SplitPathWindowsPathWithDriveLetter)
   EXPECT_EQ(extension, "");
 }
 #endif
+
+TEST(StringUtil, CaseInsensitiveContains_BasicMatches)
+{
+  EXPECT_TRUE(Common::CaseInsensitiveContains("hello world", "hello"));
+  EXPECT_TRUE(Common::CaseInsensitiveContains("hello world", "world"));
+  EXPECT_TRUE(Common::CaseInsensitiveContains("HELLO WORLD", "hello"));
+  EXPECT_TRUE(Common::CaseInsensitiveContains("HeLLo WoRLd", "WORLD"));
+}
+
+TEST(StringUtil, CaseInsensitiveContains_SubstringNotFound)
+{
+  EXPECT_FALSE(Common::CaseInsensitiveContains("hello world", "hey"));
+}
+
+TEST(StringUtil, CaseInsensitiveContains_EmptyStrings)
+{
+  EXPECT_TRUE(Common::CaseInsensitiveContains("", ""));
+  EXPECT_TRUE(Common::CaseInsensitiveContains("hello", ""));
+  EXPECT_FALSE(Common::CaseInsensitiveContains("", "world"));
+}
+
+TEST(StringUtil, CaseInsensitiveContains_EntireStringMatch)
+{
+  EXPECT_TRUE(Common::CaseInsensitiveContains("Test", "TEST"));
+}
+
+TEST(StringUtil, CaseInsensitiveContains_OverlappingMatches)
+{
+  EXPECT_TRUE(Common::CaseInsensitiveContains("aaaaaa", "aa"));
+  EXPECT_TRUE(Common::CaseInsensitiveContains("ababababa", "bABa"));
+}


### PR DESCRIPTION
In certain cases, the platform can be "wayland-egl", "wayland-xcomposite", and other values for which I haven't found a full list yet. Instead of matching only "wayland", we now look for "wayland" anywhere in the `QT_QPA_PLATFORM` string in a case-insensitive manner.

Acknowledgements:
`CaseInsensitiveContains`' implementation was heavily inspired by GNU's non-standard glibc `strcasestr` function, which can be found here licensed under GPLv2 or later: https://ftp.gnu.org/gnu/libc/

Addendum:
We don't want to force the use of `xcb` in all situations. For example, `offscreen` is currently used in Arch Linux's `dolphin-emu-git` AUR package as a final check to see if everything is working.