### PR TITLE
Cheats: Refresh active code after editing it.

### DIFF
--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -272,6 +272,8 @@ void ARCodeWidget::OnCodeEditClicked()
     return;
 
   const auto* const selected = items[0];
+  const bool enabled = selected->checkState() == Qt::Checked;
+
   auto& current_ar = m_ar_codes[m_code_list->row(selected)];
 
   if (current_ar.user_defined)
@@ -292,6 +294,9 @@ void ARCodeWidget::OnCodeEditClicked()
 
   SaveCodes();
   UpdateList();
+
+  if (!m_restart_required && enabled)
+    ActionReplay::ApplyCodes(m_ar_codes, m_game_id, m_game_revision);
 }
 
 void ARCodeWidget::OnCodeRemoveClicked()

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -224,6 +224,7 @@ void GeckoCodeWidget::EditCode()
     return;
 
   const int index = item->data(Qt::UserRole).toInt();
+  const bool enabled = item->checkState() == Qt::Checked;
 
   m_cheat_code_editor->SetGeckoCode(&m_gecko_codes[index]);
   if (m_cheat_code_editor->exec() == QDialog::Rejected)
@@ -231,6 +232,9 @@ void GeckoCodeWidget::EditCode()
 
   SaveCodes();
   UpdateList();
+
+  if (!m_restart_required && enabled)
+    Gecko::SetActiveCodes(m_gecko_codes, m_game_id, m_game_revision);
 }
 
 void GeckoCodeWidget::RemoveCode()


### PR DESCRIPTION
Previously you had to edit a code, disabled it, then re-enable it for it to activate the changes, which doesn't make much sense to me.

@SuperSamus Any thoughts?