### PR TITLE
Android: Set Dolphin documents as Local only

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/DocumentProvider.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/DocumentProvider.kt
@@ -65,7 +65,7 @@ class DocumentProvider : DocumentsProvider() {
             add(DocumentsContract.Root.COLUMN_ICON, R.drawable.ic_dolphin)
             add(
                 DocumentsContract.Root.COLUMN_FLAGS,
-                DocumentsContract.Root.FLAG_SUPPORTS_CREATE or DocumentsContract.Root.FLAG_SUPPORTS_RECENTS or DocumentsContract.Root.FLAG_SUPPORTS_SEARCH or DocumentsContract.Root.FLAG_LOCAL_ONLY
+                DocumentsContract.Root.FLAG_SUPPORTS_CREATE or DocumentsContract.Root.FLAG_SUPPORTS_RECENTS or DocumentsContract.Root.FLAG_SUPPORTS_SEARCH or DocumentsContract.Root.FLAG_LOCAL_ONLY or DocumentsContract.Root.FLAG_SUPPORTS_IS_CHILD
             )
             add(DocumentsContract.Root.COLUMN_DOCUMENT_ID, ROOT_ID)
         }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/DocumentProvider.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/DocumentProvider.kt
@@ -65,7 +65,7 @@ class DocumentProvider : DocumentsProvider() {
             add(DocumentsContract.Root.COLUMN_ICON, R.drawable.ic_dolphin)
             add(
                 DocumentsContract.Root.COLUMN_FLAGS,
-                DocumentsContract.Root.FLAG_SUPPORTS_CREATE or DocumentsContract.Root.FLAG_SUPPORTS_RECENTS or DocumentsContract.Root.FLAG_SUPPORTS_SEARCH
+                DocumentsContract.Root.FLAG_SUPPORTS_CREATE or DocumentsContract.Root.FLAG_SUPPORTS_RECENTS or DocumentsContract.Root.FLAG_SUPPORTS_SEARCH or DocumentsContract.Root.FLAG_LOCAL_ONLY
             )
             add(DocumentsContract.Root.COLUMN_DOCUMENT_ID, ROOT_ID)
         }


### PR DESCRIPTION
Adds `DocumentsContract.Root.FLAG_LOCAL_ONLY` to the list of the flags in order to show up for third-party apps for easier file syncing with local/cloud file server providers







