### PR TITLE
HW/VideoInterface: Don't affect aspect ratio with VBI Frequency Override

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -505,12 +505,12 @@ float VideoInterfaceManager::GetAspectRatio() const
   int active_width_samples = (m_h_timing_0.HLW + m_h_timing_1.HBS640 - m_h_timing_1.HBE640);
 
   // 2. TVs are analog and don't have pixels. So we convert to seconds.
+  const auto ticks_per_halfline = GetNominalTicksPerHalfLine();
   float tick_length = (1.0f / m_system.GetSystemTimers().GetTicksPerSecond());
-  float vertical_period = tick_length * GetTicksPerField();
-  float horizontal_period = tick_length * GetTicksPerHalfLine() * 2;
+  float vertical_period = tick_length * ticks_per_halfline * GetHalfLinesPerEvenField();
+  float horizontal_period = tick_length * ticks_per_halfline * 2;
   float vertical_active_area = active_lines * horizontal_period;
-  float horizontal_active_area =
-      tick_length * GetTicksPerSample() * active_width_samples / m_config_vi_oc_factor;
+  float horizontal_active_area = tick_length * GetTicksPerSample() * active_width_samples;
 
   // We are approximating the horizontal/vertical flyback transformers that control the
   // position of the electron beam on the screen. Our flyback transformers create a
@@ -760,9 +760,14 @@ u32 VideoInterfaceManager::GetTicksPerSample() const
   return 2 * m_system.GetSystemTimers().GetTicksPerSecond() / CLOCK_FREQUENCIES[m_clock & 1];
 }
 
+u32 VideoInterfaceManager::GetNominalTicksPerHalfLine() const
+{
+  return GetTicksPerSample() * m_h_timing_0.HLW;
+}
+
 u32 VideoInterfaceManager::GetTicksPerHalfLine() const
 {
-  return GetTicksPerSample() * m_h_timing_0.HLW / m_config_vi_oc_factor;
+  return GetNominalTicksPerHalfLine() / m_config_vi_oc_factor;
 }
 
 u32 VideoInterfaceManager::GetTicksPerField() const

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -389,6 +389,9 @@ public:
   u32 GetTicksPerHalfLine() const;
   u32 GetTicksPerField() const;
 
+  // Not adjusted by VBI Clock Override.
+  u32 GetNominalTicksPerHalfLine() const;
+
   // Get the aspect ratio of VI's active area (rarely matching pure 4:3).
   // This function only deals with standard aspect ratios. For widescreen aspect ratios, multiply
   // the result by 1.33333... (the ratio between 16:9 and 4:3)


### PR DESCRIPTION
Small fixup of #13046: changing the VBI Frequency slightly affected the aspect ratio due to rounding errors.
This PR fixes it by ignoring the setting when calculating the aspect ratio.