### PR TITLE
JitArm64_Integer: subfcx optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1432,6 +1432,17 @@ void JitArm64::subfcx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC0(gpr.GetImm(d));
   }
+  else if (gpr.IsImm(a, 0))
+  {
+    if (d != b)
+    {
+      gpr.BindToRegister(d, false);
+      MOV(gpr.R(d), gpr.R(b));
+    }
+    ComputeCarry(true);
+    if (inst.Rc)
+      ComputeRC0(gpr.R(d));
+  }
   else
   {
     gpr.BindToRegister(d, d == a || d == b);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1443,6 +1443,14 @@ void JitArm64::subfcx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC0(gpr.R(d));
   }
+  else if (gpr.IsImm(b, 0))
+  {
+    gpr.BindToRegister(d, d == a);
+    CARRY_IF_NEEDED(NEG, NEGS, gpr.R(d), gpr.R(a));
+    ComputeCarry();
+    if (inst.Rc)
+      ComputeRC0(gpr.R(d));
+  }
   else
   {
     gpr.BindToRegister(d, d == a || d == b);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1443,6 +1443,14 @@ void JitArm64::subfcx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC0(gpr.R(d));
   }
+  else if (gpr.IsImm(a) && ((gpr.GetImm(a) & 0xFFF) == gpr.GetImm(a)))
+  {
+    gpr.BindToRegister(d, d == b);
+    CARRY_IF_NEEDED(SUB, SUBS, gpr.R(d), gpr.R(b), gpr.GetImm(a));
+    ComputeCarry();
+    if (inst.Rc)
+      ComputeRC0(gpr.R(d));
+  }
   else if (gpr.IsImm(b, 0))
   {
     gpr.BindToRegister(d, d == a);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1451,6 +1451,14 @@ void JitArm64::subfcx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC0(gpr.R(d));
   }
+  else if (gpr.IsImm(a) && ((gpr.GetImm(a) & 0xFFF000) == gpr.GetImm(a)))
+  {
+    gpr.BindToRegister(d, d == b);
+    CARRY_IF_NEEDED(SUB, SUBS, gpr.R(d), gpr.R(b), gpr.GetImm(a) >> 12, true);
+    ComputeCarry();
+    if (inst.Rc)
+      ComputeRC0(gpr.R(d));
+  }
   else if (gpr.IsImm(b, 0))
   {
     gpr.BindToRegister(d, d == a);


### PR DESCRIPTION
Nothing too shocking, some of the optimization are similar to what I did in #13324 for cmp/cmpl.

<details><summary>Optimize a == 0</summary>

Before:
```
0x52800013 mov w19, #0x0 ; =0
0x6b1302b3 subs w19, w21, w19
```
After:
```
0x2a1503f3 mov w19, w21
```
</details>

<details><summary>Optimize b == 0</summary>

Before:
```
0x52800015 mov w21, #0x0 ; =0
0x6b1802b6 subs w22, w21, w24
```
After:
```
0x6b1803f6 negs w22, w24

```
</details>


<details><summary>Subtract 12-bit constant</summary>

Before:
```
0x5280037a mov w26, #0x1b ; =27
0x6b1a02bb subs w27, w21, w26
0x93407f78 sxtw x24, w27
```
After:
```
0x71006ebb subs w27, w21, #0x1b
0x93407f7a sxtw x26, w27
```
</details>

<details><summary>Subtract shifted 12-bit constant</summary>

Before:
```
0x52900019 mov w25, #0x8000 ; =32768
0x6b190359 subs w25, w26, w25
```
After:
```
0x71402359 subs w25, w26, #0x8, lsl #12 ; =0x8000
```
</details>