### PR TITLE
MathUtil: Simplify SaturatingCast implementation and fix edge case.

### DIFF
--- a/Source/UnitTests/Common/MathUtilTest.cpp
+++ b/Source/UnitTests/Common/MathUtilTest.cpp
@@ -66,6 +66,13 @@ TEST(MathUtil, SaturatingCast)
   // 16777217 = 2^24 + 1 is the first integer that cannot be represented correctly with a f32.
   EXPECT_EQ(16777216, MathUtil::SaturatingCast<s32>(float(16777216)));
   EXPECT_EQ(16777216, MathUtil::SaturatingCast<s32>(float(16777217)));
+
+  // Note that values in the range [2147483584, 2147483776] have an equivalent float representation.
+  EXPECT_EQ(std::numeric_limits<s32>::max(), MathUtil::SaturatingCast<s32>(2147483648.f));
+  EXPECT_EQ(std::numeric_limits<s32>::min(), MathUtil::SaturatingCast<s32>(-2147483649.f));
+
+  // Cast from a signed integer type to a smaller signed integer type
+  EXPECT_EQ(-128, (MathUtil::SaturatingCast<s8, int>(-129)));
 }
 
 TEST(MathUtil, RectangleEquality)


### PR DESCRIPTION
Using `std::cmp_less` and `std::cmp_greater` handle the mismatched signedness logic for us.

Explicit `static_cast<T>` in the floating point path eliminated a warning produced in `MathUtilTest`:
```
MathUtil.h:68:17: warning: implicit conversion from 'const int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
```
Using `>=` instead of `>` fixed a floating point edge case that Dentomologist identified.