### PR TITLE
VideoBackends / VideoCommon: rename member variables in RenderState

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -365,16 +365,16 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
   if (it != m_blend.end())
     return it->second.Get();
 
-  if (state.logicopenable && g_backend_info.bSupportsLogicOp)
+  if (state.logic_op_enable && g_backend_info.bSupportsLogicOp)
   {
     D3D11_BLEND_DESC1 desc = {};
     D3D11_RENDER_TARGET_BLEND_DESC1& tdesc = desc.RenderTarget[0];
-    if (state.colorupdate)
+    if (state.color_update)
       tdesc.RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_RED | D3D11_COLOR_WRITE_ENABLE_GREEN |
                                     D3D11_COLOR_WRITE_ENABLE_BLUE;
     else
       tdesc.RenderTargetWriteMask = 0;
-    if (state.alphaupdate)
+    if (state.alpha_update)
       tdesc.RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
 
     static constexpr std::array<D3D11_LOGIC_OP, 16> logic_ops = {
@@ -384,7 +384,7 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
          D3D11_LOGIC_OP_COPY_INVERTED, D3D11_LOGIC_OP_OR_INVERTED, D3D11_LOGIC_OP_NAND,
          D3D11_LOGIC_OP_SET}};
     tdesc.LogicOpEnable = TRUE;
-    tdesc.LogicOp = logic_ops[u32(state.logicmode.Value())];
+    tdesc.LogicOp = logic_ops[u32(state.logic_mode.Value())];
 
     ComPtr<ID3D11BlendState1> res;
     HRESULT hr = D3D::device1->CreateBlendState1(&desc, res.GetAddressOf());
@@ -400,17 +400,17 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
   desc.IndependentBlendEnable = FALSE;
 
   D3D11_RENDER_TARGET_BLEND_DESC& tdesc = desc.RenderTarget[0];
-  tdesc.BlendEnable = state.blendenable;
+  tdesc.BlendEnable = state.blend_enable;
 
-  if (state.colorupdate)
+  if (state.color_update)
     tdesc.RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_RED | D3D11_COLOR_WRITE_ENABLE_GREEN |
                                   D3D11_COLOR_WRITE_ENABLE_BLUE;
   else
     tdesc.RenderTargetWriteMask = 0;
-  if (state.alphaupdate)
+  if (state.alpha_update)
     tdesc.RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
 
-  const bool use_dual_source = state.usedualsrc;
+  const bool use_dual_source = state.use_dual_src;
   const std::array<D3D11_BLEND, 8> src_factors = {
       {D3D11_BLEND_ZERO, D3D11_BLEND_ONE, D3D11_BLEND_DEST_COLOR, D3D11_BLEND_INV_DEST_COLOR,
        use_dual_source ? D3D11_BLEND_SRC1_ALPHA : D3D11_BLEND_SRC_ALPHA,
@@ -422,12 +422,12 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
        use_dual_source ? D3D11_BLEND_INV_SRC1_ALPHA : D3D11_BLEND_INV_SRC_ALPHA,
        D3D11_BLEND_DEST_ALPHA, D3D11_BLEND_INV_DEST_ALPHA}};
 
-  tdesc.SrcBlend = src_factors[u32(state.srcfactor.Value())];
-  tdesc.SrcBlendAlpha = src_factors[u32(state.srcfactoralpha.Value())];
-  tdesc.DestBlend = dst_factors[u32(state.dstfactor.Value())];
-  tdesc.DestBlendAlpha = dst_factors[u32(state.dstfactoralpha.Value())];
+  tdesc.SrcBlend = src_factors[u32(state.src_factor.Value())];
+  tdesc.SrcBlendAlpha = src_factors[u32(state.src_factor_alpha.Value())];
+  tdesc.DestBlend = dst_factors[u32(state.dst_factor.Value())];
+  tdesc.DestBlendAlpha = dst_factors[u32(state.dst_factor_alpha.Value())];
   tdesc.BlendOp = state.subtract ? D3D11_BLEND_OP_REV_SUBTRACT : D3D11_BLEND_OP_ADD;
-  tdesc.BlendOpAlpha = state.subtractAlpha ? D3D11_BLEND_OP_REV_SUBTRACT : D3D11_BLEND_OP_ADD;
+  tdesc.BlendOpAlpha = state.subtract_alpha ? D3D11_BLEND_OP_REV_SUBTRACT : D3D11_BLEND_OP_ADD;
 
   ComPtr<ID3D11BlendState> res;
   HRESULT hr = D3D::device->CreateBlendState(&desc, res.GetAddressOf());
@@ -447,7 +447,7 @@ ID3D11RasterizerState* StateCache::Get(RasterizationState state)
 
   D3D11_RASTERIZER_DESC desc = {};
   desc.FillMode = D3D11_FILL_SOLID;
-  desc.CullMode = cull_modes[u32(state.cullmode.Value())];
+  desc.CullMode = cull_modes[u32(state.cull_mode.Value())];
   desc.ScissorEnable = TRUE;
 
   ComPtr<ID3D11RasterizerState> res;
@@ -478,11 +478,11 @@ ID3D11DepthStencilState* StateCache::Get(DepthState state)
       D3D11_COMPARISON_GREATER_EQUAL, D3D11_COMPARISON_LESS,    D3D11_COMPARISON_NOT_EQUAL,
       D3D11_COMPARISON_LESS_EQUAL,    D3D11_COMPARISON_ALWAYS};
 
-  if (state.testenable)
+  if (state.test_enable)
   {
     depthdc.DepthEnable = TRUE;
     depthdc.DepthWriteMask =
-        state.updateenable ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
+        state.update_enable ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
     depthdc.DepthFunc = d3dCmpFuncs[u32(state.func.Value())];
   }
   else

--- a/Source/Core/VideoBackends/D3D/DXPipeline.cpp
+++ b/Source/Core/VideoBackends/D3D/DXPipeline.cpp
@@ -54,7 +54,8 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
           nullptr;
 
   // Only use the integer RTV if logic op is supported, and enabled.
-  const bool use_logic_op = config.blending_state.logicopenable && g_backend_info.bSupportsLogicOp;
+  const bool use_logic_op =
+      config.blending_state.logic_op_enable && g_backend_info.bSupportsLogicOp;
 
   return std::make_unique<DXPipeline>(config, input_layout, vertex_shader->GetD3DVertexShader(),
                                       geometry_shader ? geometry_shader->GetD3DGeometryShader() :

--- a/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
+++ b/Source/Core/VideoBackends/D3D12/DX12Pipeline.cpp
@@ -66,7 +66,7 @@ static void GetD3DRasterizerDesc(D3D12_RASTERIZER_DESC* desc, const Rasterizatio
       {D3D12_CULL_MODE_NONE, D3D12_CULL_MODE_BACK, D3D12_CULL_MODE_FRONT, D3D12_CULL_MODE_FRONT}};
 
   desc->FillMode = D3D12_FILL_MODE_SOLID;
-  desc->CullMode = cull_modes[u32(rs_state.cullmode.Value())];
+  desc->CullMode = cull_modes[u32(rs_state.cull_mode.Value())];
   desc->MultisampleEnable = fb_state.samples > 1;
 }
 
@@ -79,10 +79,10 @@ static void GetD3DDepthDesc(D3D12_DEPTH_STENCIL_DESC* desc, const DepthState& st
        D3D12_COMPARISON_FUNC_NOT_EQUAL, D3D12_COMPARISON_FUNC_LESS_EQUAL,
        D3D12_COMPARISON_FUNC_ALWAYS}};
 
-  desc->DepthEnable = state.testenable;
+  desc->DepthEnable = state.test_enable;
   desc->DepthFunc = compare_funcs[u32(state.func.Value())];
   desc->DepthWriteMask =
-      state.updateenable ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
+      state.update_enable ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
 }
 
 static void GetD3DBlendDesc(D3D12_BLEND_DESC* desc, const BlendingState& state,
@@ -119,44 +119,44 @@ static void GetD3DBlendDesc(D3D12_BLEND_DESC* desc, const BlendingState& state,
   for (u8 i = 0; i < render_target_count; i++)
   {
     D3D12_RENDER_TARGET_BLEND_DESC* rtblend = &desc->RenderTarget[i];
-    if (state.colorupdate)
+    if (state.color_update)
     {
       rtblend->RenderTargetWriteMask |= D3D12_COLOR_WRITE_ENABLE_RED |
                                         D3D12_COLOR_WRITE_ENABLE_GREEN |
                                         D3D12_COLOR_WRITE_ENABLE_BLUE;
     }
-    if (state.alphaupdate)
+    if (state.alpha_update)
     {
       rtblend->RenderTargetWriteMask |= D3D12_COLOR_WRITE_ENABLE_ALPHA;
     }
 
     // blend takes precedence over logic op
-    rtblend->BlendEnable = state.blendenable;
-    if (state.blendenable)
+    rtblend->BlendEnable = state.blend_enable;
+    if (state.blend_enable)
     {
       rtblend->BlendOp = state.subtract ? D3D12_BLEND_OP_REV_SUBTRACT : D3D12_BLEND_OP_ADD;
       rtblend->BlendOpAlpha =
-          state.subtractAlpha ? D3D12_BLEND_OP_REV_SUBTRACT : D3D12_BLEND_OP_ADD;
-      if (state.usedualsrc)
+          state.subtract_alpha ? D3D12_BLEND_OP_REV_SUBTRACT : D3D12_BLEND_OP_ADD;
+      if (state.use_dual_src)
       {
-        rtblend->SrcBlend = src_dual_src_factors[u32(state.srcfactor.Value())];
-        rtblend->SrcBlendAlpha = src_dual_src_factors[u32(state.srcfactoralpha.Value())];
-        rtblend->DestBlend = dst_dual_src_factors[u32(state.dstfactor.Value())];
-        rtblend->DestBlendAlpha = dst_dual_src_factors[u32(state.dstfactoralpha.Value())];
+        rtblend->SrcBlend = src_dual_src_factors[u32(state.src_factor.Value())];
+        rtblend->SrcBlendAlpha = src_dual_src_factors[u32(state.src_factor_alpha.Value())];
+        rtblend->DestBlend = dst_dual_src_factors[u32(state.dst_factor.Value())];
+        rtblend->DestBlendAlpha = dst_dual_src_factors[u32(state.dst_factor_alpha.Value())];
       }
       else
       {
-        rtblend->SrcBlend = src_factors[u32(state.srcfactor.Value())];
-        rtblend->SrcBlendAlpha = src_factors[u32(state.srcfactoralpha.Value())];
-        rtblend->DestBlend = dst_factors[u32(state.dstfactor.Value())];
-        rtblend->DestBlendAlpha = dst_factors[u32(state.dstfactoralpha.Value())];
+        rtblend->SrcBlend = src_factors[u32(state.src_factor.Value())];
+        rtblend->SrcBlendAlpha = src_factors[u32(state.src_factor_alpha.Value())];
+        rtblend->DestBlend = dst_factors[u32(state.dst_factor.Value())];
+        rtblend->DestBlendAlpha = dst_factors[u32(state.dst_factor_alpha.Value())];
       }
     }
     else
     {
-      rtblend->LogicOpEnable = state.logicopenable;
-      if (state.logicopenable)
-        rtblend->LogicOp = logic_ops[u32(state.logicmode.Value())];
+      rtblend->LogicOpEnable = state.logic_op_enable;
+      if (state.logic_op_enable)
+        rtblend->LogicOp = logic_ops[u32(state.logic_mode.Value())];
     }
   }
 }
@@ -204,7 +204,7 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
     desc.NumRenderTargets =
         static_cast<u8>(config.framebuffer_state.additional_color_attachment_count) + 1;
     desc.RTVFormats[0] = D3DCommon::GetRTVFormatForAbstractFormat(
-        config.framebuffer_state.color_texture_format, config.blending_state.logicopenable);
+        config.framebuffer_state.color_texture_format, config.blending_state.logic_op_enable);
     for (u8 i = 0; i < static_cast<u8>(config.framebuffer_state.additional_color_attachment_count);
          i++)
     {
@@ -230,7 +230,7 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
   }
 
   const bool use_integer_rtv =
-      !config.blending_state.blendenable && config.blending_state.logicopenable;
+      !config.blending_state.blend_enable && config.blending_state.logic_op_enable;
   return std::make_unique<DXPipeline>(config, pso, desc.pRootSignature, config.usage,
                                       GetD3DTopology(config.rasterization_state), use_integer_rtv);
 }

--- a/Source/Core/VideoBackends/Metal/MTLObjectCache.h
+++ b/Source/Core/VideoBackends/Metal/MTLObjectCache.h
@@ -30,8 +30,8 @@ struct DepthStencilSelector
   {
   }
   DepthStencilSelector(DepthState state)
-      : DepthStencilSelector(state.testenable ? state.updateenable : false,
-                             state.testenable ? state.func : CompareMode::Always)
+      : DepthStencilSelector(state.test_enable ? state.update_enable : false,
+                             state.test_enable ? state.func : CompareMode::Always)
   {
   }
 

--- a/Source/Core/VideoBackends/Metal/MTLObjectCache.mm
+++ b/Source/Core/VideoBackends/Metal/MTLObjectCache.mm
@@ -230,7 +230,7 @@ static MTLCullMode Convert(CullMode cull)
   }
 }
 
-static MTLBlendFactor Convert(DstBlendFactor factor, bool usedualsrc)
+static MTLBlendFactor Convert(DstBlendFactor factor, bool use_dual_src)
 {
   // clang-format off
   switch (factor)
@@ -239,9 +239,9 @@ static MTLBlendFactor Convert(DstBlendFactor factor, bool usedualsrc)
   case DstBlendFactor::One:         return MTLBlendFactorOne;
   case DstBlendFactor::SrcClr:      return MTLBlendFactorSourceColor;
   case DstBlendFactor::InvSrcClr:   return MTLBlendFactorOneMinusSourceColor;
-  case DstBlendFactor::SrcAlpha:    return usedualsrc ? MTLBlendFactorSource1Alpha
+  case DstBlendFactor::SrcAlpha:    return use_dual_src ? MTLBlendFactorSource1Alpha
                                                       : MTLBlendFactorSourceAlpha;
-  case DstBlendFactor::InvSrcAlpha: return usedualsrc ? MTLBlendFactorOneMinusSource1Alpha
+  case DstBlendFactor::InvSrcAlpha: return use_dual_src ? MTLBlendFactorOneMinusSource1Alpha
                                                       : MTLBlendFactorOneMinusSourceAlpha;
   case DstBlendFactor::DstAlpha:    return MTLBlendFactorDestinationAlpha;
   case DstBlendFactor::InvDstAlpha: return MTLBlendFactorOneMinusDestinationAlpha;
@@ -249,7 +249,7 @@ static MTLBlendFactor Convert(DstBlendFactor factor, bool usedualsrc)
   // clang-format on
 }
 
-static MTLBlendFactor Convert(SrcBlendFactor factor, bool usedualsrc)
+static MTLBlendFactor Convert(SrcBlendFactor factor, bool use_dual_src)
 {
   // clang-format off
   switch (factor)
@@ -258,9 +258,9 @@ static MTLBlendFactor Convert(SrcBlendFactor factor, bool usedualsrc)
   case SrcBlendFactor::One:         return MTLBlendFactorOne;
   case SrcBlendFactor::DstClr:      return MTLBlendFactorDestinationColor;
   case SrcBlendFactor::InvDstClr:   return MTLBlendFactorOneMinusDestinationColor;
-  case SrcBlendFactor::SrcAlpha:    return usedualsrc ? MTLBlendFactorSource1Alpha
+  case SrcBlendFactor::SrcAlpha:    return use_dual_src ? MTLBlendFactorSource1Alpha
                                                       : MTLBlendFactorSourceAlpha;
-  case SrcBlendFactor::InvSrcAlpha: return usedualsrc ? MTLBlendFactorOneMinusSource1Alpha
+  case SrcBlendFactor::InvSrcAlpha: return use_dual_src ? MTLBlendFactorOneMinusSource1Alpha
                                                       : MTLBlendFactorOneMinusSourceAlpha;
   case SrcBlendFactor::DstAlpha:    return MTLBlendFactorDestinationAlpha;
   case SrcBlendFactor::InvDstAlpha: return MTLBlendFactorOneMinusDestinationAlpha;
@@ -316,19 +316,19 @@ public:
       framebuffer.samples = cfg.framebuffer_state.samples.Value();
       framebuffer.additional_color_attachment_count =
           cfg.framebuffer_state.additional_color_attachment_count.Value();
-      blend.colorupdate = cfg.blending_state.colorupdate.Value();
-      blend.alphaupdate = cfg.blending_state.alphaupdate.Value();
-      if (cfg.blending_state.blendenable)
+      blend.color_update = cfg.blending_state.color_update.Value();
+      blend.alpha_update = cfg.blending_state.alpha_update.Value();
+      if (cfg.blending_state.blend_enable)
       {
         // clang-format off
-        blend.blendenable = true;
-        blend.usedualsrc     = cfg.blending_state.usedualsrc.Value();
-        blend.srcfactor      = cfg.blending_state.srcfactor.Value();
-        blend.dstfactor      = cfg.blending_state.dstfactor.Value();
-        blend.srcfactoralpha = cfg.blending_state.srcfactoralpha.Value();
-        blend.dstfactoralpha = cfg.blending_state.dstfactoralpha.Value();
+        blend.blend_enable = true;
+        blend.use_dual_src     = cfg.blending_state.use_dual_src.Value();
+        blend.src_factor      = cfg.blending_state.src_factor.Value();
+        blend.dst_factor      = cfg.blending_state.dst_factor.Value();
+        blend.src_factor_alpha = cfg.blending_state.src_factor_alpha.Value();
+        blend.dst_factor_alpha = cfg.blending_state.dst_factor_alpha.Value();
         blend.subtract       = cfg.blending_state.subtract.Value();
-        blend.subtractAlpha  = cfg.blending_state.subtractAlpha.Value();
+        blend.subtract_alpha  = cfg.blending_state.subtract_alpha.Value();
         // clang-format on
       }
 
@@ -403,21 +403,21 @@ public:
           [[desc colorAttachments] objectAtIndexedSubscript:0];
       BlendingState bs = config.blending_state;
       MTLColorWriteMask mask = MTLColorWriteMaskNone;
-      if (bs.colorupdate)
+      if (bs.color_update)
         mask |= MTLColorWriteMaskRed | MTLColorWriteMaskGreen | MTLColorWriteMaskBlue;
-      if (bs.alphaupdate)
+      if (bs.alpha_update)
         mask |= MTLColorWriteMaskAlpha;
       [color0 setWriteMask:mask];
-      if (bs.blendenable)
+      if (bs.blend_enable)
       {
         // clang-format off
         [color0 setBlendingEnabled:YES];
-        [color0 setSourceRGBBlendFactor:       Convert(bs.srcfactor,      bs.usedualsrc)];
-        [color0 setSourceAlphaBlendFactor:     Convert(bs.srcfactoralpha, bs.usedualsrc)];
-        [color0 setDestinationRGBBlendFactor:  Convert(bs.dstfactor,      bs.usedualsrc)];
-        [color0 setDestinationAlphaBlendFactor:Convert(bs.dstfactoralpha, bs.usedualsrc)];
+        [color0 setSourceRGBBlendFactor:       Convert(bs.src_factor,      bs.use_dual_src)];
+        [color0 setSourceAlphaBlendFactor:     Convert(bs.src_factor_alpha, bs.use_dual_src)];
+        [color0 setDestinationRGBBlendFactor:  Convert(bs.dst_factor,      bs.use_dual_src)];
+        [color0 setDestinationAlphaBlendFactor:Convert(bs.dst_factor_alpha, bs.use_dual_src)];
         [color0 setRgbBlendOperation:  bs.subtract      ? MTLBlendOperationReverseSubtract : MTLBlendOperationAdd];
-        [color0 setAlphaBlendOperation:bs.subtractAlpha ? MTLBlendOperationReverseSubtract : MTLBlendOperationAdd];
+        [color0 setAlphaBlendOperation:bs.subtract_alpha ? MTLBlendOperationReverseSubtract : MTLBlendOperationAdd];
         // clang-format on
       }
       FramebufferState fs = config.framebuffer_state;
@@ -461,15 +461,15 @@ public:
           fmt::println(file, "Sample Count: {}", fs.samples);
           if (u32 cnt = fs.additional_color_attachment_count)
             fmt::println(file, "Additional Color Attachments: {}", cnt);
-          if (bs.colorupdate && bs.alphaupdate)
+          if (bs.color_update && bs.alpha_update)
             fmt::println(file, "Write Color, Alpha");
-          else if (bs.colorupdate)
+          else if (bs.color_update)
             fmt::println(file, "Write Color");
-          else if (bs.alphaupdate)
+          else if (bs.alpha_update)
             fmt::println(file, "Write Alpha");
           else
             fmt::println(file, "Write None");
-          if (bs.blendenable)
+          if (bs.blend_enable)
           {
             auto print_blend = [file](const char* name, SrcBlendFactor src, DstBlendFactor dst,
                                       bool subtract) {
@@ -478,9 +478,9 @@ public:
               else
                 fmt::println(file, "{}: src * {} + dst * {}", name, src, dst);
             };
-            print_blend("Color Blend", bs.srcfactor, bs.dstfactor, bs.subtract);
-            print_blend("Alpha Blend", bs.srcfactoralpha, bs.dstfactoralpha, bs.subtractAlpha);
-            fmt::println(file, "Blend Dual Source: {}", bs.usedualsrc ? "true" : "false");
+            print_blend("Color Blend", bs.src_factor, bs.dst_factor, bs.subtract);
+            print_blend("Alpha Blend", bs.src_factor_alpha, bs.dst_factor_alpha, bs.subtract_alpha);
+            fmt::println(file, "Blend Dual Source: {}", bs.use_dual_src ? "true" : "false");
           }
           else
           {
@@ -562,7 +562,7 @@ Metal::ObjectCache::CreatePipeline(const AbstractPipelineConfig& config)
     return nullptr;
   return std::make_unique<Pipeline>(config, std::move(pipeline.first), pipeline.second,
                                     Convert(config.rasterization_state.primitive),
-                                    Convert(config.rasterization_state.cullmode),
+                                    Convert(config.rasterization_state.cull_mode),
                                     config.depth_state, config.usage);
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLGfx.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLGfx.cpp
@@ -366,11 +366,11 @@ void OGLGfx::SetAndClearFramebuffer(AbstractFramebuffer* framebuffer, const Clea
   // Restore color/depth mask.
   if (framebuffer->HasColorBuffer())
   {
-    glColorMask(m_current_blend_state.colorupdate, m_current_blend_state.colorupdate,
-                m_current_blend_state.colorupdate, m_current_blend_state.alphaupdate);
+    glColorMask(m_current_blend_state.color_update, m_current_blend_state.color_update,
+                m_current_blend_state.color_update, m_current_blend_state.alpha_update);
   }
   if (framebuffer->HasDepthBuffer())
-    glDepthMask(m_current_depth_state.updateenable);
+    glDepthMask(m_current_depth_state.update_enable);
 }
 
 void OGLGfx::ClearRegion(const MathUtil::Rectangle<int>& target_rc, bool colorEnable,
@@ -400,11 +400,11 @@ void OGLGfx::ClearRegion(const MathUtil::Rectangle<int>& target_rc, bool colorEn
   // Restore color/depth mask.
   if (colorEnable || alphaEnable)
   {
-    glColorMask(m_current_blend_state.colorupdate, m_current_blend_state.colorupdate,
-                m_current_blend_state.colorupdate, m_current_blend_state.alphaupdate);
+    glColorMask(m_current_blend_state.color_update, m_current_blend_state.color_update,
+                m_current_blend_state.color_update, m_current_blend_state.alpha_update);
   }
   if (zEnable)
-    glDepthMask(m_current_depth_state.updateenable);
+    glDepthMask(m_current_depth_state.update_enable);
 }
 
 bool OGLGfx::BindBackbuffer(const ClearColor& clear_color)
@@ -510,11 +510,11 @@ void OGLGfx::ApplyRasterizationState(const RasterizationState state)
     return;
 
   // none, ccw, cw, ccw
-  if (state.cullmode != CullMode::None)
+  if (state.cull_mode != CullMode::None)
   {
     // TODO: GX_CULL_ALL not supported, yet!
     glEnable(GL_CULL_FACE);
-    glFrontFace(state.cullmode == CullMode::Front ? GL_CCW : GL_CW);
+    glFrontFace(state.cull_mode == CullMode::Front ? GL_CCW : GL_CW);
   }
   else
   {
@@ -532,10 +532,10 @@ void OGLGfx::ApplyDepthState(const DepthState state)
   const GLenum glCmpFuncs[8] = {GL_NEVER,   GL_LESS,     GL_EQUAL,  GL_LEQUAL,
                                 GL_GREATER, GL_NOTEQUAL, GL_GEQUAL, GL_ALWAYS};
 
-  if (state.testenable)
+  if (state.test_enable)
   {
     glEnable(GL_DEPTH_TEST);
-    glDepthMask(state.updateenable ? GL_TRUE : GL_FALSE);
+    glDepthMask(state.update_enable ? GL_TRUE : GL_FALSE);
     glDepthFunc(glCmpFuncs[u32(state.func.Value())]);
   }
   else
@@ -555,7 +555,7 @@ void OGLGfx::ApplyBlendingState(const BlendingState state)
   if (m_current_blend_state == state)
     return;
 
-  bool useDualSource = state.usedualsrc;
+  bool useDualSource = state.use_dual_src;
 
   const GLenum src_factors[8] = {GL_ZERO,
                                  GL_ONE,
@@ -576,7 +576,7 @@ void OGLGfx::ApplyBlendingState(const BlendingState state)
                                  GL_DST_ALPHA,
                                  GL_ONE_MINUS_DST_ALPHA};
 
-  if (state.blendenable)
+  if (state.blend_enable)
     glEnable(GL_BLEND);
   else
     glDisable(GL_BLEND);
@@ -586,12 +586,12 @@ void OGLGfx::ApplyBlendingState(const BlendingState state)
   // driver issues?). See https://bugs.dolphin-emu.org/issues/10120 : "Sonic
   // Adventure 2 Battle: graphics crash when loading first Dark level"
   GLenum equation = state.subtract ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
-  GLenum equationAlpha = state.subtractAlpha ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
+  GLenum equationAlpha = state.subtract_alpha ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
   glBlendEquationSeparate(equation, equationAlpha);
-  glBlendFuncSeparate(src_factors[u32(state.srcfactor.Value())],
-                      dst_factors[u32(state.dstfactor.Value())],
-                      src_factors[u32(state.srcfactoralpha.Value())],
-                      dst_factors[u32(state.dstfactoralpha.Value())]);
+  glBlendFuncSeparate(src_factors[u32(state.src_factor.Value())],
+                      dst_factors[u32(state.dst_factor.Value())],
+                      src_factors[u32(state.src_factor_alpha.Value())],
+                      dst_factors[u32(state.dst_factor_alpha.Value())]);
 
   const GLenum logic_op_codes[16] = {
       GL_CLEAR,         GL_AND,         GL_AND_REVERSE, GL_COPY,  GL_AND_INVERTED, GL_NOOP,
@@ -601,10 +601,10 @@ void OGLGfx::ApplyBlendingState(const BlendingState state)
   // Logic ops aren't available in GLES3
   if (!IsGLES())
   {
-    if (state.logicopenable)
+    if (state.logic_op_enable)
     {
       glEnable(GL_COLOR_LOGIC_OP);
-      glLogicOp(logic_op_codes[u32(state.logicmode.Value())]);
+      glLogicOp(logic_op_codes[u32(state.logic_mode.Value())]);
     }
     else
     {
@@ -612,7 +612,7 @@ void OGLGfx::ApplyBlendingState(const BlendingState state)
     }
   }
 
-  glColorMask(state.colorupdate, state.colorupdate, state.colorupdate, state.alphaupdate);
+  glColorMask(state.color_update, state.color_update, state.color_update, state.alpha_update);
   m_current_blend_state = state;
 }
 

--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -301,7 +301,7 @@ void ProcessTriangle(OutputVertexData* v0, OutputVertexData* v1, OutputVertexDat
 
   if (!backface)
   {
-    if (bpmem.genMode.cullmode == CullMode::Back || bpmem.genMode.cullmode == CullMode::All)
+    if (bpmem.genMode.cull_mode == CullMode::Back || bpmem.genMode.cull_mode == CullMode::All)
     {
       // cull frontfacing - we still need to update the slope for zfreeze
       PerspectiveDivide(v0);
@@ -314,7 +314,7 @@ void ProcessTriangle(OutputVertexData* v0, OutputVertexData* v1, OutputVertexDat
   }
   else
   {
-    if (bpmem.genMode.cullmode == CullMode::Front || bpmem.genMode.cullmode == CullMode::All)
+    if (bpmem.genMode.cull_mode == CullMode::Front || bpmem.genMode.cull_mode == CullMode::All)
     {
       // cull backfacing - we still need to update the slope for zfreeze
       PerspectiveDivide(v0);

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -153,7 +153,7 @@ static void Draw(s32 x, s32 y, s32 xi, s32 yi)
   {
     // TODO: Test if perf regs are incremented even if test is disabled
     EfbInterface::IncPerfCounterQuadCount(PQ_ZCOMP_INPUT_ZCOMPLOC);
-    if (bpmem.zmode.testenable)
+    if (bpmem.zmode.test_enable)
     {
       // early z
       if (!EfbInterface::ZCompare(x, y, z))

--- a/Source/Core/VideoBackends/Software/SWEfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/SWEfbInterface.cpp
@@ -311,8 +311,8 @@ static u32 GetDestinationFactor(u8* srcClr, u8* dstClr, DstBlendFactor mode)
 
 static void BlendColor(u8* srcClr, u8* dstClr)
 {
-  u32 srcFactor = GetSourceFactor(srcClr, dstClr, bpmem.blendmode.srcfactor);
-  u32 dstFactor = GetDestinationFactor(srcClr, dstClr, bpmem.blendmode.dstfactor);
+  u32 srcFactor = GetSourceFactor(srcClr, dstClr, bpmem.blendmode.src_factor);
+  u32 dstFactor = GetDestinationFactor(srcClr, dstClr, bpmem.blendmode.dst_factor);
 
   for (int i = 0; i < 4; i++)
   {
@@ -416,16 +416,16 @@ void BlendTev(u16 x, u16 y, u8* color)
 
   u8* dstClrPtr = (u8*)&dstClr;
 
-  if (bpmem.blendmode.blendenable)
+  if (bpmem.blendmode.blend_enable)
   {
     if (bpmem.blendmode.subtract)
       SubtractBlend(color, dstClrPtr);
     else
       BlendColor(color, dstClrPtr);
   }
-  else if (bpmem.blendmode.logicopenable)
+  else if (bpmem.blendmode.logic_op_enable)
   {
-    LogicBlend(*((u32*)color), &dstClr, bpmem.blendmode.logicmode);
+    LogicBlend(*((u32*)color), &dstClr, bpmem.blendmode.logic_mode);
   }
   else
   {
@@ -435,15 +435,15 @@ void BlendTev(u16 x, u16 y, u8* color)
   if (bpmem.dstalpha.enable)
     dstClrPtr[ALP_C] = bpmem.dstalpha.alpha;
 
-  if (bpmem.blendmode.colorupdate)
+  if (bpmem.blendmode.color_update)
   {
     Dither(x, y, dstClrPtr);
-    if (bpmem.blendmode.alphaupdate)
+    if (bpmem.blendmode.alpha_update)
       SetPixelAlphaColor(offset, dstClrPtr);
     else
       SetPixelColorOnly(offset, dstClrPtr);
   }
-  else if (bpmem.blendmode.alphaupdate)
+  else if (bpmem.blendmode.alpha_update)
   {
     SetPixelAlphaOnly(offset, dstClrPtr[ALP_C]);
   }
@@ -452,14 +452,14 @@ void BlendTev(u16 x, u16 y, u8* color)
 void SetColor(u16 x, u16 y, u8* color)
 {
   u32 offset = GetColorOffset(x, y);
-  if (bpmem.blendmode.colorupdate)
+  if (bpmem.blendmode.color_update)
   {
-    if (bpmem.blendmode.alphaupdate)
+    if (bpmem.blendmode.alpha_update)
       SetPixelAlphaColor(offset, color);
     else
       SetPixelColorOnly(offset, color);
   }
-  else if (bpmem.blendmode.alphaupdate)
+  else if (bpmem.blendmode.alpha_update)
   {
     SetPixelAlphaOnly(offset, color[ALP_C]);
   }
@@ -467,7 +467,7 @@ void SetColor(u16 x, u16 y, u8* color)
 
 void SetDepth(u16 x, u16 y, u32 depth)
 {
-  if (bpmem.zmode.updateenable)
+  if (bpmem.zmode.update_enable)
     SetPixelDepth(GetDepthOffset(x, y), depth);
 }
 
@@ -702,7 +702,7 @@ bool ZCompare(u16 x, u16 y, u32 z)
     break;
   }
 
-  if (pass && bpmem.zmode.updateenable)
+  if (pass && bpmem.zmode.update_enable)
   {
     SetPixelDepth(offset, z);
   }

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -55,8 +55,8 @@ GetVulkanRasterizationState(const RasterizationState& state)
       depth_clamp,           // VkBool32                                  depthClampEnable
       VK_FALSE,              // VkBool32                                  rasterizerDiscardEnable
       VK_POLYGON_MODE_FILL,  // VkPolygonMode                             polygonMode
-      cull_modes[u32(state.cullmode.Value())],  // VkCullModeFlags        cullMode
-      VK_FRONT_FACE_CLOCKWISE,                  // VkFrontFace            frontFace
+      cull_modes[u32(state.cull_mode.Value())],  // VkCullModeFlags        cullMode
+      VK_FRONT_FACE_CLOCKWISE,                   // VkFrontFace            frontFace
       VK_FALSE,  // VkBool32                                              depthBiasEnable
       0.0f,      // float                                                 depthBiasConstantFactor
       0.0f,      // float                                                 depthBiasClamp
@@ -120,17 +120,17 @@ static VkPipelineDepthStencilStateCreateInfo GetVulkanDepthStencilState(const De
 
   return {
       VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,  // VkStructureType sType
-      nullptr,             // const void*                               pNext
-      0,                   // VkPipelineDepthStencilStateCreateFlags    flags
-      state.testenable,    // VkBool32                                  depthTestEnable
-      state.updateenable,  // VkBool32                                  depthWriteEnable
-      compare_op,          // VkCompareOp                               depthCompareOp
-      VK_FALSE,            // VkBool32                                  depthBoundsTestEnable
-      VK_FALSE,            // VkBool32                                  stencilTestEnable
-      {},                  // VkStencilOpState                          front
-      {},                  // VkStencilOpState                          back
-      0.0f,                // float                                     minDepthBounds
-      1.0f                 // float                                     maxDepthBounds
+      nullptr,              // const void*                               pNext
+      0,                    // VkPipelineDepthStencilStateCreateFlags    flags
+      state.test_enable,    // VkBool32                                  depthTestEnable
+      state.update_enable,  // VkBool32                                  depthWriteEnable
+      compare_op,           // VkCompareOp                               depthCompareOp
+      VK_FALSE,             // VkBool32                                  depthBoundsTestEnable
+      VK_FALSE,             // VkBool32                                  stencilTestEnable
+      {},                   // VkStencilOpState                          front
+      {},                   // VkStencilOpState                          back
+      0.0f,                 // float                                     minDepthBounds
+      1.0f                  // float                                     maxDepthBounds
   };
 }
 
@@ -139,11 +139,11 @@ GetVulkanAttachmentBlendState(const BlendingState& state, AbstractPipelineUsage 
 {
   VkPipelineColorBlendAttachmentState vk_state = {};
 
-  bool use_dual_source = state.usedualsrc;
+  bool use_dual_source = state.use_dual_src;
 
-  vk_state.blendEnable = static_cast<VkBool32>(state.blendenable);
+  vk_state.blendEnable = static_cast<VkBool32>(state.blend_enable);
   vk_state.colorBlendOp = state.subtract ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
-  vk_state.alphaBlendOp = state.subtractAlpha ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
+  vk_state.alphaBlendOp = state.subtract_alpha ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
 
   if (use_dual_source)
   {
@@ -160,10 +160,10 @@ GetVulkanAttachmentBlendState(const BlendingState& state, AbstractPipelineUsage 
         VK_BLEND_FACTOR_DST_ALPHA,  VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA,
     };
 
-    vk_state.srcColorBlendFactor = src_factors[state.srcfactor];
-    vk_state.srcAlphaBlendFactor = src_factors[state.srcfactoralpha];
-    vk_state.dstColorBlendFactor = dst_factors[state.dstfactor];
-    vk_state.dstAlphaBlendFactor = dst_factors[state.dstfactoralpha];
+    vk_state.srcColorBlendFactor = src_factors[state.src_factor];
+    vk_state.srcAlphaBlendFactor = src_factors[state.src_factor_alpha];
+    vk_state.dstColorBlendFactor = dst_factors[state.dst_factor];
+    vk_state.dstAlphaBlendFactor = dst_factors[state.dst_factor_alpha];
   }
   else
   {
@@ -181,13 +181,13 @@ GetVulkanAttachmentBlendState(const BlendingState& state, AbstractPipelineUsage 
         VK_BLEND_FACTOR_DST_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA,
     };
 
-    vk_state.srcColorBlendFactor = src_factors[state.srcfactor];
-    vk_state.srcAlphaBlendFactor = src_factors[state.srcfactoralpha];
-    vk_state.dstColorBlendFactor = dst_factors[state.dstfactor];
-    vk_state.dstAlphaBlendFactor = dst_factors[state.dstfactoralpha];
+    vk_state.srcColorBlendFactor = src_factors[state.src_factor];
+    vk_state.srcAlphaBlendFactor = src_factors[state.src_factor_alpha];
+    vk_state.dstColorBlendFactor = dst_factors[state.dst_factor];
+    vk_state.dstAlphaBlendFactor = dst_factors[state.dst_factor_alpha];
   }
 
-  if (state.colorupdate)
+  if (state.color_update)
   {
     vk_state.colorWriteMask =
         VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
@@ -197,7 +197,7 @@ GetVulkanAttachmentBlendState(const BlendingState& state, AbstractPipelineUsage 
     vk_state.colorWriteMask = 0;
   }
 
-  if (state.alphaupdate)
+  if (state.alpha_update)
     vk_state.colorWriteMask |= VK_COLOR_COMPONENT_A_BIT;
 
   return vk_state;
@@ -214,7 +214,7 @@ GetVulkanColorBlendState(const BlendingState& state,
        VK_LOGIC_OP_NOR, VK_LOGIC_OP_EQUIVALENT, VK_LOGIC_OP_INVERT, VK_LOGIC_OP_OR_REVERSE,
        VK_LOGIC_OP_COPY_INVERTED, VK_LOGIC_OP_OR_INVERTED, VK_LOGIC_OP_NAND, VK_LOGIC_OP_SET}};
 
-  VkBool32 vk_logic_op_enable = static_cast<VkBool32>(state.logicopenable);
+  VkBool32 vk_logic_op_enable = static_cast<VkBool32>(state.logic_op_enable);
   if (vk_logic_op_enable && !g_backend_info.bSupportsLogicOp)
   {
     // At the time of writing, Adreno and Mali drivers didn't support logic ops.
@@ -224,7 +224,7 @@ GetVulkanColorBlendState(const BlendingState& state,
   }
 
   VkLogicOp vk_logic_op =
-      vk_logic_op_enable ? vk_logic_ops[u32(state.logicmode.Value())] : VK_LOGIC_OP_CLEAR;
+      vk_logic_op_enable ? vk_logic_ops[u32(state.logic_mode.Value())] : VK_LOGIC_OP_CLEAR;
 
   VkPipelineColorBlendStateCreateInfo vk_state = {
       VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,  // VkStructureType sType

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -293,9 +293,9 @@ void SetBlendMode()
 */
 void ClearScreen(const MathUtil::Rectangle<int>& rc)
 {
-  bool colorEnable = (bpmem.blendmode.colorupdate != 0);
-  bool alphaEnable = (bpmem.blendmode.alphaupdate != 0);
-  bool zEnable = (bpmem.zmode.updateenable != 0);
+  bool colorEnable = (bpmem.blendmode.color_update != 0);
+  bool alphaEnable = (bpmem.blendmode.alpha_update != 0);
+  bool zEnable = (bpmem.zmode.update_enable != 0);
   auto pixel_format = bpmem.zcontrol.pixel_format;
 
   // (1): Disable unused color channels

--- a/Source/Core/VideoCommon/BPMemory.cpp
+++ b/Source/Core/VideoCommon/BPMemory.cpp
@@ -12,11 +12,11 @@ BPMemory bpmem;
 bool BlendMode::UseLogicOp() const
 {
   // Blending overrides the logicop bit.
-  if (blendenable || !logicopenable)
+  if (blend_enable || !logic_op_enable)
     return false;
 
   // Fast path for Kirby's Return to Dreamland, they use it with dstAlpha.
-  if (logicmode == LogicOp::NoOp)
+  if (logic_mode == LogicOp::NoOp)
     return false;
 
   return true;

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -1167,7 +1167,7 @@ union GenMode
   // This value is 1 less than the actual number (0-15 map to 1-16).
   // In other words there is always at least 1 tev stage
   BitField<10, 4, u32> numtevstages;
-  BitField<14, 2, CullMode> cullmode;
+  BitField<14, 2, CullMode> cull_mode;
   BitField<16, 3, u32> numindstages;
   BitField<19, 1, bool, u32> zfreeze;
 
@@ -1192,7 +1192,7 @@ struct fmt::formatter<GenMode>
                           "ZFreeze: {}",
                           mode.numtexgens, mode.numcolchans, mode.unused,
                           mode.flat_shading ? "Yes" : "No", mode.multisampling ? "Yes" : "No",
-                          mode.numtevstages + 1, mode.cullmode, mode.numindstages,
+                          mode.numtevstages + 1, mode.cull_mode, mode.numindstages,
                           mode.zfreeze ? "Yes" : "No");
   }
 };
@@ -1379,15 +1379,15 @@ struct fmt::formatter<LogicOp> : EnumFormatter<LogicOp::Set>
 
 union BlendMode
 {
-  BitField<0, 1, bool, u32> blendenable;
-  BitField<1, 1, bool, u32> logicopenable;
+  BitField<0, 1, bool, u32> blend_enable;
+  BitField<1, 1, bool, u32> logic_op_enable;
   BitField<2, 1, bool, u32> dither;
-  BitField<3, 1, bool, u32> colorupdate;
-  BitField<4, 1, bool, u32> alphaupdate;
-  BitField<5, 3, DstBlendFactor> dstfactor;
-  BitField<8, 3, SrcBlendFactor> srcfactor;
+  BitField<3, 1, bool, u32> color_update;
+  BitField<4, 1, bool, u32> alpha_update;
+  BitField<5, 3, DstBlendFactor> dst_factor;
+  BitField<8, 3, SrcBlendFactor> src_factor;
   BitField<11, 1, bool, u32> subtract;
-  BitField<12, 4, LogicOp> logicmode;
+  BitField<12, 4, LogicOp> logic_mode;
 
   u32 hex;
 
@@ -1411,9 +1411,9 @@ struct fmt::formatter<BlendMode>
                           "Source factor: {}\n"
                           "Subtract: {}\n"
                           "Logic mode: {}",
-                          no_yes[mode.blendenable], no_yes[mode.logicopenable], no_yes[mode.dither],
-                          no_yes[mode.colorupdate], no_yes[mode.alphaupdate], mode.dstfactor,
-                          mode.srcfactor, no_yes[mode.subtract], mode.logicmode);
+                          no_yes[mode.blend_enable], no_yes[mode.logic_op_enable],
+                          no_yes[mode.dither], no_yes[mode.color_update], no_yes[mode.alpha_update],
+                          mode.dst_factor, mode.src_factor, no_yes[mode.subtract], mode.logic_mode);
   }
 };
 
@@ -1599,9 +1599,9 @@ struct fmt::formatter<CompareMode> : EnumFormatter<CompareMode::Always>
 
 union ZMode
 {
-  BitField<0, 1, bool, u32> testenable;
+  BitField<0, 1, bool, u32> test_enable;
   BitField<1, 3, CompareMode> func;
-  BitField<4, 1, bool, u32> updateenable;
+  BitField<4, 1, bool, u32> update_enable;
 
   u32 hex;
 };
@@ -1616,8 +1616,8 @@ struct fmt::formatter<ZMode>
                           "Enable test: {}\n"
                           "Compare function: {}\n"
                           "Enable updates: {}",
-                          mode.testenable ? "Yes" : "No", mode.func,
-                          mode.updateenable ? "Yes" : "No");
+                          mode.test_enable ? "Yes" : "No", mode.func,
+                          mode.update_enable ? "Yes" : "No");
   }
 };
 
@@ -2519,7 +2519,7 @@ struct BPMemory
 
   EmulatedZ GetEmulatedZ() const
   {
-    if (!zmode.testenable)
+    if (!zmode.test_enable)
       return EmulatedZ::Disabled;
     if (zcontrol.early_ztest)
       return EmulatedZ::Early;

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -99,10 +99,11 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
   switch (bp.address)
   {
   case BPMEM_GENMODE:  // Set the Generation Mode
-    PRIM_LOG("genmode: texgen={}, col={}, multisampling={}, tev={}, cullmode={}, ind={}, zfeeze={}",
-             bpmem.genMode.numtexgens, bpmem.genMode.numcolchans, bpmem.genMode.multisampling,
-             bpmem.genMode.numtevstages + 1, bpmem.genMode.cullmode, bpmem.genMode.numindstages,
-             bpmem.genMode.zfreeze);
+    PRIM_LOG(
+        "genmode: texgen={}, col={}, multisampling={}, tev={}, cull_mode={}, ind={}, zfeeze={}",
+        bpmem.genMode.numtexgens, bpmem.genMode.numcolchans, bpmem.genMode.multisampling,
+        bpmem.genMode.numtevstages + 1, bpmem.genMode.cull_mode, bpmem.genMode.numindstages,
+        bpmem.genMode.zfreeze);
 
     if (bp.changes)
       pixel_shader_manager.SetGenModeChanged();
@@ -144,8 +145,8 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
     geometry_shader_manager.SetLinePtWidthChanged();
     return;
   case BPMEM_ZMODE:  // Depth Control
-    PRIM_LOG("zmode: test={}, func={}, upd={}", bpmem.zmode.testenable, bpmem.zmode.func,
-             bpmem.zmode.updateenable);
+    PRIM_LOG("zmode: test={}, func={}, upd={}", bpmem.zmode.test_enable, bpmem.zmode.func,
+             bpmem.zmode.update_enable);
     SetDepthMode();
     pixel_shader_manager.SetZModeControl();
     return;
@@ -153,9 +154,10 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
     if (bp.changes & 0xFFFF)
     {
       PRIM_LOG("blendmode: en={}, open={}, colupd={}, alphaupd={}, dst={}, src={}, sub={}, mode={}",
-               bpmem.blendmode.blendenable, bpmem.blendmode.logicopenable,
-               bpmem.blendmode.colorupdate, bpmem.blendmode.alphaupdate, bpmem.blendmode.dstfactor,
-               bpmem.blendmode.srcfactor, bpmem.blendmode.subtract, bpmem.blendmode.logicmode);
+               bpmem.blendmode.blend_enable, bpmem.blendmode.logic_op_enable,
+               bpmem.blendmode.color_update, bpmem.blendmode.alpha_update,
+               bpmem.blendmode.dst_factor, bpmem.blendmode.src_factor, bpmem.blendmode.subtract,
+               bpmem.blendmode.logic_mode);
 
       SetBlendMode();
 

--- a/Source/Core/VideoCommon/CPUCull.cpp
+++ b/Source/Core/VideoCommon/CPUCull.cpp
@@ -160,12 +160,12 @@ bool CPUCull::AreAllVerticesCulled(VertexLoaderBase* loader, OpcodeDecoder::Prim
   static constexpr Common::EnumMap<CullMode, CullMode::All> cullmode_invert = {
       CullMode::None, CullMode::Front, CullMode::Back, CullMode::All};
 
-  CullMode cullmode = bpmem.genMode.cullmode;
+  CullMode cull_mode = bpmem.genMode.cull_mode;
   if (xfmem.viewport.ht > 0)  // See videosoftware Clipper.cpp:IsBackface
-    cullmode = cullmode_invert[cullmode];
+    cull_mode = cullmode_invert[cull_mode];
   const TransformFunction transform = m_transform_table[posHas3Elems][perVertexPosMtx];
   transform(m_transform_buffer.get(), src, stride, count);
-  const CullFunction cull = m_cull_table[primitive][cullmode];
+  const CullFunction cull = m_cull_table[primitive][cull_mode];
   return cull(m_transform_buffer.get(), count);
 }
 

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -906,14 +906,14 @@ bool FramebufferManager::CompileClearPipelines()
 
   for (u32 color_enable = 0; color_enable < 2; color_enable++)
   {
-    config.blending_state.colorupdate = color_enable != 0;
+    config.blending_state.color_update = color_enable != 0;
     for (u32 alpha_enable = 0; alpha_enable < 2; alpha_enable++)
     {
-      config.blending_state.alphaupdate = alpha_enable != 0;
+      config.blending_state.alpha_update = alpha_enable != 0;
       for (u32 depth_enable = 0; depth_enable < 2; depth_enable++)
       {
-        config.depth_state.testenable = depth_enable != 0;
-        config.depth_state.updateenable = depth_enable != 0;
+        config.depth_state.test_enable = depth_enable != 0;
+        config.depth_state.update_enable = depth_enable != 0;
 
         m_clear_pipelines[color_enable][alpha_enable][depth_enable] = g_gfx->CreatePipeline(config);
         if (!m_clear_pipelines[color_enable][alpha_enable][depth_enable])

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -145,11 +145,11 @@ bool OnScreenUI::RecompileImGuiPipeline()
   pconfig.rasterization_state = RenderState::GetNoCullRasterizationState(PrimitiveType::Triangles);
   pconfig.depth_state = RenderState::GetNoDepthTestingDepthState();
   pconfig.blending_state = RenderState::GetNoBlendingBlendState();
-  pconfig.blending_state.blendenable = true;
-  pconfig.blending_state.srcfactor = SrcBlendFactor::SrcAlpha;
-  pconfig.blending_state.dstfactor = DstBlendFactor::InvSrcAlpha;
-  pconfig.blending_state.srcfactoralpha = SrcBlendFactor::Zero;
-  pconfig.blending_state.dstfactoralpha = DstBlendFactor::One;
+  pconfig.blending_state.blend_enable = true;
+  pconfig.blending_state.src_factor = SrcBlendFactor::SrcAlpha;
+  pconfig.blending_state.dst_factor = DstBlendFactor::InvSrcAlpha;
+  pconfig.blending_state.src_factor_alpha = SrcBlendFactor::Zero;
+  pconfig.blending_state.dst_factor_alpha = DstBlendFactor::One;
   pconfig.framebuffer_state.color_texture_format = g_presenter->GetBackbufferFormat();
   pconfig.framebuffer_state.depth_texture_format = AbstractTextureFormat::Undefined;
   pconfig.framebuffer_state.samples = 1;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -174,7 +174,7 @@ PixelShaderUid GetPixelShaderUid()
   PixelShaderUid out;
 
   pixel_shader_uid_data* const uid_data = out.GetUidData();
-  uid_data->useDstAlpha = bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate &&
+  uid_data->useDstAlpha = bpmem.dstalpha.enable && bpmem.blendmode.alpha_update &&
                           bpmem.zcontrol.pixel_format == PixelFormat::RGBA6_Z24;
 
   uid_data->genMode_numindstages = bpmem.genMode.numindstages;
@@ -203,8 +203,8 @@ PixelShaderUid GetPixelShaderUid()
   const bool forced_early_z = uid_data->ztest == EmulatedZ::ForcedEarly;
   const bool per_pixel_depth =
       (bpmem.ztex2.op != ZTexOp::Disabled && uid_data->ztest == EmulatedZ::Late) ||
-      (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !forced_early_z) ||
-      (bpmem.zmode.testenable && bpmem.genMode.zfreeze);
+      (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.test_enable && !forced_early_z) ||
+      (bpmem.zmode.test_enable && bpmem.genMode.zfreeze);
 
   uid_data->per_pixel_depth = per_pixel_depth;
 

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -162,7 +162,7 @@ void PixelShaderManager::SetConstants()
   {
     // Destination alpha is only enabled if alpha writes are enabled. Force entire uniform to zero
     // when disabled.
-    u32 dstalpha = bpmem.blendmode.alphaupdate && bpmem.dstalpha.enable &&
+    u32 dstalpha = bpmem.blendmode.alpha_update && bpmem.dstalpha.enable &&
                            bpmem.zcontrol.pixel_format == PixelFormat::RGBA6_Z24 ?
                        bpmem.dstalpha.hex :
                        0;
@@ -468,29 +468,29 @@ void PixelShaderManager::SetBlendModeChanged()
   }
   BlendingState state = {};
   state.Generate(bpmem);
-  if (constants.blend_enable != state.blendenable)
+  if (constants.blend_enable != state.blend_enable)
   {
-    constants.blend_enable = state.blendenable;
+    constants.blend_enable = state.blend_enable;
     dirty = true;
   }
-  if (constants.blend_src_factor != state.srcfactor)
+  if (constants.blend_src_factor != state.src_factor)
   {
-    constants.blend_src_factor = state.srcfactor;
+    constants.blend_src_factor = state.src_factor;
     dirty = true;
   }
-  if (constants.blend_src_factor_alpha != state.srcfactoralpha)
+  if (constants.blend_src_factor_alpha != state.src_factor_alpha)
   {
-    constants.blend_src_factor_alpha = state.srcfactoralpha;
+    constants.blend_src_factor_alpha = state.src_factor_alpha;
     dirty = true;
   }
-  if (constants.blend_dst_factor != state.dstfactor)
+  if (constants.blend_dst_factor != state.dst_factor)
   {
-    constants.blend_dst_factor = state.dstfactor;
+    constants.blend_dst_factor = state.dst_factor;
     dirty = true;
   }
-  if (constants.blend_dst_factor_alpha != state.dstfactoralpha)
+  if (constants.blend_dst_factor_alpha != state.dst_factor_alpha)
   {
-    constants.blend_dst_factor_alpha = state.dstfactoralpha;
+    constants.blend_dst_factor_alpha = state.dst_factor_alpha;
     dirty = true;
   }
   if (constants.blend_subtract != state.subtract)
@@ -498,19 +498,19 @@ void PixelShaderManager::SetBlendModeChanged()
     constants.blend_subtract = state.subtract;
     dirty = true;
   }
-  if (constants.blend_subtract_alpha != state.subtractAlpha)
+  if (constants.blend_subtract_alpha != state.subtract_alpha)
   {
-    constants.blend_subtract_alpha = state.subtractAlpha;
+    constants.blend_subtract_alpha = state.subtract_alpha;
     dirty = true;
   }
-  if (constants.logic_op_enable != state.logicopenable)
+  if (constants.logic_op_enable != state.logic_op_enable)
   {
-    constants.logic_op_enable = state.logicopenable;
+    constants.logic_op_enable = state.logic_op_enable;
     dirty = true;
   }
-  if (constants.logic_op_mode != state.logicmode)
+  if (constants.logic_op_mode != state.logic_mode)
   {
-    constants.logic_op_mode = state.logicmode;
+    constants.logic_op_mode = state.logic_mode;
     dirty = true;
   }
   m_dest_alpha_dirty = true;

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -49,7 +49,7 @@ union RasterizationState
   bool operator==(const RasterizationState& rhs) const { return hex == rhs.hex; }
   bool operator<(const RasterizationState& rhs) const { return hex < rhs.hex; }
 
-  BitField<0, 2, CullMode> cullmode;
+  BitField<0, 2, CullMode> cull_mode;
   BitField<3, 2, PrimitiveType> primitive;
 
   u32 hex = 0;
@@ -108,8 +108,8 @@ union DepthState
   bool operator==(const DepthState& rhs) const { return hex == rhs.hex; }
   bool operator<(const DepthState& rhs) const { return hex < rhs.hex; }
 
-  BitField<0, 1, u32> testenable;
-  BitField<1, 1, u32> updateenable;
+  BitField<0, 1, u32> test_enable;
+  BitField<1, 1, u32> update_enable;
   BitField<2, 3, CompareMode> func;
 
   u32 hex = 0;
@@ -142,18 +142,18 @@ union BlendingState
   bool operator==(const BlendingState& rhs) const { return hex == rhs.hex; }
   bool operator<(const BlendingState& rhs) const { return hex < rhs.hex; }
 
-  BitField<0, 1, u32> blendenable;
-  BitField<1, 1, u32> logicopenable;
-  BitField<3, 1, u32> colorupdate;
-  BitField<4, 1, u32> alphaupdate;
+  BitField<0, 1, u32> blend_enable;
+  BitField<1, 1, u32> logic_op_enable;
+  BitField<3, 1, u32> color_update;
+  BitField<4, 1, u32> alpha_update;
   BitField<5, 1, u32> subtract;
-  BitField<6, 1, u32> subtractAlpha;
-  BitField<7, 1, u32> usedualsrc;
-  BitField<8, 3, DstBlendFactor> dstfactor;
-  BitField<11, 3, SrcBlendFactor> srcfactor;
-  BitField<14, 3, DstBlendFactor> dstfactoralpha;
-  BitField<17, 3, SrcBlendFactor> srcfactoralpha;
-  BitField<20, 4, LogicOp> logicmode;
+  BitField<6, 1, u32> subtract_alpha;
+  BitField<7, 1, u32> use_dual_src;
+  BitField<8, 3, DstBlendFactor> dst_factor;
+  BitField<11, 3, SrcBlendFactor> src_factor;
+  BitField<14, 3, DstBlendFactor> dst_factor_alpha;
+  BitField<17, 3, SrcBlendFactor> src_factor_alpha;
+  BitField<20, 4, LogicOp> logic_mode;
 
   bool RequiresDualSrc() const;
 

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -26,11 +26,11 @@ PixelShaderUid GetPixelShaderUid()
   uid_data->early_depth = bpmem.GetEmulatedZ() == EmulatedZ::Early &&
                           (g_ActiveConfig.bFastDepthCalc ||
                            bpmem.alpha_test.TestResult() == AlphaTestResult::Undetermined) &&
-                          !(bpmem.zmode.testenable && bpmem.genMode.zfreeze);
+                          !(bpmem.zmode.test_enable && bpmem.genMode.zfreeze);
   uid_data->per_pixel_depth =
       (bpmem.ztex2.op != ZTexOp::Disabled && bpmem.GetEmulatedZ() == EmulatedZ::Late) ||
-      (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !uid_data->early_depth) ||
-      (bpmem.zmode.testenable && bpmem.genMode.zfreeze);
+      (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.test_enable && !uid_data->early_depth) ||
+      (bpmem.zmode.test_enable && bpmem.genMode.zfreeze);
   uid_data->uint_output = bpmem.blendmode.UseLogicOp();
 
   return out;

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -434,7 +434,7 @@ int RunVertices(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int coun
     // if cull mode is CULL_ALL, tell VertexManager to skip triangles and quads.
     // They still need to go through vertex loading, because we need to calculate a zfreeze
     // reference slope.
-    const bool cullall = (bpmem.genMode.cullmode == CullMode::All &&
+    const bool cullall = (bpmem.genMode.cull_mode == CullMode::All &&
                           primitive < OpcodeDecoder::Primitive::GX_DRAW_LINES);
 
     const int stride = loader->m_native_vtx_decl.stride;

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -472,8 +472,8 @@ void VertexManagerBase::Flush()
 #if defined(_DEBUG) || defined(DEBUGFAST)
   PRIM_LOG("frame{}:\n texgen={}, numchan={}, dualtex={}, ztex={}, cole={}, alpe={}, ze={}",
            g_ActiveConfig.iSaveTargetId, xfmem.numTexGen.numTexGens, xfmem.numChan.numColorChans,
-           xfmem.dualTexTrans.enabled, bpmem.ztex2.op.Value(), bpmem.blendmode.colorupdate.Value(),
-           bpmem.blendmode.alphaupdate.Value(), bpmem.zmode.updateenable.Value());
+           xfmem.dualTexTrans.enabled, bpmem.ztex2.op.Value(), bpmem.blendmode.color_update.Value(),
+           bpmem.blendmode.alpha_update.Value(), bpmem.zmode.update_enable.Value());
 
   for (u32 i = 0; i < xfmem.numChan.numColorChans; ++i)
   {


### PR DESCRIPTION
This renames the `RenderState` members of the bitfields to be a little more consistent.  This was requested in #13894 