### PR TITLE
FloatUtils: Replace quieting SNaNs via `0.0 + x` with MakeQuiet

### DIFF
--- a/Source/Core/Common/FloatUtils.cpp
+++ b/Source/Core/Common/FloatUtils.cpp
@@ -108,7 +108,7 @@ double ApproximateReciprocalSquareRoot(double val)
       return 0.0;
     }
 
-    return 0.0 + val;
+    return MakeQuiet(val);
   }
 
   // Negative numbers return NaN
@@ -165,7 +165,7 @@ double ApproximateReciprocal(double val)
   {
     if (mantissa == 0)
       return std::copysign(0.0, val);
-    return 0.0 + val;
+    return MakeQuiet(val);
   }
 
   // Special case small inputs

--- a/Source/Core/Common/FloatUtils.h
+++ b/Source/Core/Common/FloatUtils.h
@@ -68,6 +68,13 @@ inline double FlushToZero(double d)
   return std::bit_cast<double>(i);
 }
 
+inline double MakeQuiet(double d)
+{
+  const u64 integral = std::bit_cast<u64>(d) | Common::DOUBLE_QBIT;
+
+  return std::bit_cast<double>(integral);
+}
+
 enum PPCFpClass
 {
   PPC_FPCLASS_QNAN = 0x11,

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -123,13 +123,6 @@ inline double Force25Bit(double d)
   return std::bit_cast<double>(integral);
 }
 
-inline double MakeQuiet(double d)
-{
-  const u64 integral = std::bit_cast<u64>(d) | Common::DOUBLE_QBIT;
-
-  return std::bit_cast<double>(integral);
-}
-
 // these functions allow globally modify operations behaviour
 // also, these may be used to set flags like FR, FI, OX, UX
 
@@ -162,12 +155,12 @@ inline FPResult NI_mul(PowerPC::PowerPCState& ppc_state, double a, double b)
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(a);
+      result.value = Common::MakeQuiet(a);
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(b);
+      result.value = Common::MakeQuiet(b);
       return result;
     }
 
@@ -200,12 +193,12 @@ inline FPResult NI_div(PowerPC::PowerPCState& ppc_state, double a, double b)
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(a);
+      result.value = Common::MakeQuiet(a);
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(b);
+      result.value = Common::MakeQuiet(b);
       return result;
     }
 
@@ -234,12 +227,12 @@ inline FPResult NI_add(PowerPC::PowerPCState& ppc_state, double a, double b)
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(a);
+      result.value = Common::MakeQuiet(a);
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(b);
+      result.value = Common::MakeQuiet(b);
       return result;
     }
 
@@ -267,12 +260,12 @@ inline FPResult NI_sub(PowerPC::PowerPCState& ppc_state, double a, double b)
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(a);
+      result.value = Common::MakeQuiet(a);
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(b);
+      result.value = Common::MakeQuiet(b);
       return result;
     }
 
@@ -303,17 +296,17 @@ inline FPResult NI_madd(PowerPC::PowerPCState& ppc_state, double a, double c, do
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(a);
+      result.value = Common::MakeQuiet(a);
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(b);  // !
+      result.value = Common::MakeQuiet(b);  // !
       return result;
     }
     if (std::isnan(c))
     {
-      result.value = MakeQuiet(c);
+      result.value = Common::MakeQuiet(c);
       return result;
     }
 
@@ -341,17 +334,17 @@ inline FPResult NI_msub(PowerPC::PowerPCState& ppc_state, double a, double c, do
 
     if (std::isnan(a))
     {
-      result.value = MakeQuiet(a);
+      result.value = Common::MakeQuiet(a);
       return result;
     }
     if (std::isnan(b))
     {
-      result.value = MakeQuiet(b);  // !
+      result.value = Common::MakeQuiet(b);  // !
       return result;
     }
     if (std::isnan(c))
     {
-      result.value = MakeQuiet(c);
+      result.value = Common::MakeQuiet(c);
       return result;
     }
 


### PR DESCRIPTION
I recently upgraded the Xcode on the Mac builder from 15.4 to 16.4. Unit tests related to floating point operations began to fail after the upgrade.

Apparently, something changed within clang which caused `Common::ApproximateReciprocalSquareRoot()` to start returning incorrect values for some inputs:

```
Expected equality of these values:
  expected
    Which is: 7FF8000000000001
  actual
    Which is: 7FF0000000000001
Expected equality of these values:
  expected
    Which is: 7FFFFFFFFFFFFFFF
  actual
    Which is: 7FF7FFFFFFFFFFFF
Expected equality of these values:
  expected
    Which is: FFF8000000000001
  actual
    Which is: FFF0000000000001
Expected equality of these values:
  expected
    Which is: FFFFFFFFFFFFFFFF
  actual
    Which is: FFF7FFFFFFFFFFFF
```

Geotale helped me track down the problem to [this line](https://github.com/dolphin-emu/dolphin/blob/b8352eeeb99721abbfa34473878f10863223b178/Source/Core/Common/FloatUtils.cpp#L111). After the update, it no longer turned SNaNs into QNaNs.

By default, [LLVM has the following behaviour](https://reviews.llvm.org/D143074):

```
The default LLVM floating-point environment assumes that traps are disabled and
status flags are not observable. Therefore, floating-point math operations do
not have side effects and may be speculated freely. Results assume the
round-to-nearest rounding mode.

Floating-point math operations are allowed to treat all NaNs as if they were
quiet NaNs. For example, "pow(1.0, SNaN)" may be simplified to 1.0. This also
means that SNaN may be passed through a math operation without quieting. For
example, "fmul SNaN, 1.0" may be simplified to SNaN rather than QNaN. However,
SNaN values are never created by math operations. They may only occur when
provided as a program input value.
```

Geotale suggested that the function `MakeQuiet` could be used instead of `0.0 + x` to solve the problem.