### PR TITLE
Define DATA_ROOT_DIR and use it to look for locale files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,9 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Set up paths
 set(datadir ${CMAKE_INSTALL_FULL_DATADIR}/dolphin-emu CACHE PATH "datadir")
+set(datarootdir ${CMAKE_INSTALL_FULL_DATAROOTDIR} CACHE PATH "datarootdir")
 add_definitions(-DDATA_DIR="${datadir}/")
+add_definitions(-DDATA_ROOT_DIR="${datarootdir}/")
 
 if(CMAKE_SYSROOT)
   # If we should use a sysroot, tell pkg-config to search for packages in there, not on the host

--- a/Source/Core/DolphinQt/Translation.cpp
+++ b/Source/Core/DolphinQt/Translation.cpp
@@ -284,7 +284,7 @@ static bool TryInstallTranslator(const QString& exact_language_code)
 #elif defined LINUX_LOCAL_DEV
         fmt::format("{}/../Source/Core/DolphinQt/{}/dolphin-emu.mo", File::GetExeDirectory(), lang)
 #else
-        fmt::format("{}/../locale/{}/LC_MESSAGES/dolphin-emu.mo", DATA_DIR, lang)
+        fmt::format("{}/locale/{}/LC_MESSAGES/dolphin-emu.mo", DATA_ROOT_DIR, lang)
 #endif
         ;
 


### PR DESCRIPTION
If DATA_DIR was modified at build time, locale files won't be picked up, as they are (correctly) installed into the system's localedir, not a path based on $datadir.