### PR TITLE
PatchEngine: OSD message showing number of enabled patches and cheats

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -174,6 +174,15 @@ void AddCode(ARCode code)
   }
 }
 
+size_t CountEnabledCodes()
+{
+  if (!Config::AreCheatsEnabled())
+    return 0;
+
+  std::lock_guard guard(s_lock);
+  return s_active_codes.size();
+}
+
 void LoadAndApplyCodes(const Common::IniFile& global_ini, const Common::IniFile& local_ini,
                        const std::string& game_id, u16 revision)
 {

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -50,6 +50,7 @@ void SetSyncedCodesAsActive();
 void UpdateSyncedCodes(std::span<const ARCode> codes);
 std::vector<ARCode> ApplyAndReturnCodes(std::span<const ARCode> codes);
 void AddCode(ARCode new_code);
+size_t CountEnabledCodes();
 void LoadAndApplyCodes(const Common::IniFile& global_ini, const Common::IniFile& local_ini,
                        const std::string& game_id, u16 revision);
 

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -50,6 +50,15 @@ static std::vector<GeckoCode> s_active_codes;
 static std::vector<GeckoCode> s_synced_codes;
 static std::mutex s_active_codes_lock;
 
+size_t CountEnabledCodes()
+{
+  if (!Config::AreCheatsEnabled())
+    return 0;
+
+  std::lock_guard guard(s_active_codes_lock);
+  return s_active_codes.size();
+}
+
 void SetActiveCodes(std::span<const GeckoCode> gcodes, const std::string& game_id, u16 revision)
 {
   std::lock_guard lk(s_active_codes_lock);

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -60,6 +60,7 @@ constexpr u32 HLE_TRAMPOLINE_ADDRESS = INSTALLER_END_ADDRESS - 4;
 // preserve the emulation performance.
 constexpr u32 MAGIC_GAMEID = 0xD01F1BAD;
 
+size_t CountEnabledCodes();
 void SetActiveCodes(std::span<const GeckoCode> gcodes, const std::string& game_id, u16 revision);
 void SetSyncedCodesAsActive();
 void UpdateSyncedCodes(std::span<const GeckoCode> gcodes);

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -35,6 +35,7 @@
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
+#include "VideoCommon/OnScreenDisplay.h"
 
 namespace PatchEngine
 {
@@ -200,6 +201,18 @@ void LoadPatches()
     ActionReplay::LoadAndApplyCodes(globalIni, localIni, sconfig.GetGameID(),
                                     sconfig.GetRevision());
   }
+
+  const size_t enabled_patch_count =
+      std::ranges::count_if(s_on_frame, [](Patch patch) { return patch.enabled; });
+  if (enabled_patch_count > 0)
+  {
+    OSD::AddMessage(fmt::format("{} game patch(es) enabled", enabled_patch_count),
+                    OSD::Duration::NORMAL);
+  }
+
+  const size_t enabled_cheat_count = ActionReplay::CountEnabledCodes() + Gecko::CountEnabledCodes();
+  if (enabled_cheat_count > 0)
+    OSD::AddMessage(fmt::format("{} cheat(s) enabled", enabled_cheat_count), OSD::Duration::NORMAL);
 }
 
 static void ApplyPatches(const Core::CPUThreadGuard& guard, const std::vector<Patch>& patches)


### PR DESCRIPTION
Informing the user never hurts.

The count for AR and Gecko codes is intentionally combined. <sub><sup>In the future, I'd like to merge their tabs in the UI as well...</sup></sub>