### PR TITLE
IOS/FS: add safety assert

### DIFF
--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -43,6 +43,8 @@ HostFileSystem::HostFilename HostFileSystem::BuildFilename(const std::string& wi
     }
   }
 
+  ASSERT(!m_root_path.empty());
+
   if (wii_path.starts_with("/"))
     return HostFilename{m_root_path + Common::EscapePath(wii_path), false};
 


### PR DESCRIPTION
This is to prevent someone (me) from accidentally deleting their entire /tmp directory just by not initializing the config system correctly.