### PR TITLE
DolphinQt: Center dialogs on top-level parent window.

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -256,12 +256,7 @@ MainWindow::MainWindow(Core::System& system, std::unique_ptr<BootParameters> boo
           });
 #endif
 
-  connect(m_cheats_manager, &CheatsManager::OpenGeneralSettings, this,
-          &MainWindow::ShowGeneralWindow);
-
 #ifdef USE_RETRO_ACHIEVEMENTS
-  connect(m_cheats_manager, &CheatsManager::OpenAchievementSettings, this,
-          &MainWindow::ShowAchievementSettings);
   connect(m_game_list, &GameList::OpenAchievementSettings, this,
           &MainWindow::ShowAchievementSettings);
 #endif  // USE_RETRO_ACHIEVEMENTS
@@ -481,7 +476,6 @@ void MainWindow::CreateComponents()
   m_watch_widget = new WatchWidget(this);
   m_breakpoint_widget = new BreakpointWidget(this);
   m_code_widget = new CodeWidget(this);
-  m_cheats_manager = new CheatsManager(m_system, this);
   m_assembler_widget = new AssemblerWidget(this);
 
   const auto request_watch = [this](QString name, u32 addr) {
@@ -523,8 +517,6 @@ void MainWindow::CreateComponents()
   });
   connect(m_breakpoint_widget, &BreakpointWidget::ShowMemory, m_memory_widget,
           &MemoryWidget::SetAddress);
-  connect(m_cheats_manager, &CheatsManager::ShowMemory, m_memory_widget, &MemoryWidget::SetAddress);
-  connect(m_cheats_manager, &CheatsManager::RequestWatch, request_watch);
 }
 
 void MainWindow::ConnectMenuBar()
@@ -2037,6 +2029,22 @@ void MainWindow::ShowResourcePackManager()
 
 void MainWindow::ShowCheatsManager()
 {
+  if (!m_cheats_manager)
+  {
+    m_cheats_manager = new CheatsManager(m_system, this);
+
+    connect(m_cheats_manager, &CheatsManager::ShowMemory, m_memory_widget,
+            &MemoryWidget::SetAddress);
+    connect(m_cheats_manager, &CheatsManager::RequestWatch, m_watch_widget, &WatchWidget::AddWatch);
+    connect(m_cheats_manager, &CheatsManager::OpenGeneralSettings, this,
+            &MainWindow::ShowGeneralWindow);
+
+#ifdef USE_RETRO_ACHIEVEMENTS
+    connect(m_cheats_manager, &CheatsManager::OpenAchievementSettings, this,
+            &MainWindow::ShowAchievementSettings);
+#endif  // USE_RETRO_ACHIEVEMENTS
+  }
+
   m_cheats_manager->show();
 }
 

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -281,6 +281,6 @@ private:
   RegisterWidget* m_register_widget;
   ThreadWidget* m_thread_widget;
   WatchWidget* m_watch_widget;
-  CheatsManager* m_cheats_manager;
+  CheatsManager* m_cheats_manager{};
   QByteArray m_render_widget_geometry;
 };

--- a/Source/Core/DolphinQt/QtUtils/QtUtils.cpp
+++ b/Source/Core/DolphinQt/QtUtils/QtUtils.cpp
@@ -43,6 +43,29 @@ void AdjustSizeWithinScreen(QWidget* widget)
   const auto adj_screen_size = screen_size * 9 / 10;
 
   widget->resize(widget->sizeHint().boundedTo(adj_screen_size));
+
+  CenterOnParentWindow(widget);
+}
+
+void CenterOnParentWindow(QWidget* const widget)
+{
+  // Find the top-level window.
+  const QWidget* const parent_widget{widget->parentWidget()};
+  if (!parent_widget)
+    return;
+  const QWidget* const window{parent_widget->window()};
+
+  // Calculate position based on the widgets' size and position.
+  const QRect window_geometry{window->geometry()};
+  const QSize window_size{window_geometry.size()};
+  const QPoint window_pos{window_geometry.topLeft()};
+  const QRect geometry{widget->geometry()};
+  const QSize size{geometry.size()};
+  const QPoint offset{(window_size.width() - size.width()) / 2,
+                      (window_size.height() - size.height()) / 2};
+  const QPoint pos{window_pos + offset};
+
+  widget->setGeometry(QRect(pos, size));
 }
 
 }  // namespace QtUtils

--- a/Source/Core/DolphinQt/QtUtils/QtUtils.h
+++ b/Source/Core/DolphinQt/QtUtils/QtUtils.h
@@ -19,6 +19,10 @@ QWidget* CreateIconWarning(QWidget* parent, QStyle::StandardPixmap standard_pixm
 // Similar to QWidget::adjustSize except maximum size is 9/10 of screen rather than 2/3.
 void AdjustSizeWithinScreen(QWidget* widget);
 
+// Centers the widget on its parent. It should be called after any adjustments to the widget's size
+// has been applied.
+void CenterOnParentWindow(QWidget* widget);
+
 // A QWidget that returns the minimumSizeHint as the primary sizeHint.
 // Useful for QListWidget which hints a fairly large height even when entirely empty.
 // Usage: QtUtils::MinimumSizeHintWidget<QListWidget>


### PR DESCRIPTION
The `QtUtils::AdjustSizeWithinScreen()` function now centers the widget on their parent window after the widget's size is adjusted. This is required in some desktop environments (generally on Linux systems) to ensure that the just-resized widget remains aligned with its parent window.

The creation of the **Cheats Manager** dialog is now deferred to first show, as creating it within the main window's constructor prevents the dialog from knowing the real position of its parent window, which is only properly calculated on first show.

For the same reasons, the analytics prompt is now shown only when the application is ready (i.e. when the main window has been shown).

| Before | After |
| ------ | ----- |
| <img width="1920" height="1080" alt="[Dolphin Emulator] Misplaced analytics prompt" title="[Dolphin Emulator] Misplaced analytics prompt" src="https://github.com/user-attachments/assets/c3e43b3b-cf79-4398-b531-7de6068c583e" /> | <img width="1920" height="1080" alt="[Dolphin Emulator] Centered analytics prompt" title="[Dolphin Emulator] Centered analytics prompt" src="https://github.com/user-attachments/assets/a10d06d9-7438-4032-b96c-dfcb48826349" /> |
| <img width="1920" height="1080" alt="[Dolphin Emulator] Misplaced Settings dialog" title="[Dolphin Emulator] Misplaced Settings dialog" src="https://github.com/user-attachments/assets/f35b10ee-4f07-48d4-86f9-2537ad5ca7ca" /> | <img width="1920" height="1080" alt="[Dolphin Emulator] Centered Settings dialog" title="[Dolphin Emulator] Centered Settings dialog" src="https://github.com/user-attachments/assets/33e37237-77a4-44f6-a0e2-b709f65b672b" /> |
| <img width="1920" height="1080" alt="[Dolphin Emulator] Misplaced Cheats Manager dialog" title="[Dolphin Emulator] Misplaced Cheats Manager dialog" src="https://github.com/user-attachments/assets/1fbd3836-5639-4d5a-b57e-e2e21f21c9db" /> | <img width="1920" height="1080" alt="[Dolphin Emulator] Centered Cheats Manager dialog" title="[Dolphin Emulator] Centered Cheats Manager dialog" src="https://github.com/user-attachments/assets/3f2b1b50-de16-49b7-bac4-c444c6cab0bc" /> |