### PR TITLE
USBDevicePicker: Modify USBDeviceAddToWhitelistDialog to be more generic, and use it for a new "More Options..." selection in Bluetooth Passthrough adapters

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -364,8 +364,8 @@ add_executable(dolphin-emu
   Settings/InterfacePane.h
   Settings/PathPane.cpp
   Settings/PathPane.h
-  Settings/USBDeviceAddToWhitelistDialog.cpp
-  Settings/USBDeviceAddToWhitelistDialog.h
+  Settings/USBDevicePicker.cpp
+  Settings/USBDevicePicker.h
   Settings/WiiPane.cpp
   Settings/WiiPane.h
   SkylanderPortal/SkylanderModifyDialog.cpp

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -219,7 +219,7 @@
     <ClCompile Include="Settings\GeneralPane.cpp" />
     <ClCompile Include="Settings\InterfacePane.cpp" />
     <ClCompile Include="Settings\PathPane.cpp" />
-    <ClCompile Include="Settings\USBDeviceAddToWhitelistDialog.cpp" />
+    <ClCompile Include="Settings\USBDevicePicker.cpp" />
     <ClCompile Include="Settings\WiiPane.cpp" />
     <ClCompile Include="SkylanderPortal\SkylanderModifyDialog.cpp" />
     <ClCompile Include="SkylanderPortal\SkylanderPortalWindow.cpp" />
@@ -429,7 +429,7 @@
     <QtMoc Include="Settings\GeneralPane.h" />
     <QtMoc Include="Settings\InterfacePane.h" />
     <QtMoc Include="Settings\PathPane.h" />
-    <QtMoc Include="Settings\USBDeviceAddToWhitelistDialog.h" />
+    <QtMoc Include="Settings\USBDevicePicker.h" />
     <QtMoc Include="Settings\WiiPane.h" />
     <QtMoc Include="SkylanderPortal\SkylanderPortalWindow.h" />
     <QtMoc Include="TAS\GCTASInputWindow.h" />

--- a/Source/Core/DolphinQt/Settings/USBDevicePicker.h
+++ b/Source/Core/DolphinQt/Settings/USBDevicePicker.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include <QDialog>
@@ -24,16 +25,21 @@ class QPushButton;
 class QErrorMessage;
 class QMessageBox;
 
-class USBDeviceAddToWhitelistDialog final : public QDialog
+class USBDevicePicker final : public QDialog
 {
   Q_OBJECT
 public:
-  explicit USBDeviceAddToWhitelistDialog(QWidget* parent);
+  using FilterFunctionType = std::function<bool(const USBUtils::DeviceInfo&)>;
+  explicit USBDevicePicker(QWidget* parent, FilterFunctionType filter);
+
+  static std::optional<USBUtils::DeviceInfo> Run(
+      QWidget* parent, const QString& title,
+      const FilterFunctionType filter = [](const USBUtils::DeviceInfo&) { return true; });
 
 private:
   static constexpr int DEVICE_REFRESH_INTERVAL_MS = 100;
   QTimer* m_refresh_devices_timer;
-  QDialogButtonBox* m_whitelist_buttonbox;
+  QDialogButtonBox* m_picker_buttonbox;
   QVBoxLayout* main_layout;
   QLabel* enter_device_id_label;
   QHBoxLayout* entry_hbox_layout;
@@ -42,9 +48,12 @@ private:
   QLabel* select_label;
   QListWidget* usb_inserted_devices_list;
 
+  FilterFunctionType m_filter;
+
+  std::optional<USBUtils::DeviceInfo> GetSelectedDevice() const;
+
   void InitControls();
   void RefreshDeviceList();
-  void AddUSBDeviceToWhitelist();
 
   void OnDeviceSelection();
 


### PR DESCRIPTION
This would allow avoiding users editing the ini file in case the adapter doesn't properly disclose itself as a Bluetooth adapter.

This idea was suggested on Discord by @jordan-woyak.