### PR TITLE
JitArm64: Add missing ORR pattern in MOVI2RImpl

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1908,7 +1908,7 @@ void ARM64XEmitter::MOVI2RImpl(ARM64Reg Rd, T imm)
   {
     if constexpr (sizeof(T) == 8)
     {
-      for (u64 orr_imm : {(imm << 32) | (imm & 0x0000'0000'FFFF'FFFF),
+      for (u64 orr_imm : {imm, (imm << 32) | (imm & 0x0000'0000'FFFF'FFFF),
                           (imm & 0xFFFF'FFFF'0000'0000) | (imm >> 32),
                           (imm << 48) | (imm & 0x0000'FFFF'FFFF'0000) | (imm >> 48)})
       {

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1913,7 +1913,12 @@ void ARM64XEmitter::MOVI2RImpl(ARM64Reg Rd, T imm)
                           (imm << 48) | (imm & 0x0000'FFFF'FFFF'0000) | (imm >> 48)})
       {
         if (LogicalImm(orr_imm, GPRSize::B64))
+        {
           try_base(orr_imm, Approach::ORRBase, false);
+
+          if (instructions_required(best_parts, best_approach) <= 1)
+            break;
+        }
       }
     }
     else


### PR DESCRIPTION
We should attempt to use not only mirrored versions of the immediate as an ORR base, but also the immediate itself. This lets us emit certain 64-bit constants using fewer instructions.