### PR TITLE
Fix Single-Precision-Only Inputs to FMAs Instructions in Interpreter

### DIFF
--- a/Source/Core/Common/FloatUtils.h
+++ b/Source/Core/Common/FloatUtils.h
@@ -26,7 +26,6 @@ static constexpr u64 DOUBLE_ZERO = 0x0000000000000000ULL;
 static constexpr int DOUBLE_EXP_WIDTH = 11;
 static constexpr int DOUBLE_FRAC_WIDTH = 52;
 
-static constexpr u32 FLOAT_QBIT = 0x00400000;
 static constexpr u32 FLOAT_SIGN = 0x80000000;
 static constexpr u32 FLOAT_EXP = 0x7F800000;
 static constexpr u32 FLOAT_FRAC = 0x007FFFFF;

--- a/Source/Core/Common/FloatUtils.h
+++ b/Source/Core/Common/FloatUtils.h
@@ -34,23 +34,10 @@ static constexpr u32 FLOAT_ZERO = 0x00000000;
 static constexpr int FLOAT_EXP_WIDTH = 8;
 static constexpr int FLOAT_FRAC_WIDTH = 23;
 
-inline bool IsQNAN(float f)
-{
-  const u32 i = std::bit_cast<u32>(f);
-  return ((i & FLOAT_EXP) == FLOAT_EXP) && ((i & FLOAT_QBIT) == FLOAT_QBIT);
-}
-
 inline bool IsQNAN(double d)
 {
   const u64 i = std::bit_cast<u64>(d);
   return ((i & DOUBLE_EXP) == DOUBLE_EXP) && ((i & DOUBLE_QBIT) == DOUBLE_QBIT);
-}
-
-inline bool IsSNAN(float f)
-{
-  const u32 i = std::bit_cast<u32>(f);
-  return ((i & FLOAT_EXP) == FLOAT_EXP) && ((i & FLOAT_FRAC) != FLOAT_ZERO) &&
-         ((i & FLOAT_QBIT) == FLOAT_ZERO);
 }
 
 inline bool IsSNAN(double d)

--- a/Source/Core/Common/FloatUtils.h
+++ b/Source/Core/Common/FloatUtils.h
@@ -26,6 +26,7 @@ static constexpr u64 DOUBLE_ZERO = 0x0000000000000000ULL;
 static constexpr int DOUBLE_EXP_WIDTH = 11;
 static constexpr int DOUBLE_FRAC_WIDTH = 52;
 
+static constexpr u32 FLOAT_QBIT = 0x00400000;
 static constexpr u32 FLOAT_SIGN = 0x80000000;
 static constexpr u32 FLOAT_EXP = 0x7F800000;
 static constexpr u32 FLOAT_FRAC = 0x007FFFFF;
@@ -33,10 +34,23 @@ static constexpr u32 FLOAT_ZERO = 0x00000000;
 static constexpr int FLOAT_EXP_WIDTH = 8;
 static constexpr int FLOAT_FRAC_WIDTH = 23;
 
+inline bool IsQNAN(float d)
+{
+  const u32 i = std::bit_cast<u32>(d);
+  return ((i & FLOAT_EXP) == FLOAT_EXP) && ((i & FLOAT_QBIT) == FLOATQ_BIT);
+}
+
 inline bool IsQNAN(double d)
 {
   const u64 i = std::bit_cast<u64>(d);
   return ((i & DOUBLE_EXP) == DOUBLE_EXP) && ((i & DOUBLE_QBIT) == DOUBLE_QBIT);
+}
+
+inline bool IsSNAN(float f)
+{
+  const u32 i = std::bit_cast<u32>(f);
+  return ((i & FLOAT_EXP) == FLOAT_EXP) && ((i & FLOAT_FRAC) != FLOAT_ZERO) &&
+         ((i & FLOAT_QBIT) == FLOAT_ZERO);
 }
 
 inline bool IsSNAN(double d)

--- a/Source/Core/Common/FloatUtils.h
+++ b/Source/Core/Common/FloatUtils.h
@@ -34,10 +34,10 @@ static constexpr u32 FLOAT_ZERO = 0x00000000;
 static constexpr int FLOAT_EXP_WIDTH = 8;
 static constexpr int FLOAT_FRAC_WIDTH = 23;
 
-inline bool IsQNAN(float d)
+inline bool IsQNAN(float f)
 {
-  const u32 i = std::bit_cast<u32>(d);
-  return ((i & FLOAT_EXP) == FLOAT_EXP) && ((i & FLOAT_QBIT) == FLOATQ_BIT);
+  const u32 i = std::bit_cast<u32>(f);
+  return ((i & FLOAT_EXP) == FLOAT_EXP) && ((i & FLOAT_QBIT) == FLOAT_QBIT);
 }
 
 inline bool IsQNAN(double d)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -287,12 +287,125 @@ inline FPResult NI_sub(PowerPC::PowerPCState& ppc_state, double a, double b)
   return result;
 }
 
-// FMA instructions on PowerPC are weird:
-// They calculate (a * c) + b, but the order in which
-// inputs are checked for NaN is still a, b, c.
-inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
+// The bulk work for fm(add/sub)(s)x operations
+template <bool sub, bool single>
+inline FPResult NI_madd_msub(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
 {
-  FPResult result{std::fma(a, c, b)};
+  // The FMA instructions on PowerPC are incredibly weird, and the single precision variations are
+  // the only ones with the unfortunate side effect of completely accurately emulating them requiring
+  // either software floats or the manual checking of the individual float operations performed,
+  // down to a precision greater than that of subnormals.
+  // The first oddity to be found is that they calculate (a * c) + b, but in the case of NaNs,
+  // they're still checked in the order a, b, c.
+  // The rest generally come from the single precision variation.
+  // 1. The arguments are *not* forced to 32-bit precision in all ways, meaning you can end
+  //    up with results that rely on a 64-bit precision mantissa.
+  // 2. The only argument which *is* forced to 32-bit precision in a way is frC, and even that
+  //    is only forced to have a 32-bit mantissa.
+  // 3. fC is forced to have a 32-bit mantissa (rounding in the same way no matter what the
+  //    rounding mode is set to), while keeping the exponent at any 64-bit value.
+  //    But rather than the highest values rounding to infinity, because PowerPC internally uses
+  //    a higher precision exponent, it rounds up to a value normally unreachable with even
+  //    double precision floats.
+  // 4. CPUs, unsurprisingly, don't tend to support 64-bit float inputs to an operation with a 32-bit
+  //    result. One quirk of PowerPC is that instead of just not caring about the 32-bit precision
+  //    mantissas, it includes them and *only rounds once* to 32-bit. This means that you can have
+  //    double precision inputs that round differently than if you do a double precision FMA then
+  //    round the result to 32-bit.
+  //    - What makes FMA so special here is that it's the only basic operation which, upon being 
+  //      converted to a 64-bit operation then rounded back to a 32-bit result, does *not* give
+  //      the same result when rounding to nearest!
+  //      Addition, subtraction, multiplication, and division do not have this issue and will give
+  //      the correct result for all inputs!
+  //    - In fact, rounding to nearest is the *only* rounding mode where it ends up having issues!
+  //      The reason being, if the result was to round in one direction, it would
+  //      always direct the double precision output in a way such that rounding to single precision
+  //      would end up having that same transformation (or it would already be exactly representable
+  //      as a single precision value).
+  //
+  // It is relatively easy to find 32-bit values which do not round properly if one performs
+  // f32(fma(f64(a), f64(c), f64(b))), despite the rarity. The requirements can be shown fairly easily as well:
+  // - Final Result = sign * (1.fffffffffffffffffffffffddddddddddddddddddddddddddddd * 2^exponent + c * 2^(exponent - 52))
+  // What we need is some form of discrepency occurs from rounding twice, such that moving `d` over to be part of `c` (and
+  // adjusting the exponent multiplied by the concatenated values)
+  // There are a few ways which a discrepency from rounding twice can be caused:
+  // 1. Tying down to even because `c` is too small
+  //    a. The highest bit of `d` is 1, the rest of the bits of `d` are 0 (this means it ties)
+  //    b. The lowest bit of `f` is 0 (this means it ties to even downwards)
+  //    c. `c` is positive (nonzero) and does not round `d` upwards
+  //    -  This means while a single round would round up, instead this rounds down because of tying to even.
+  // 2. Tying up because `d` rounded up
+  //    a. The highest bit of `d` is 0, the rest of the bits of `d` are 1
+  //    b. The lowest bit of `f` is 1 (this means it ties to even upwards)
+  //    c. `c` is positive, and the highest bit of c is 1
+  //    - This will cause `d` to round to 100...00, meaning it will tie then round upwards.
+  // 3. Tying up to even because `c` is too small
+  //    a. The highest bit of `d` is 1, the rest of the bits of `d` are 0 (this means it ties)
+  //    b. The lowest bit of `f` is 1 (this means it ties to even downwards)
+  //    c. `c` is negative and does not round `d` downwards
+  //    -  This is similar to the first one but in reverse, rounding up instead of down.
+  // 4. Tying down because `d` rounded down
+  //    a. The highest and lowest bits of `d` are 1, the rest of the bits of `d` are 0
+  //    b. The lowest bit of `f` is 0 (this means it ties to even upwards)
+  //    c. `c` is negative, and the highest bit of c is 1 and at least one other bit of c is nonzero
+  //    - The backwards counterpart to case 2, this will cause `d` to round back down to 100..00,
+  //      where the tie down will cause it to round down instead of up.
+  //
+  // The first values found which were shown to definitively cause issues appeared in Super Mario Strikers, where:
+  // a = 0x42480000 (50.0)
+  // c = 0xbc88cc38 (-0.01669894158840179443359375)
+  // b = 0x1b1c72a0 (0.0000000000000000000001294105489087172032066277841712287344222431784146465361118316650390625)
+  // 
+  //   1.fffffffffffffffffffffffddddddddddddddddddddddddddddd * 2^exp +/- c
+  // -(1.1010101101111110001011110000000000000000000000000000 * 2^-1   -  1.001110001110010101 * 2^-73)
+  // This exactly matches case 3 as shown above, so while the result should be 0xbf55bf17, Dolphin was returning 0xbf55bf18!
+  // Due to being able to choose any value of `c` easily to counter the value in the multiplication, it's not particularly difficult
+  // to make your own examples as well, but of course these happening in practice is going to be absurdly uncommon most of the time.
+  // 
+  // Currently Dolphin supports:
+  // - Correct ordering of NaN checking (for both double and single precision)
+  // - Rounding frC up
+  // - Rounding only once for single precision inputs (this will be the large, large majority of cases!)
+  //   - Currently this is interpreter-only. This can be implemented in the JIT just as easily, though.
+  //     Eventually the JITs should hopefully support detecting back to back single-precision operations,
+  //     
+  // Currently it does not support:
+  // - Handling frC overflowing to an unreachable value
+  //   - This is simple enough to check for and handle properly, but the likelihood of it occuring is
+  //     so low that it's not worth it to check for it for the extremely rare accuracy improvement
+  // - Rounding only once for inputs with single precision mantissas but double precision exponents
+  //   - This one is also very simple again is not really something that would happen.
+  //     It's also the most likely one to occur, as paired singles similarly only round the mantissa,
+  //     not the exponent, and there are games which which do in fact utilize this (for example, any
+  //     games which use nw4r -- this includes Mario Kart Wii, although no ghosts are known which
+  //     desync on Dolphin because of this or even the single precision -> double precision FMA issue)
+  // - Rounding only once for inputs with double precision mantissas
+  //
+  // All of these can be resolved in a software float emulation method, or by using things such as
+  // error-free float algorithms, but the nature of both of these lead to incredible speed costs,
+  // and with the extreme rarity of anything beyond what's currently handled mattering, the other
+  // cases don't seem to have any reason to be implemented as of now.
+
+  FPResult result;
+  
+  // In double precision, just doing the normal operation will be exact with no issues.
+  if (!single)
+    result.value = std::fma(a, c, sub ? -b : b);
+  else {
+    // For the single precision case, all we currently do is rounding frC properly,
+    // then check if the single precision case will work,
+    // and if it does, we perform a single precision fma instead.
+    const double c_round = Force25Bit(c);
+
+    const float a_float = static_cast<float>(a);
+    const float b_float = static_cast<float>(b);
+    const float c_float = static_cast<float>(c_round);
+
+    if (static_cast<double>(a_float) == a && static_cast<double>(b_float) == b && static_cast<double>(c_float) == c_round)
+      result.value = static_cast<double>(std::fma(a_float, c_float, sub ? -b_float : b_float));
+    else
+      result.value = std::fma(a, c_round, sub ? -b : b);
+  }
 
   if (std::isnan(result.value))
   {
@@ -328,42 +441,16 @@ inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, do
   return result;
 }
 
+template <bool single>
+inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
+{
+  return NI_madd_msub<false, single>(ppc_state, a, c, b);
+}
+
+template <bool single>
 inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
 {
-  FPResult result{std::fma(a, c, -b)};
-
-  if (std::isnan(result.value))
-  {
-    if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
-      result.SetException(ppc_state, FPSCR_VXSNAN);
-
-    ppc_state.fpscr.ClearFIFR();
-
-    if (std::isnan(a))
-    {
-      result.value = MakeQuiet(static_cast<float>(a));
-      return result;
-    }
-    if (std::isnan(b))
-    {
-      result.value = MakeQuiet(static_cast<float>(b));  // !
-      return result;
-    }
-    if (std::isnan(c))
-    {
-      result.value = MakeQuiet(static_cast<float>(c));
-      return result;
-    }
-
-    result.SetException(ppc_state, std::isnan(a * c) ? FPSCR_VXIMZ : FPSCR_VXISI);
-    result.value = PPC_NAN;
-    return result;
-  }
-
-  if (std::isinf(a) || std::isinf(b) || std::isinf(c))
-    ppc_state.fpscr.ClearFIFR();
-
-  return result;
+  return NI_madd_msub<true, single>(ppc_state, a, c, b);
 }
 
 // used by stfsXX instructions and ps_rsqrte

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -351,7 +351,7 @@ inline FPResult NI_madd_msub(PowerPC::PowerPCState& ppc_state, double a, double 
   //    - The backwards counterpart to case 2, this will cause `d` to round back down to 100..00,
   //      where the tie down will cause it to round down instead of up.
   //
-  // The first values found which were shown to definitively cause issues appeared in Super Mario Strikers, where:
+  // The first values found which were shown to definitively cause issues appeared in Mario Strikers Charged, where:
   // a = 0x42480000 (50.0)
   // c = 0xbc88cc38 (-0.01669894158840179443359375)
   // b = 0x1b1c72a0 (0.0000000000000000000001294105489087172032066277841712287344222431784146465361118316650390625)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -290,10 +290,9 @@ inline FPResult NI_sub(PowerPC::PowerPCState& ppc_state, double a, double b)
 // FMA instructions on PowerPC are weird:
 // They calculate (a * c) + b, but the order in which
 // inputs are checked for NaN is still a, b, c.
-template <typename T>
-inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, T a, T c, T b)
+inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
 {
-  FPResult result{static_cast<double>(std::fma(a, c, b))};
+  FPResult result{std::fma(a, c, b)};
 
   if (std::isnan(result.value))
   {
@@ -329,10 +328,9 @@ inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, T a, T c, T b)
   return result;
 }
 
-template <typename T>
-inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, T a, T c, T b)
+inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
 {
-  FPResult result{static_cast<double>(std::fma(a, c, -b))};
+  FPResult result{std::fma(a, c, -b)};
 
   if (std::isnan(result.value))
   {

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -416,17 +416,17 @@ inline FPResult NI_madd_msub(PowerPC::PowerPCState& ppc_state, double a, double 
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(static_cast<float>(a));
+      result.value = MakeQuiet(a);
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(static_cast<float>(b));  // !
+      result.value = MakeQuiet(b);  // !
       return result;
     }
     if (std::isnan(c))
     {
-      result.value = MakeQuiet(static_cast<float>(c));
+      result.value = MakeQuiet(c);
       return result;
     }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -290,9 +290,10 @@ inline FPResult NI_sub(PowerPC::PowerPCState& ppc_state, double a, double b)
 // FMA instructions on PowerPC are weird:
 // They calculate (a * c) + b, but the order in which
 // inputs are checked for NaN is still a, b, c.
-inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
+template <typename T>
+inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, T a, T c, T b)
 {
-  FPResult result{std::fma(a, c, b)};
+  FPResult result{static_cast<double>(std::fma(a, c, b))};
 
   if (std::isnan(result.value))
   {
@@ -303,17 +304,17 @@ inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, do
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(a);
+      result.value = MakeQuiet(static_cast<float>(a));
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(b);  // !
+      result.value = MakeQuiet(static_cast<float>(b));  // !
       return result;
     }
     if (std::isnan(c))
     {
-      result.value = MakeQuiet(c);
+      result.value = MakeQuiet(static_cast<float>(c));
       return result;
     }
 
@@ -328,9 +329,10 @@ inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, do
   return result;
 }
 
-inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, double a, double c, double b)
+template <typename T>
+inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, T a, T c, T b)
 {
-  FPResult result{std::fma(a, c, -b)};
+  FPResult result{static_cast<double>(std::fma(a, c, -b))};
 
   if (std::isnan(result.value))
   {
@@ -341,17 +343,17 @@ inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, double a, double c, do
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(a);
+      result.value = MakeQuiet(static_cast<float>(a));
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(b);  // !
+      result.value = MakeQuiet(static_cast<float>(b));  // !
       return result;
     }
     if (std::isnan(c))
     {
-      result.value = MakeQuiet(c);
+      result.value = MakeQuiet(static_cast<float>(c));
       return result;
     }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -392,7 +392,8 @@ void Interpreter::fmaddx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& a = ppc_state.ps[inst.FA];
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
-  const FPResult product = NI_madd(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
+
+  const FPResult product = NI_madd<false>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -412,8 +413,7 @@ void Interpreter::fmaddsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult product = NI_madd(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
+  const FPResult product = NI_madd<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -602,7 +602,7 @@ void Interpreter::fmsubx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const FPResult product = NI_msub(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
+  const FPResult product = NI_msub<false>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -622,8 +622,7 @@ void Interpreter::fmsubsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult product = NI_msub(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
+  const FPResult product = NI_msub<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -643,7 +642,7 @@ void Interpreter::fnmaddx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const FPResult product = NI_madd(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
+  const FPResult product = NI_madd<false>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -665,8 +664,7 @@ void Interpreter::fnmaddsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult product = NI_madd(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
+  const FPResult product = NI_madd<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -688,7 +686,7 @@ void Interpreter::fnmsubx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const FPResult product = NI_msub(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
+  const FPResult product = NI_msub<false>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -710,8 +708,7 @@ void Interpreter::fnmsubsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult product = NI_msub(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
+  const FPResult product = NI_msub<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -370,11 +370,11 @@ void Interpreter::fmulsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& c = ppc_state.ps[inst.FC];
 
   const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult d_value = NI_mul(ppc_state, a.PS0AsDouble(), c_value);
+  const FPResult product = NI_mul(ppc_state, a.PS0AsDouble(), c_value);
 
-  if (ppc_state.fpscr.VE == 0 || d_value.HasNoInvalidExceptions())
+  if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
-    const float result = ForceSingle(ppc_state.fpscr, d_value.value);
+    const float result = ForceSingle(ppc_state.fpscr, product.value);
 
     ppc_state.ps[inst.FD].Fill(result);
     ppc_state.fpscr.FI = 0;
@@ -412,26 +412,8 @@ void Interpreter::fmaddsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double a_value = a.PS0AsDouble();
-  const double b_value = b.PS0AsDouble();
   const double c_value = Force25Bit(c.PS0AsDouble());
-
-  const float a_float = static_cast<float>(a_value);
-  const float b_float = static_cast<float>(b_value);
-  const float c_float = static_cast<float>(c_value);
-
-  FPResult product;
-  if (a_float == a_value && b_float == b_value && c_float == c_value)
-  {
-    // In most circumstances, all inputs will be floats, rather than anything outside of the float range
-    // To maintain accuracy in these situations the fma is performed directly on the f32 value
-    product = NI_madd(ppc_state, a_float, c_float, b_float);
-  }
-  else
-  {
-    // If any weirdness occurs then we fall back to the less slightly less accurate double version
-    product = NI_madd(ppc_state, a_value, c_value, b_value);
-  }
+  const FPResult product = NI_madd(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -640,19 +622,8 @@ void Interpreter::fmsubsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double a_value = a.PS0AsDouble();
-  const double b_value = b.PS0AsDouble();
   const double c_value = Force25Bit(c.PS0AsDouble());
-
-  const float a_float = static_cast<float>(a_value);
-  const float b_float = static_cast<float>(b_value);
-  const float c_float = static_cast<float>(c_value);
-
-  FPResult product;
-  if (a_float == a_value && b_float == b_value && c_float == c_value)
-    product = NI_msub(ppc_state, a_float, c_float, b_float);
-  else
-    product = NI_msub(ppc_state, a_value, c_value, b_value);
+  const FPResult product = NI_msub(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -694,19 +665,8 @@ void Interpreter::fnmaddsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double a_value = a.PS0AsDouble();
-  const double b_value = b.PS0AsDouble();
   const double c_value = Force25Bit(c.PS0AsDouble());
-
-  const float a_float = static_cast<float>(a_value);
-  const float b_float = static_cast<float>(b_value);
-  const float c_float = static_cast<float>(c_value);
-
-  FPResult product;
-  if (a_float == a_value && b_float == b_value && c_float == c_value)
-    product = NI_madd(ppc_state, a_float, c_float, b_float);
-  else
-    product = NI_madd(ppc_state, a_value, c_value, b_value);
+  const FPResult product = NI_madd(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -750,19 +710,8 @@ void Interpreter::fnmsubsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double a_value = a.PS0AsDouble();
-  const double b_value = b.PS0AsDouble();
   const double c_value = Force25Bit(c.PS0AsDouble());
-
-  const float a_float = static_cast<float>(a_value);
-  const float b_float = static_cast<float>(b_value);
-  const float c_float = static_cast<float>(c_value);
-
-  FPResult product;
-  if (a_float == a_value && b_float == b_value && c_float == c_value)
-    product = NI_msub(ppc_state, a_float, c_float, b_float);
-  else
-    product = NI_msub(ppc_state, a_value, c_value, b_value);
+  const FPResult product = NI_msub(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -412,15 +412,33 @@ void Interpreter::fmaddsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
+  const double a_value = a.PS0AsDouble();
+  const double b_value = b.PS0AsDouble();
   const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult d_value = NI_madd(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
 
-  if (ppc_state.fpscr.VE == 0 || d_value.HasNoInvalidExceptions())
+  const float a_float = static_cast<float>(a_value);
+  const float b_float = static_cast<float>(b_value);
+  const float c_float = static_cast<float>(c_value);
+
+  FPResult product;
+  if (a_float == a_value && b_float == b_value && c_float == c_value)
   {
-    const float result = ForceSingle(ppc_state.fpscr, d_value.value);
+    // In most circumstances, all inputs will be floats, rather than anything outside of the float range
+    // To maintain accuracy in these situations the fma is performed directly on the f32 value
+    product = NI_madd(ppc_state, a_float, c_float, b_float);
+  }
+  else
+  {
+    // If any weirdness occurs then we fall back to the less slightly less accurate double version
+    product = NI_madd(ppc_state, a_value, c_value, b_value);
+  }
+
+  if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
+  {
+    const float result = ForceSingle(ppc_state.fpscr, product.value);
 
     ppc_state.ps[inst.FD].Fill(result);
-    ppc_state.fpscr.FI = d_value.value != result;
+    ppc_state.fpscr.FI = product.value != result;
     ppc_state.fpscr.FR = 0;
     ppc_state.UpdateFPRFSingle(result);
   }
@@ -622,8 +640,19 @@ void Interpreter::fmsubsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
+  const double a_value = a.PS0AsDouble();
+  const double b_value = b.PS0AsDouble();
   const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult product = NI_msub(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
+
+  const float a_float = static_cast<float>(a_value);
+  const float b_float = static_cast<float>(b_value);
+  const float c_float = static_cast<float>(c_value);
+
+  FPResult product;
+  if (a_float == a_value && b_float == b_value && c_float == c_value)
+    product = NI_msub(ppc_state, a_float, c_float, b_float);
+  else
+    product = NI_msub(ppc_state, a_value, c_value, b_value);
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -665,8 +694,19 @@ void Interpreter::fnmaddsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
+  const double a_value = a.PS0AsDouble();
+  const double b_value = b.PS0AsDouble();
   const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult product = NI_madd(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
+
+  const float a_float = static_cast<float>(a_value);
+  const float b_float = static_cast<float>(b_value);
+  const float c_float = static_cast<float>(c_value);
+
+  FPResult product;
+  if (a_float == a_value && b_float == b_value && c_float == c_value)
+    product = NI_madd(ppc_state, a_float, c_float, b_float);
+  else
+    product = NI_madd(ppc_state, a_value, c_value, b_value);
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {
@@ -710,8 +750,19 @@ void Interpreter::fnmsubsx(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
+  const double a_value = a.PS0AsDouble();
+  const double b_value = b.PS0AsDouble();
   const double c_value = Force25Bit(c.PS0AsDouble());
-  const FPResult product = NI_msub(ppc_state, a.PS0AsDouble(), c_value, b.PS0AsDouble());
+
+  const float a_float = static_cast<float>(a_value);
+  const float b_float = static_cast<float>(b_value);
+  const float c_float = static_cast<float>(c_value);
+
+  FPResult product;
+  if (a_float == a_value && b_float == b_value && c_float == c_value)
+    product = NI_msub(ppc_state, a_float, c_float, b_float);
+  else
+    product = NI_msub(ppc_state, a_value, c_value, b_value);
 
   if (ppc_state.fpscr.VE == 0 || product.HasNoInvalidExceptions())
   {

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -263,13 +263,10 @@ void Interpreter::ps_msub(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c0 = Force25Bit(c.PS0AsDouble());
-  const double c1 = Force25Bit(c.PS1AsDouble());
-
   const float ps0 =
-      ForceSingle(ppc_state.fpscr, NI_msub(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_msub<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble()).value);
   const float ps1 =
-      ForceSingle(ppc_state.fpscr, NI_msub(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_msub<true>(ppc_state, a.PS1AsDouble(), c.PS1AsDouble(), b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -285,13 +282,10 @@ void Interpreter::ps_madd(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c0 = Force25Bit(c.PS0AsDouble());
-  const double c1 = Force25Bit(c.PS1AsDouble());
-
   const float ps0 =
-      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_madd<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble()).value);
   const float ps1 =
-      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_madd<true>(ppc_state, a.PS1AsDouble(), c.PS1AsDouble(), b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -307,13 +301,10 @@ void Interpreter::ps_nmsub(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c0 = Force25Bit(c.PS0AsDouble());
-  const double c1 = Force25Bit(c.PS1AsDouble());
-
   const float tmp0 =
-      ForceSingle(ppc_state.fpscr, NI_msub(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_msub<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble()).value);
   const float tmp1 =
-      ForceSingle(ppc_state.fpscr, NI_msub(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_msub<true>(ppc_state, a.PS1AsDouble(), c.PS1AsDouble(), b.PS1AsDouble()).value);
 
   const float ps0 = std::isnan(tmp0) ? tmp0 : -tmp0;
   const float ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
@@ -332,13 +323,10 @@ void Interpreter::ps_nmadd(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c0 = Force25Bit(c.PS0AsDouble());
-  const double c1 = Force25Bit(c.PS1AsDouble());
-
   const float tmp0 =
-      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_madd<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble()).value);
   const float tmp1 =
-      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_madd<true>(ppc_state, a.PS1AsDouble(), c.PS1AsDouble(), b.PS1AsDouble()).value);
 
   const float ps0 = std::isnan(tmp0) ? tmp0 : -tmp0;
   const float ps1 = std::isnan(tmp1) ? tmp1 : -tmp1;
@@ -427,11 +415,10 @@ void Interpreter::ps_madds0(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c0 = Force25Bit(c.PS0AsDouble());
   const float ps0 =
-      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS0AsDouble(), c0, b.PS0AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_madd<true>(ppc_state, a.PS0AsDouble(), c.PS0AsDouble(), b.PS0AsDouble()).value);
   const float ps1 =
-      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS1AsDouble(), c0, b.PS1AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_madd<true>(ppc_state, a.PS1AsDouble(), c.PS0AsDouble(), b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);
@@ -447,11 +434,10 @@ void Interpreter::ps_madds1(Interpreter& interpreter, UGeckoInstruction inst)
   const auto& b = ppc_state.ps[inst.FB];
   const auto& c = ppc_state.ps[inst.FC];
 
-  const double c1 = Force25Bit(c.PS1AsDouble());
   const float ps0 =
-      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS0AsDouble(), c1, b.PS0AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_madd<true>(ppc_state, a.PS0AsDouble(), c.PS1AsDouble(), b.PS0AsDouble()).value);
   const float ps1 =
-      ForceSingle(ppc_state.fpscr, NI_madd(ppc_state, a.PS1AsDouble(), c1, b.PS1AsDouble()).value);
+      ForceSingle(ppc_state.fpscr, NI_madd<true>(ppc_state, a.PS1AsDouble(), c.PS1AsDouble(), b.PS1AsDouble()).value);
 
   ppc_state.ps[inst.FD].SetBoth(ps0, ps1);
   ppc_state.UpdateFPRFSingle(ps0);


### PR DESCRIPTION
Adjusts all single-precision FMA instructions to check in the interpreter if the inputs all can be represented by 32-bit floats, and if so, performing a 32-bit FMA on them! This fixes an issue as mentioned in <https://bugs.dolphin-emu.org/issues/13865>, along with *thoroughly* explaining every completed and uncompleted quirk of fmadds/etc, along with explaining why this is necessary with the Super Mario Strikers example (as shown in the issue), and what could potentially cause additional cases to be added to the code in the future
I'm not super happy with the name `NI_madd_msub`, but I can't think of anything better as of now, sorry
This also moves `Round25Bit` into `NI_madd_msub`, because now it needs to check if the input is single precision anyways, it's just a bit less duplicate code
I'm half sorry for the huge comment but also hope it's informative and makes it completely obvious why any possible future discrepancies may be caused, and why the code is there in the first place :>