### PR TITLE
DolphinQt: Reduce maximum initial dialog size to 80% of the screen dimensions.

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/QtUtils.cpp
+++ b/Source/Core/DolphinQt/QtUtils/QtUtils.cpp
@@ -39,8 +39,9 @@ QWidget* CreateIconWarning(QWidget* parent, QStyle::StandardPixmap standard_pixm
 void AdjustSizeWithinScreen(QWidget* widget)
 {
   const auto screen_size = widget->screen()->availableSize();
-
-  const auto adj_screen_size = screen_size * 9 / 10;
+  const bool landscape{screen_size.width() > screen_size.height()};
+  const QSize adj_screen_size{(landscape && screen_size.height() >= 1080) ? (screen_size * 8 / 10) :
+                                                                            (screen_size * 9 / 10)};
 
   widget->resize(widget->sizeHint().boundedTo(adj_screen_size));
 }

--- a/Source/Core/DolphinQt/QtUtils/QtUtils.h
+++ b/Source/Core/DolphinQt/QtUtils/QtUtils.h
@@ -16,7 +16,9 @@ void ShowFourDigitYear(QDateTimeEdit* widget);
 
 QWidget* CreateIconWarning(QWidget* parent, QStyle::StandardPixmap standard_pixmap, QLabel* label);
 
-// Similar to QWidget::adjustSize except maximum size is 9/10 of screen rather than 2/3.
+// Similar to `QWidget::adjustSize()` except maximum size is either 8/10 of the screen (for screen
+// resolutions greater than FullHD) or 9/10 of the screen (for smaller resolutions), as opposed to
+// the 2/3 factor that is used in `QWidget::adjustSize()`.
 void AdjustSizeWithinScreen(QWidget* widget);
 
 // A QWidget that returns the minimumSizeHint as the primary sizeHint.


### PR DESCRIPTION
The maximum size for the initial size in dialogs has been reduced from 90% to 80% of the screen dimensions for screen resolutions greater than FullHD (`1920x1080`).

Rationale: Almost no dialog in the application requires such a tall window resolution (an exception is the **Graphics > Advanced** pane in the **Settings** dialog). The reduced size prevents dialogs from appearing close to the edges of the screen, which was _opinionatedly_ not too elegant.

| Before | After |
| ------ | ----- |
| <img width="1920" height="1080" alt="[Dolphin Emulator] Overly long Settings dialog" title="[Dolphin Emulator] Overly long Settings dialog" src="https://github.com/user-attachments/assets/0c5ecded-68bf-46e2-8696-399b2f263345" /> | <img width="1920" height="1080" alt="[Dolphin Emulator] Reduced Settings dialog" title="[Dolphin Emulator] Reduced Settings dialog" src="https://github.com/user-attachments/assets/45a63f2f-a7a7-4663-bacf-96d4172d42bf" /> |

Devices with smaller screen resolutions (generally handheld devices) will continue to use a 90% factor of the screen dimensions.