### PR TITLE
GameList: Use List View's sorting for Grid View

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -122,11 +122,18 @@ GameList::GameList(QWidget* parent) : QStackedWidget(parent), m_model(this)
   m_list_proxy->setSortRole(GameListModel::SORT_ROLE);
   m_list_proxy->setSourceModel(&m_model);
   m_grid_proxy = new GridProxyModel(this);
+  m_grid_proxy->setSortCaseSensitivity(Qt::CaseInsensitive);
+  m_grid_proxy->setSortRole(GameListModel::SORT_ROLE);
   m_grid_proxy->setSourceModel(&m_model);
 
   MakeListView();
   MakeGridView();
   MakeEmptyView();
+
+  // Use List View's sorting for Grid View too.
+  m_grid_proxy->sort(m_list_proxy->sortColumn(), m_list_proxy->sortOrder());
+  connect(m_list->horizontalHeader(), &QHeaderView::sortIndicatorChanged, m_grid_proxy,
+          &GridProxyModel::sort);
 
   if (Settings::GetQSettings().contains(QStringLiteral("gridview/scale")))
     m_model.SetScale(Settings::GetQSettings().value(QStringLiteral("gridview/scale")).toFloat());

--- a/Source/Core/DolphinQt/GameList/GridProxyModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GridProxyModel.cpp
@@ -18,8 +18,7 @@ const QSize LARGE_BANNER_SIZE(144, 48);
 
 GridProxyModel::GridProxyModel(QObject* parent) : QSortFilterProxyModel(parent)
 {
-  setSortCaseSensitivity(Qt::CaseInsensitive);
-  sort(static_cast<int>(GameListModel::Column::Title));
+  setDynamicSortFilter(true);
 }
 
 QVariant GridProxyModel::data(const QModelIndex& i, int role) const
@@ -75,4 +74,25 @@ bool GridProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_
 {
   GameListModel* glm = qobject_cast<GameListModel*>(sourceModel());
   return glm->ShouldDisplayGameListItem(source_row);
+}
+
+bool GridProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
+{
+  if (left.data(GameListModel::SORT_ROLE) != right.data(GameListModel::SORT_ROLE))
+    return QSortFilterProxyModel::lessThan(left, right);
+
+  // If two items are otherwise equal, compare them by their title
+  const auto right_title = sourceModel()
+                               ->index(right.row(), static_cast<int>(GameListModel::Column::Title))
+                               .data()
+                               .toString();
+  const auto left_title = sourceModel()
+                              ->index(left.row(), static_cast<int>(GameListModel::Column::Title))
+                              .data()
+                              .toString();
+
+  if (sortOrder() == Qt::AscendingOrder)
+    return left_title < right_title;
+
+  return right_title < left_title;
 }

--- a/Source/Core/DolphinQt/GameList/GridProxyModel.h
+++ b/Source/Core/DolphinQt/GameList/GridProxyModel.h
@@ -14,5 +14,8 @@ class GridProxyModel final : public QSortFilterProxyModel
 public:
   explicit GridProxyModel(QObject* parent = nullptr);
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+
+protected:
   bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+  bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 };


### PR DESCRIPTION
Since Grid View doesn't have a header for users to change sorting options with, use List View's sorting in Grid View too.

Resolves https://bugs.dolphin-emu.org/issues/12958.