### PR TITLE
CMakeLists: Set `-ffp-model=strict` when using clang

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -62,6 +62,13 @@ else()
   endif()
 endif()
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # By default, LLVM allows all NaNs to be treated as if they were quiet NaNs.
+  # This causes problems in Common::ApproximateReciprocalSquareRoot().
+  # https://llvm.org/docs/LangRef.html#behavior-of-floating-point-nan-values
+  check_and_add_flag(FFP_MODEL -ffp-model=strict)
+endif()
+
 # These aren't actually needed for C11/C++11
 # but some dependencies require them (LLVM, libav).
 add_definitions(-D__STDC_LIMIT_MACROS)


### PR DESCRIPTION
I recently upgraded the Xcode on the Mac builder from 15.4 to 16.4. Unit tests related to floating point operations began to fail after the upgrade.

Apparently, something changed within clang which caused `Common::ApproximateReciprocalSquareRoot()` to start returning incorrect values for some inputs:

```
Expected equality of these values:
  expected
    Which is: 7FF8000000000001
  actual
    Which is: 7FF0000000000001
Expected equality of these values:
  expected
    Which is: 7FFFFFFFFFFFFFFF
  actual
    Which is: 7FF7FFFFFFFFFFFF
Expected equality of these values:
  expected
    Which is: FFF8000000000001
  actual
    Which is: FFF0000000000001
Expected equality of these values:
  expected
    Which is: FFFFFFFFFFFFFFFF
  actual
    Which is: FFF7FFFFFFFFFFFF
```

Geotale helped me track down the problem to [this line](https://github.com/dolphin-emu/dolphin/blob/b8352eeeb99721abbfa34473878f10863223b178/Source/Core/Common/FloatUtils.cpp#L111). After the update, it no longer turned SNaNs into QNaNs.

By default, [LLVM has the following behaviour](https://reviews.llvm.org/D143074):

```
The default LLVM floating-point environment assumes that traps are disabled and
status flags are not observable. Therefore, floating-point math operations do
not have side effects and may be speculated freely. Results assume the
round-to-nearest rounding mode.

Floating-point math operations are allowed to treat all NaNs as if they were
quiet NaNs. For example, "pow(1.0, SNaN)" may be simplified to 1.0. This also
means that SNaN may be passed through a math operation without quieting. For
example, "fmul SNaN, 1.0" may be simplified to SNaN rather than QNaN. However,
SNaN values are never created by math operations. They may only occur when
provided as a program input value.
```

Setting `-ffp-model=strict` fixes the issue.

However, I'm not sure if I should be using this flag, `-ffp-exception-behavior=strict`, or perhaps using pragmas (`#pragma clang fp exceptions(strict)`) to only modify the behavior within `Common::ApproximateReciprocalSquareRoot()`.