### PR TITLE
DolphinQt/Styles/Dark: Adjust progress bar

### DIFF
--- a/Source/Core/DolphinQt/Styles/Dark/dark.qss
+++ b/Source/Core/DolphinQt/Styles/Dark/dark.qss
@@ -506,7 +506,12 @@ QTableCornerButton::section {
 }
 
 QProgressBar {
-	border: 2px solid grey;
-	border-radius: 5px;
 	background-color: #202020;
+	border: 1px solid #7e7e7e;
+	color: #dcdcdc;
+	text-align: center;
+}
+QProgressBar::chunk {
+	background-color: #24a806;
+	width: 1px;
 }

--- a/Source/Core/DolphinQt/Styles/Dark/dark.qss
+++ b/Source/Core/DolphinQt/Styles/Dark/dark.qss
@@ -496,17 +496,17 @@ QTabBar QToolButton::left-arrow {
 QTabBar QToolButton::right-arrow {
 	image: url(:/dolphin_dark_win/right-triangle-tabbar.svg);
 }
+
 QTableCornerButton::section {
-    background-color: #202020;
-    border: 1px solid #7e7e7e;
-    border-top: 0px;
-    border-left: 0px;
-    border-bottom: 0px;
+	background-color: #202020;
+	border: 1px solid #7e7e7e;
+	border-top: 0px;
+	border-left: 0px;
+	border-bottom: 0px;
 }
 
 QProgressBar {
-     border: 2px solid grey;
-     border-radius: 5px;
-     background-color: #202020;
- }
- 
+	border: 2px solid grey;
+	border-radius: 5px;
+	background-color: #202020;
+}


### PR DESCRIPTION
Honestly this is just making it consistent with the rest of the style and fixing the text alignment. I also made the green a bit darker so that the percentage remains readable.

---

Old:

<img width="246" height="131" alt="Clipboard_08-31-2025_03" src="https://github.com/user-attachments/assets/f5b15011-4962-46f8-8470-53dd4847068a" />

New:

<img width="304" height="130" alt="Clipboard_08-31-2025_02" src="https://github.com/user-attachments/assets/1d9cb76d-e08b-45a2-b5a0-07a967dc9404" />
