### PR TITLE
Arm64Emitter: Add FMOV (vector, immediate)

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -3742,6 +3742,11 @@ void ARM64FloatEmitter::FMLA(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 
 }
 
 // Modified Immediate
+void ARM64FloatEmitter::FMOV(u8 size, ARM64Reg Rd, uint8_t imm8)
+{
+  EncodeModImm(IsQuad(Rd), size >> 6, 0xF, 0, Rd, imm8);
+}
+
 void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
 {
   bool Q = IsQuad(Rd);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -1395,6 +1395,7 @@ public:
   void FMLA(u8 esize, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index);
 
   // Modified Immediate
+  void FMOV(u8 size, ARM64Reg Rd, uint8_t imm8);
   void MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift = 0);
   void ORR(u8 size, ARM64Reg Rd, u8 imm, u8 shift = 0);
   void BIC(u8 size, ARM64Reg Rd, u8 imm, u8 shift = 0);


### PR DESCRIPTION
I implemented this because I thought it would be useful for my FMA PR. In the end I didn't have any use for it, but since I already implemented it, here's a patch for it.