### PR TITLE
FIFOAnalyzer: fix command description updates

### DIFF
--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -117,8 +117,7 @@ void FIFOAnalyzer::CreateWidgets()
 void FIFOAnalyzer::ConnectWidgets()
 {
   connect(m_tree_widget, &QTreeWidget::itemSelectionChanged, this, &FIFOAnalyzer::UpdateDetails);
-  connect(m_detail_list, &QListWidget::itemSelectionChanged, this,
-          &FIFOAnalyzer::UpdateDescription);
+  connect(m_detail_list, &QListWidget::currentRowChanged, this, &FIFOAnalyzer::UpdateDescription);
 
   connect(m_search_edit, &QLineEdit::returnPressed, this, &FIFOAnalyzer::BeginSearch);
   connect(m_search_new, &QPushButton::clicked, this, &FIFOAnalyzer::BeginSearch);


### PR DESCRIPTION
When dragging the selection, the mismatch between signal (itemSelectionChanged) and data consumed (currentRow) seemed to cause the description to lag behind by one row.