### PR TITLE
Android: Allow the user to quickly load a savestate on game startup

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
@@ -60,6 +60,7 @@ import org.dolphinemu.dolphinemu.ui.main.ThemeProvider
 import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper
+import org.dolphinemu.dolphinemu.utils.Log
 import org.dolphinemu.dolphinemu.utils.ThemeHelper
 import kotlin.math.roundToInt
 
@@ -456,6 +457,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             MENU_ACTION_PAUSE_EMULATION -> {
                 hasUserPausedEmulation = true
                 NativeLibrary.PauseEmulation(false)
+                saveOnExit()
             }
 
             MENU_ACTION_UNPAUSE_EMULATION -> {
@@ -1166,5 +1168,27 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             view.getGlobalVisibleRect(viewBounds)
             return !viewBounds.contains(x.roundToInt(), y.roundToInt())
         }
+    }
+
+     fun saveOnExit() {
+      if (BooleanSetting.MAIN_EXIT_SAVE_AND_LOAD.boolean) {
+        Log.error("[EmulationActivity] Exitsave on Pause")
+        NativeLibrary.SaveState(10, true)
+      }
+    }
+
+     fun loadExitsaveOnStart() {
+      if (BooleanSetting.MAIN_EXIT_SAVE_AND_LOAD.boolean) {
+        while (!NativeLibrary.IsRunningAndUnpaused()){
+          Thread.sleep(10)
+        }
+        Log.error("[EmulationActivity] Load Exitsave on start")
+        val creationTime = NativeLibrary.GetUnixTimeOfStateSlot(9)
+        if (creationTime != 0L) {
+          NativeLibrary.LoadState(9)
+        } else {
+          Log.error("[EmulationActivity] Exitsave-Slot not available")
+        }
+      }
     }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -136,6 +136,12 @@ enum class BooleanSetting(
         "EnableSaveStates",
         false
     ),
+    MAIN_EXIT_SAVE_AND_LOAD(
+      Settings.FILE_DOLPHIN,
+      Settings.SECTION_INI_CORE,
+      "EnableExitSaveAndLoad",
+      false
+    ),
     MAIN_WII_WIILINK_ENABLE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "EnableWiiLink", false),
     MAIN_DSP_JIT(Settings.FILE_DOLPHIN, Settings.SECTION_INI_DSP, "EnableJIT", true),
     MAIN_TIME_TRACKING(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -291,6 +291,14 @@ class SettingsFragmentPresenter(
                 R.string.enable_save_states_description
             )
         )
+        sl.add(
+          SwitchSetting(
+            context,
+            BooleanSetting.MAIN_EXIT_SAVE_AND_LOAD,
+            R.string.enable_exit_save_and_load,
+            R.string.enable_exit_save_and_load_description
+          )
+        )
     }
 
     private fun addInterfaceSettings(sl: ArrayList<SettingsItem>) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
@@ -111,6 +111,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             Log.debug("[EmulationFragment] Pausing emulation.")
             NativeLibrary.PauseEmulation(true)
         }
+        // create exitsave here too, in case android kills the paused process
+        emulationActivity?.saveOnExit()
         super.onPause()
     }
 
@@ -161,6 +163,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     }
 
     fun stopEmulation() {
+        emulationActivity?.saveOnExit()
         Log.debug("[EmulationFragment] Stopping emulation.")
         NativeLibrary.StopEmulation()
     }
@@ -220,6 +223,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                 EmulationActivity.stopIgnoringLaunchRequests()
             }, "NativeEmulation")
             emulationThread.start()
+            emulationActivity?.loadExitsaveOnStart()
         } else {
             if (!EmulationActivity.hasUserPausedEmulation && !NativeLibrary.IsShowingAlertMessage()) {
                 Log.debug("[EmulationFragment] Resuming emulation.")

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="wiimote_extensions">Extension</string>
 
     <string name="input_device">Device</string>
+    <string name="input_test">TEST</string>
     <string name="input_device_all_devices">Create Mappings for Other Devices</string>
     <string name="input_device_all_devices_description">Detects inputs from all devices, not just the selected device.</string>
     <string name="input_profile">Profile</string>
@@ -126,6 +127,8 @@
     <string name="fallback_region">Fallback Region</string>
     <string name="enable_save_states">Enable Savestates</string>
     <string name="enable_save_states_description">WARNING: Savestates may not be compatible with future versions of Dolphin and can make it impossible to create normal saves in some cases. Never use savestates as the only way of saving your progress.</string>
+    <string name="enable_exit_save_and_load">Enable Exitsave and Quickload</string>
+    <string name="enable_exit_save_and_load_description">Pick it right up where you left it! This will save your game every time you exit the game, and loads it back when you start it again.</string>
     <string name="analytics">Enable usage statistics reporting</string>
     <string name="analytics_desc">If authorized, Dolphin can collect data on its performance, feature usage, and configuration, as well as data on your system\'s hardware and operating system.\n\nNo private data is ever collected. This data helps us understand how people and emulated games use Dolphin and prioritize our efforts. It also helps us identify rare configurations that are causing bugs, performance and stability issues. This authorization can be revoked at any time through Dolphin\'s settings.</string>
     <string name="analytics_new_id">Generate a New Statistics Identity</string>


### PR DESCRIPTION
This allows the user to enable an "exitsave". This is a specific savegame that is made everytime the emulation exits or pauses, and is automatically loaded on game-startup.

This is an android-specific feature.