### PR TITLE
Data: add gecko code for Mario Strikers Charged that allows disabling captain mega strikes

### DIFF
--- a/Data/Sys/GameSettings/R4QE01.ini
+++ b/Data/Sys/GameSettings/R4QE01.ini
@@ -1,0 +1,6 @@
+# R4QE01 - Mario Strikers Charged
+[Gecko]
+$Disable Captain Mega Strikes [0BYK0]
+0402f788 38600000
+0402f78c 480000a0
+* Disables Mega Strikes from all captains. This makes it far easier to play this game with a controller instead of a WiiMote if preferred.

--- a/Data/Sys/GameSettings/R4QJ01.ini
+++ b/Data/Sys/GameSettings/R4QJ01.ini
@@ -1,0 +1,6 @@
+# R4QJ01 - Mario Strikers Charged
+[Gecko]
+$Disable Captain Mega Strikes [0BYK0]
+0402f788 38600000
+0402f78c 480000a0
+* Disables Mega Strikes from all captains. This makes it far easier to play this game with a controller instead of a WiiMote if preferred.

--- a/Data/Sys/GameSettings/R4QK01.ini
+++ b/Data/Sys/GameSettings/R4QK01.ini
@@ -1,0 +1,5 @@
+# R4QK01 - Mario Strikers Charged
+[Gecko]
+$Disable Captain Mega Strikes [0BYK0]
+0402f7f0 38600000
+* Disables Mega Strikes from all captains. This makes it far easier to play this game with a controller instead of a WiiMote if preferred.

--- a/Data/Sys/GameSettings/R4QP01r1.ini
+++ b/Data/Sys/GameSettings/R4QP01r1.ini
@@ -1,0 +1,6 @@
+# R4QP01r1 - Mario Strikers Charged
+[Gecko]
+$Disable Captain Mega Strikes [0BYK0]
+0402f6e0 38600000
+0402f6e4 48000008
+* Disables Mega Strikes from all captains. This makes it far easier to play this game with a controller instead of a WiiMote if preferred.

--- a/Data/Sys/GameSettings/R4QP01r2.ini
+++ b/Data/Sys/GameSettings/R4QP01r2.ini
@@ -1,0 +1,6 @@
+# R4QP01r2 - Mario Strikers Charged
+[Gecko]
+$Disable Captain Mega Strikes [0BYK0]
+0402f78c 38600000
+0402f790 48000008
+* Disables Mega Strikes from all captains. This makes it far easier to play this game with a controller instead of a WiiMote if preferred.


### PR DESCRIPTION
A request from the Mario Strikers community, they wanted this cheat added that allows the game to be more accessible with a traditional controller (by disabling Captain Mega Strikes)