### PR TITLE
RetroAchievements: Avoid crash due to uninitialized memory read

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -1027,6 +1027,9 @@ void AchievementManager::LoadGameCallback(int result, const char* error_message,
                     OSD::Color::RED);
   }
 
+  if (game == nullptr)
+    return;
+
   rc_client_set_read_memory_function(instance.m_client, MemoryPeeker);
   instance.FetchGameBadges();
   instance.m_system.store(&Core::System::GetInstance(), std::memory_order_release);


### PR DESCRIPTION
Avoid creating and then destroying a leaderboard list when `AchievementManager::m_client->game` is null, as doing so causes a crash due to reading uninitialized memory caused by a bug in rcheevos.

This can be triggered by starting a game with an invalid or expired login token.

See https://github.com/RetroAchievements/rcheevos/pull/458 for details.

Fixes https://bugs.dolphin-emu.org/issues/13880.