### PR TITLE
JitArm64: Use ORR for fmr, not INS

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -319,7 +319,7 @@ void JitArm64::fp_logic(UGeckoInstruction inst)
       m_float_emit.FNEG(reg_encoder(VD), reg_encoder(VB));
       break;
     case 72:
-      m_float_emit.INS(size, VD, 0, VB, 0);
+      m_float_emit.ORR(EncodeRegToDouble(VD), EncodeRegToDouble(VB), EncodeRegToDouble(VB));
       break;
     case 136:
       m_float_emit.FABS(reg_encoder(VD), reg_encoder(VB));


### PR DESCRIPTION
INS adds a dependency on the value in the destination register, which decreases performance, while offering no benefit to us in this case. (We ask the register cache for LowerPairSingle or LowerPair, so there's nothing meaningful in the second element of the register.)