### PR TITLE
GameINI: CPU Clock Override for Sonic Mega Collection and Sonic & Knuckles (VC)

### DIFF
--- a/Data/Sys/GameSettings/GSO.ini
+++ b/Data/Sys/GameSettings/GSO.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+Overclock = 1.4
+OverclockEnable = True
 
 [OnFrame]
 # Add memory patches to be applied every frame here.

--- a/Data/Sys/GameSettings/MCD.ini
+++ b/Data/Sys/GameSettings/MCD.ini
@@ -1,5 +1,10 @@
 # MCDE8P - Sonic & Knuckles
 
+[Core]
+# Values set here will override the main Dolphin settings.
+Overclock = 1.2
+OverclockEnable = True
+
 [Video_Settings]
 
 [Video_Hacks]


### PR DESCRIPTION
**Sonic Mega Collection** and **Sonic & Knuckles (VC)** both have issues with the Blue Sphere special stages not running properly in Dolphin due to CPU timing differences. These ini changes implement CPU clock overrides of 1.4 and 1.2 respectively to fix their visual bugs and slowdown. I encountered no visual or audio errors testing the increased clock speed across multiple areas of Sonic Mega Collection, so this should be an objective improvement for those who casually boot up SMC without reading the wiki first.

Oddly, Sonic 3 (VC) did not have any speed issues on the latest development build (2506-332), so no ini changes were included for it.