### PR TITLE
BranchWatch: Extract shared function logic

### DIFF
--- a/Source/Core/Core/Debugger/BranchWatch.h
+++ b/Source/Core/Core/Debugger/BranchWatch.h
@@ -261,6 +261,9 @@ private:
     return GetCollectionP(condition);
   }
 
+  void IsolateOverwrittenShared(const CPUThreadGuard& guard,
+                                const std::function<bool(u32, u32)>& compare_func);
+
   std::size_t m_blacklist_size = 0;
   Phase m_recording_phase = Phase::Blacklist;
   bool m_recording_active = false;


### PR DESCRIPTION
IsolateWasOverwritten and IsolateNotOverwritten share the same basic logic and have almost exactly the same code, with the only difference being the comparison function used to keep or discard branches. To avoid unnecessary code duplication and ensure that the functions stay in sync after any future changes, create a helper function that takes the comparison function as a parameter and have IsolateWasOverwritten and IsolateNotOverwritten call that helper.