### PR TITLE
Settings: Open file dialogs at user path instead of custom path

### DIFF
--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -57,7 +57,7 @@ void PathPane::BrowseDefaultGame()
 void PathPane::BrowseWiiNAND()
 {
   QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
-      this, tr("Select Wii NAND Root"), QString::fromStdString(Config::Get(Config::MAIN_FS_PATH))));
+      this, tr("Select Wii NAND Root"), QString::fromStdString(File::GetUserPath(D_WIIROOT_IDX))));
   if (!dir.isEmpty())
   {
     m_nand_edit->setText(dir);
@@ -68,7 +68,7 @@ void PathPane::BrowseWiiNAND()
 void PathPane::BrowseDump()
 {
   QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
-      this, tr("Select Dump Path"), QString::fromStdString(Config::Get(Config::MAIN_DUMP_PATH))));
+      this, tr("Select Dump Path"), QString::fromStdString(File::GetUserPath(D_DUMP_IDX))));
   if (!dir.isEmpty())
   {
     m_dump_edit->setText(dir);
@@ -79,7 +79,7 @@ void PathPane::BrowseDump()
 void PathPane::BrowseLoad()
 {
   QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
-      this, tr("Select Load Path"), QString::fromStdString(Config::Get(Config::MAIN_LOAD_PATH))));
+      this, tr("Select Load Path"), QString::fromStdString(File::GetUserPath(D_LOAD_IDX))));
   if (!dir.isEmpty())
   {
     m_load_edit->setText(dir);
@@ -91,7 +91,7 @@ void PathPane::BrowseResourcePack()
 {
   QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
       this, tr("Select Resource Pack Path"),
-      QString::fromStdString(Config::Get(Config::MAIN_RESOURCEPACK_PATH))));
+      QString::fromStdString(File::GetUserPath(D_RESOURCEPACK_IDX))));
   if (!dir.isEmpty())
   {
     m_resource_pack_edit->setText(dir);
@@ -102,7 +102,7 @@ void PathPane::BrowseResourcePack()
 void PathPane::BrowseWFS()
 {
   const QString dir = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
-      this, tr("Select WFS Path"), QString::fromStdString(Config::Get(Config::MAIN_WFS_PATH))));
+      this, tr("Select WFS Path"), QString::fromStdString(File::GetUserPath(D_WFSROOT_IDX))));
   if (!dir.isEmpty())
   {
     m_wfs_edit->setText(dir);

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -516,7 +516,7 @@ void WiiPane::BrowseSDSyncFolder()
 {
   QString file = QDir::toNativeSeparators(DolphinFileDialog::getExistingDirectory(
       this, tr("Select a Folder to Sync with the SD Card Image"),
-      QString::fromStdString(Config::Get(Config::MAIN_WII_SD_CARD_SYNC_FOLDER_PATH))));
+      QString::fromStdString(File::GetUserPath(D_WIISDCARDSYNCFOLDER_IDX))));
   if (!file.isEmpty())
     SetSDSyncFolder(file);
 }

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -279,6 +279,7 @@ void CreateDirectories()
   File::CreateFullPath(File::GetUserPath(D_RETROACHIEVEMENTSCACHE_IDX));
   File::CreateFullPath(File::GetUserPath(D_STATESAVES_IDX));
   File::CreateFullPath(File::GetUserPath(D_ASM_ROOT_IDX));
+  File::CreateFullPath(File::GetUserPath(D_WFSROOT_IDX));
 #ifndef ANDROID
   File::CreateFullPath(File::GetUserPath(D_THEMES_IDX));
   File::CreateFullPath(File::GetUserPath(D_STYLES_IDX));


### PR DESCRIPTION
When opening a file dialog to set the location of a custom path, use the corresponding user path as the starting location instead of the current custom path.

When no custom path was set the dialog would previously be opened with a blank path. This causes Windows (not sure about other platforms) to open the dialog at the same location where the last dialog was closed, or at the current working directory if no previous dialog had been opened.

If a nonempty custom path has been set then it has also set the corresponding user path, so the behavior in that case is unchanged.

This also creates `D_WFSROOT_IDX` in `UICommon::CreateDirectories` so that there's a folder to go to when opening that dialog.