### PR TITLE
GameINI: Disable ImmediateXFBEnable for Grooverider.

### DIFF
--- a/Data/Sys/GameSettings/GVR.ini
+++ b/Data/Sys/GameSettings/GVR.ini
@@ -1,0 +1,15 @@
+# GVRE7H - Grooverider: Slot Car Thunder
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+
+[Video_Hacks]
+ImmediateXFBEnable = False


### PR DESCRIPTION
Immediate XFB causes constant flickering when in game.