### PR TITLE
Mention enable MMU in the DSI Exception message (Invalid read from ###/Invalid write to ###)

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1273,8 +1273,20 @@ void MMU::GenerateDSIException(u32 effective_address, bool write)
   // DSI exceptions are only supported in MMU mode.
   if (!m_system.IsMMUMode())
   {
-    PanicAlertFmt("Invalid {} {:#010x}, PC = {:#010x}", write ? "write to" : "read from",
-                  effective_address, m_ppc_state.pc);
+    if (write)
+    {
+      PanicAlertFmtT(
+          "Invalid write to {0:#010x}, PC = {1:#010x}; the game probably would have crashed on "
+          "real hardware.\n\nFor accurate emulation, enable MMU in advanced settings.",
+          effective_address, m_ppc_state.pc);
+    }
+    else
+    {
+      PanicAlertFmtT(
+          "Invalid read from {0:#010x}, PC = {1:#010x}; the game probably would have crashed on "
+          "real hardware.\n\nFor accurate emulation, enable MMU in advanced settings.",
+          effective_address, m_ppc_state.pc);
+    }
     if (m_system.IsPauseOnPanicMode())
     {
       m_system.GetCPU().Break();


### PR DESCRIPTION
This has been possible for a long time now (see https://dolphin-emu.org/blog/2016/09/06/booting-the-final-gc-game/#side-effects-of-a-hardcode-rewrite), but it seems like people still aren't aware of it.

<img width="502" height="147" alt="image" src="https://github.com/user-attachments/assets/9634252b-8dc1-4285-87f4-93fc4c61b127" />

(The easiest way to get this message to appear is to pause a game, then change r13 to a garbage value in the registers widget, since it's used as a pointer to the small data area and thus accessed frequently.)