### PR TITLE
Jit: Optimize `dcbt` loop

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -239,6 +239,8 @@ public:
   void psq_lXX(UGeckoInstruction inst);
   void psq_stXX(UGeckoInstruction inst);
 
+  void WriteInitCacheLoop(const u32 cycle_count_per_loop, RCX64Reg& loop_counter);
+
   void fmaddXX(UGeckoInstruction inst);
   void fsign(UGeckoInstruction inst);
   void fselx(UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -229,6 +229,96 @@ void Jit64::lXXx(UGeckoInstruction inst)
     BSWAP(accessSize, Rd);
 }
 
+// Sets up the idle loop for common cache loop patterns, in the following form:
+// - dcx rX
+// - addi rX,rX,32
+// - bdnz+ -8
+//
+// While it does automatically decrease the downcount and CTR, it does *not* automatically perform
+// `rX += 32 * RSCRATCH2`.
+//
+// The passed register will be realized and clobbered. RSCRATCH will be clobbered.
+//
+// RSCRATCH2 will be set to the number of loops to execute minus 1.
+void Jit64::WriteInitCacheLoop(const u32 cycle_count_per_loop, RCX64Reg& loop_counter)
+{
+  // We'll execute somewhere between one single cacheline invalidation and however many are needed
+  // to reduce the downcount to zero, never exceeding the amount requested by the game.
+  // To stay consistent with the rest of the code we adjust the involved registers (CTR and Rb)
+  // by the amount of cache lines we invalidate minus one -- since we'll run the regular addi and
+  // bdnz afterwards! So if we invalidate a single cache line, we don't adjust the registers at
+  // all, if we invalidate 2 cachelines we adjust the registers by one step, and so on.
+
+  RCX64Reg reg_cycle_count = gpr.Scratch();
+  RCX64Reg reg_downcount = gpr.Scratch();
+  RegCache::Realize(reg_cycle_count, reg_downcount, loop_counter);
+
+  // This must be true in order for us to pick up the DIV results and not trash any data.
+  static_assert(RSCRATCH == Gen::EAX && RSCRATCH2 == Gen::EDX);
+
+  // This is both setting the adjusted loop count to 0 for the downcount <= 0 case and clearing
+  // the upper bits for the DIV instruction in the downcount > 0 case.
+  XOR(32, R(RSCRATCH2), R(RSCRATCH2));
+
+  MOV(32, R(RSCRATCH), PPCSTATE(downcount));
+  TEST(32, R(RSCRATCH), R(RSCRATCH));                       // if (downcount <= 0)
+  FixupBranch downcount_is_zero_or_negative = J_CC(CC_LE);  // only do 1 invalidation; else:
+  MOV(32, R(loop_counter), PPCSTATE_CTR);
+  MOV(32, R(reg_downcount), R(RSCRATCH));
+  MOV(32, R(reg_cycle_count), Imm32(cycle_count_per_loop));
+  DIV(32, R(reg_cycle_count));                  // RSCRATCH = downcount / cycle_count
+  LEA(32, RSCRATCH2, MDisp(loop_counter, -1));  // RSCRATCH2 = CTR - 1
+  // ^ Note that this CTR-1 implicitly handles the CTR == 0 case correctly.
+  CMP(32, R(RSCRATCH), R(RSCRATCH2));
+  CMOVcc(32, RSCRATCH2, R(RSCRATCH), CC_B);  // RSCRATCH2 = min(RSCRATCH, RSCRATCH2)
+
+  // RSCRATCH2 now holds the amount of loops to execute minus 1, which is the amount we need to
+  // adjust downcount, CTR, and Rb by to exit the loop construct with the right values in those
+  // registers.
+  SUB(32, R(loop_counter), R(RSCRATCH2));
+  MOV(32, PPCSTATE_CTR, R(loop_counter));  // CTR -= RSCRATCH2
+  IMUL(32, reg_cycle_count, R(RSCRATCH2));
+  // ^ Note that this cannot overflow because it's limited by (downcount/cycle_count).
+  SUB(32, R(reg_downcount), R(reg_cycle_count));
+  MOV(32, PPCSTATE(downcount), R(reg_downcount));  // downcount -= (RSCRATCH2 * reg_cycle_count)
+
+  SetJumpTarget(downcount_is_zero_or_negative);
+
+  if (IsDebuggingEnabled())
+  {
+    const X64Reg bw_reg_a = reg_cycle_count, bw_reg_b = reg_downcount;
+    const BitSet32 bw_caller_save = (CallerSavedRegistersInUse() | BitSet32{RSCRATCH2}) &
+                                    ~BitSet32{int(bw_reg_a), int(bw_reg_b)};
+
+    MOV(64, R(bw_reg_a), ImmPtr(&m_branch_watch));
+    MOVZX(32, 8, bw_reg_b, MDisp(bw_reg_a, Core::BranchWatch::GetOffsetOfRecordingActive()));
+    TEST(32, R(bw_reg_b), R(bw_reg_b));
+
+    FixupBranch branch_in = J_CC(CC_NZ, Jump::Near);
+    SwitchToFarCode();
+    SetJumpTarget(branch_in);
+
+    // Assert RSCRATCH2 won't be clobbered before it is moved from.
+    static_assert(RSCRATCH2 != ABI_PARAM1);
+
+    ABI_PushRegistersAndAdjustStack(bw_caller_save, 0);
+    MOV(64, R(ABI_PARAM1), R(bw_reg_a));
+    // RSCRATCH2 holds the amount of faked branch watch hits. Move RSCRATCH2 first, because
+    // ABI_PARAM2 clobbers RSCRATCH2 on Windows and ABI_PARAM3 clobbers RSCRATCH2 on Linux!
+    MOV(32, R(ABI_PARAM4), R(RSCRATCH2));
+    const PPCAnalyst::CodeOp& op = js.op[2];
+    MOV(64, R(ABI_PARAM2), Imm64(Core::FakeBranchWatchCollectionKey{op.address, op.branchTo}));
+    MOV(32, R(ABI_PARAM3), Imm32(op.inst.hex));
+    ABI_CallFunction(m_ppc_state.msr.IR ? &Core::BranchWatch::HitVirtualTrue_fk_n :
+                                          &Core::BranchWatch::HitPhysicalTrue_fk_n);
+    ABI_PopRegistersAndAdjustStack(bw_caller_save, 0);
+
+    FixupBranch branch_out = J(Jump::Near);
+    SwitchToNearCode();
+    SetJumpTarget(branch_out);
+  }
+}
+
 void Jit64::dcbx(UGeckoInstruction inst)
 {
   FALLBACK_IF(m_accurate_cpu_cache_enabled);
@@ -252,89 +342,13 @@ void Jit64::dcbx(UGeckoInstruction inst)
   RCX64Reg loop_counter;
   if (make_loop)
   {
-    // We'll execute somewhere between one single cacheline invalidation and however many are needed
-    // to reduce the downcount to zero, never exceeding the amount requested by the game.
-    // To stay consistent with the rest of the code we adjust the involved registers (CTR and Rb)
-    // by the amount of cache lines we invalidate minus one -- since we'll run the regular addi and
-    // bdnz afterwards! So if we invalidate a single cache line, we don't adjust the registers at
-    // all, if we invalidate 2 cachelines we adjust the registers by one step, and so on.
-
-    RCX64Reg reg_cycle_count = gpr.Scratch();
-    RCX64Reg reg_downcount = gpr.Scratch();
-    loop_counter = gpr.Scratch();
-    RegCache::Realize(reg_cycle_count, reg_downcount, loop_counter);
-
-    // This must be true in order for us to pick up the DIV results and not trash any data.
-    static_assert(RSCRATCH == Gen::EAX && RSCRATCH2 == Gen::EDX);
-
-    // Alright, now figure out how many loops we want to do.
-    const u8 cycle_count_per_loop =
+    const u32 cycle_count_per_loop =
         js.op[0].opinfo->num_cycles + js.op[1].opinfo->num_cycles + js.op[2].opinfo->num_cycles;
 
-    // This is both setting the adjusted loop count to 0 for the downcount <= 0 case and clearing
-    // the upper bits for the DIV instruction in the downcount > 0 case.
-    XOR(32, R(RSCRATCH2), R(RSCRATCH2));
-
-    MOV(32, R(RSCRATCH), PPCSTATE(downcount));
-    TEST(32, R(RSCRATCH), R(RSCRATCH));                       // if (downcount <= 0)
-    FixupBranch downcount_is_zero_or_negative = J_CC(CC_LE);  // only do 1 invalidation; else:
-    MOV(32, R(loop_counter), PPCSTATE_CTR);
-    MOV(32, R(reg_downcount), R(RSCRATCH));
-    MOV(32, R(reg_cycle_count), Imm32(cycle_count_per_loop));
-    DIV(32, R(reg_cycle_count));                  // RSCRATCH = downcount / cycle_count
-    LEA(32, RSCRATCH2, MDisp(loop_counter, -1));  // RSCRATCH2 = CTR - 1
-    // ^ Note that this CTR-1 implicitly handles the CTR == 0 case correctly.
-    CMP(32, R(RSCRATCH), R(RSCRATCH2));
-    CMOVcc(32, RSCRATCH2, R(RSCRATCH), CC_B);  // RSCRATCH2 = min(RSCRATCH, RSCRATCH2)
-
-    // RSCRATCH2 now holds the amount of loops to execute minus 1, which is the amount we need to
-    // adjust downcount, CTR, and Rb by to exit the loop construct with the right values in those
-    // registers.
-    SUB(32, R(loop_counter), R(RSCRATCH2));
-    MOV(32, PPCSTATE_CTR, R(loop_counter));  // CTR -= RSCRATCH2
-    IMUL(32, reg_cycle_count, R(RSCRATCH2));
-    // ^ Note that this cannot overflow because it's limited by (downcount/cycle_count).
-    SUB(32, R(reg_downcount), R(reg_cycle_count));
-    MOV(32, PPCSTATE(downcount), R(reg_downcount));  // downcount -= (RSCRATCH2 * reg_cycle_count)
-
-    SetJumpTarget(downcount_is_zero_or_negative);
-
+    loop_counter = gpr.Scratch();
+    WriteInitCacheLoop(cycle_count_per_loop, loop_counter);
     // Load the loop_counter register with the amount of invalidations to execute.
     LEA(32, loop_counter, MDisp(RSCRATCH2, 1));
-
-    if (IsDebuggingEnabled())
-    {
-      const X64Reg bw_reg_a = reg_cycle_count, bw_reg_b = reg_downcount;
-      const BitSet32 bw_caller_save = (CallerSavedRegistersInUse() | BitSet32{RSCRATCH2}) &
-                                      ~BitSet32{int(bw_reg_a), int(bw_reg_b)};
-
-      MOV(64, R(bw_reg_a), ImmPtr(&m_branch_watch));
-      MOVZX(32, 8, bw_reg_b, MDisp(bw_reg_a, Core::BranchWatch::GetOffsetOfRecordingActive()));
-      TEST(32, R(bw_reg_b), R(bw_reg_b));
-
-      FixupBranch branch_in = J_CC(CC_NZ, Jump::Near);
-      SwitchToFarCode();
-      SetJumpTarget(branch_in);
-
-      // Assert RSCRATCH2 won't be clobbered before it is moved from.
-      static_assert(RSCRATCH2 != ABI_PARAM1);
-
-      ABI_PushRegistersAndAdjustStack(bw_caller_save, 0);
-      MOV(64, R(ABI_PARAM1), R(bw_reg_a));
-      // RSCRATCH2 holds the amount of faked branch watch hits. Move RSCRATCH2 first, because
-      // ABI_PARAM2 clobbers RSCRATCH2 on Windows and ABI_PARAM3 clobbers RSCRATCH2 on Linux!
-      MOV(32, R(ABI_PARAM4), R(RSCRATCH2));
-      const PPCAnalyst::CodeOp& op = js.op[2];
-      MOV(64, R(ABI_PARAM2), Imm64(Core::FakeBranchWatchCollectionKey{op.address, op.branchTo}));
-      MOV(32, R(ABI_PARAM3), Imm32(op.inst.hex));
-      ABI_CallFunction(m_ppc_state.msr.IR ? &Core::BranchWatch::HitVirtualTrue_fk_n :
-                                            &Core::BranchWatch::HitPhysicalTrue_fk_n);
-      ABI_PopRegistersAndAdjustStack(bw_caller_save, 0);
-
-      FixupBranch branch_out = J(Jump::Near);
-      SwitchToNearCode();
-      SetJumpTarget(branch_out);
-    }
   }
 
   X64Reg addr = RSCRATCH;
@@ -423,10 +437,38 @@ void Jit64::dcbt(UGeckoInstruction inst)
   // This is important because invalidating the block cache when we don't
   // need to is terrible for performance.
   // (Invalidating the jit block cache on dcbst is a heuristic.)
-  if (CanMergeNextInstructions(1) && js.op[1].inst.OPCD == 31 && js.op[1].inst.SUBOP10 == 54 &&
-      js.op[1].inst.RA == inst.RA && js.op[1].inst.RB == inst.RB)
+  const bool followedByDcbst =
+      (CanMergeNextInstructions(1) && js.op[1].inst.OPCD == 31 && js.op[1].inst.SUBOP10 == 54 &&
+       js.op[1].inst.RA == inst.RA && js.op[1].inst.RB == inst.RB);
+
+  if (followedByDcbst)
   {
     js.skipInstructions = 1;
+  }
+
+  const u32 i = followedByDcbst;
+  // Check if the next instructions match a known looping pattern:
+  // - dcbt rX
+  // - dcbst rX (optional)
+  // - addi rX,rX,32
+  // - bdnz+ -8 (or -12 if dcbst)
+  const bool make_loop = inst.RA == 0 && inst.RB != 0 && CanMergeNextInstructions(2 + i) &&
+                         (js.op[1 + i].inst.hex & 0xfc00'ffff) == 0x38000020 &&
+                         js.op[1 + i].inst.RA_6 == inst.RB && js.op[1 + i].inst.RD_2 == inst.RB &&
+                         js.op[2 + i].inst.hex == 0x42010000 - (4 * (2 + i));
+
+  if (make_loop)
+  {
+    u32 cycle_count_per_loop = 0;
+    for (u32 j = 0; j < 3 + i; j++)
+      cycle_count_per_loop += js.op[j].opinfo->num_cycles;
+    RCX64Reg loop_counter = gpr.Scratch();
+    WriteInitCacheLoop(cycle_count_per_loop, loop_counter);
+
+    SHL(32, R(RSCRATCH2), Imm8(5));
+    RCX64Reg Rb = gpr.Bind(inst.RB, RCMode::ReadWrite);
+    RegCache::Realize(Rb);
+    ADD(32, R(Rb), R(RSCRATCH2));  // Rb += (RSCRATCH2 * 32)
   }
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -140,6 +140,9 @@ public:
   void mtfsfx(UGeckoInstruction inst);
 
   // LoadStore
+  void WriteInitCacheLoop(const u32 cycle_count_per_loop, const Arm64Gen::ARM64Reg loop_counter,
+                          const Arm64Gen::ARM64Reg WA, const Arm64Gen::ARM64Reg WB);
+
   void lXX(UGeckoInstruction inst);
   void stX(UGeckoInstruction inst);
   void lmw(UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -755,6 +755,90 @@ void JitArm64::stmw(UGeckoInstruction inst)
     gpr.Unlock(ARM64Reg::W0);
 }
 
+// Sets up the idle loop for common cache loop patterns, in the following form:
+// - dcx rX
+// - addi rX,rX,32
+// - bdnz+ -8
+//
+// While it does automatically decrease the downcount and CTR, it does *not* automatically perform
+// `rX += 32 * WA`.
+//
+// All the passed registers will be clobbered.
+//
+// WA will be set to the number of loops to execute minus 1.
+void JitArm64::WriteInitCacheLoop(const u32 cycle_count_per_loop, const ARM64Reg loop_counter,
+                                  const ARM64Reg WA, const ARM64Reg WB)
+{
+  // We'll execute somewhere between one single cacheline invalidation and however many are needed
+  // to reduce the downcount to zero, never exceeding the amount requested by the game.
+  // To stay consistent with the rest of the code we adjust the involved registers (CTR and Rb)
+  // by the amount of cache lines we invalidate minus one -- since we'll run the regular addi and
+  // bdnz afterwards! So if we invalidate a single cache line, we don't adjust the registers at
+  // all, if we invalidate 2 cachelines we adjust the registers by one step, and so on.
+
+  const auto reg_cycle_count = gpr.GetScopedReg();
+  const auto reg_downcount = gpr.GetScopedReg();
+
+  LDR(IndexType::Unsigned, reg_downcount, PPC_REG, PPCSTATE_OFF(downcount));
+  MOVI2R(WA, 0);
+  CMP(reg_downcount, 0);                                          // if (downcount <= 0)
+  FixupBranch downcount_is_zero_or_negative = B(CCFlags::CC_LE);  // only do 1 invalidation; else:
+  LDR(IndexType::Unsigned, loop_counter, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
+  MOVI2R(reg_cycle_count, cycle_count_per_loop);
+  SDIV(WB, reg_downcount, reg_cycle_count);  // WB = downcount / cycle_count
+  SUB(WA, loop_counter, 1);                  // WA = CTR - 1
+  // ^ Note that this CTR-1 implicitly handles the CTR == 0 case correctly.
+  CMP(WB, WA);
+  CSEL(WA, WB, WA, CCFlags::CC_LO);  // WA = min(WB, WA)
+
+  // WA now holds the amount of loops to execute minus 1, which is the amount we need to adjust
+  // downcount, CTR, and Rb by to exit the loop construct with the right values in those
+  // registers.
+
+  // CTR -= WA
+  SUB(loop_counter, loop_counter, WA);
+  STR(IndexType::Unsigned, loop_counter, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
+
+  // downcount -= (WA * reg_cycle_count)
+  MSUB(reg_downcount, WA, reg_cycle_count, reg_downcount);
+  // ^ Note that this cannot overflow because it's limited by (downcount/cycle_count).
+  STR(IndexType::Unsigned, reg_downcount, PPC_REG, PPCSTATE_OFF(downcount));
+
+  SetJumpTarget(downcount_is_zero_or_negative);
+
+  if (IsDebuggingEnabled())
+  {
+    const ARM64Reg branch_watch = EncodeRegTo64(reg_cycle_count);
+    MOVP2R(branch_watch, &m_branch_watch);
+    LDRB(IndexType::Unsigned, WB, branch_watch, Core::BranchWatch::GetOffsetOfRecordingActive());
+    FixupBranch branch_over = CBZ(WB);
+
+    FixupBranch branch_in = B();
+    SwitchToFarCode();
+    SetJumpTarget(branch_in);
+
+    const BitSet32 gpr_caller_save =
+        gpr.GetCallerSavedUsed() &
+        ~BitSet32{DecodeReg(WB), DecodeReg(reg_cycle_count), DecodeReg(reg_downcount)};
+    ABI_PushRegisters(gpr_caller_save);
+    const ARM64Reg float_emit_tmp = EncodeRegTo64(WB);
+    const BitSet32 fpr_caller_save = fpr.GetCallerSavedUsed();
+    m_float_emit.ABI_PushRegisters(fpr_caller_save, float_emit_tmp);
+    const PPCAnalyst::CodeOp& op = js.op[2];
+    ABI_CallFunction(m_ppc_state.msr.IR ? &Core::BranchWatch::HitVirtualTrue_fk_n :
+                                          &Core::BranchWatch::HitPhysicalTrue_fk_n,
+                     branch_watch, Core::FakeBranchWatchCollectionKey{op.address, op.branchTo},
+                     op.inst.hex, WA);
+    m_float_emit.ABI_PopRegisters(fpr_caller_save, float_emit_tmp);
+    ABI_PopRegisters(gpr_caller_save);
+
+    FixupBranch branch_out = B();
+    SwitchToNearCode();
+    SetJumpTarget(branch_out);
+    SetJumpTarget(branch_over);
+  }
+}
+
 void JitArm64::dcbx(UGeckoInstruction inst)
 {
   FALLBACK_IF(m_accurate_cpu_cache_enabled);
@@ -782,81 +866,13 @@ void JitArm64::dcbx(UGeckoInstruction inst)
     gpr.Lock(loop_counter);
     gpr.BindToRegister(b, true);
 
-    // We'll execute somewhere between one single cacheline invalidation and however many are needed
-    // to reduce the downcount to zero, never exceeding the amount requested by the game.
-    // To stay consistent with the rest of the code we adjust the involved registers (CTR and Rb)
-    // by the amount of cache lines we invalidate minus one -- since we'll run the regular addi and
-    // bdnz afterwards! So if we invalidate a single cache line, we don't adjust the registers at
-    // all, if we invalidate 2 cachelines we adjust the registers by one step, and so on.
-
-    const auto reg_cycle_count = gpr.GetScopedReg();
-    const auto reg_downcount = gpr.GetScopedReg();
-
     // Figure out how many loops we want to do.
-    const u8 cycle_count_per_loop =
+    const u32 cycle_count_per_loop =
         js.op[0].opinfo->num_cycles + js.op[1].opinfo->num_cycles + js.op[2].opinfo->num_cycles;
 
-    LDR(IndexType::Unsigned, reg_downcount, PPC_REG, PPCSTATE_OFF(downcount));
-    MOVI2R(WA, 0);
-    CMP(reg_downcount, 0);                                          // if (downcount <= 0)
-    FixupBranch downcount_is_zero_or_negative = B(CCFlags::CC_LE);  // only do 1 invalidation; else:
-    LDR(IndexType::Unsigned, loop_counter, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
-    MOVI2R(reg_cycle_count, cycle_count_per_loop);
-    SDIV(WB, reg_downcount, reg_cycle_count);  // WB = downcount / cycle_count
-    SUB(WA, loop_counter, 1);                  // WA = CTR - 1
-    // ^ Note that this CTR-1 implicitly handles the CTR == 0 case correctly.
-    CMP(WB, WA);
-    CSEL(WA, WB, WA, CCFlags::CC_LO);  // WA = min(WB, WA)
-
-    // WA now holds the amount of loops to execute minus 1, which is the amount we need to adjust
-    // downcount, CTR, and Rb by to exit the loop construct with the right values in those
-    // registers.
-
-    // CTR -= WA
-    SUB(loop_counter, loop_counter, WA);
-    STR(IndexType::Unsigned, loop_counter, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
-
-    // downcount -= (WA * reg_cycle_count)
-    MSUB(reg_downcount, WA, reg_cycle_count, reg_downcount);
-    // ^ Note that this cannot overflow because it's limited by (downcount/cycle_count).
-    STR(IndexType::Unsigned, reg_downcount, PPC_REG, PPCSTATE_OFF(downcount));
-
-    SetJumpTarget(downcount_is_zero_or_negative);
-
+    WriteInitCacheLoop(cycle_count_per_loop, loop_counter, WA, WB);
     // Load the loop_counter register with the amount of invalidations to execute.
     ADD(loop_counter, WA, 1);
-
-    if (IsDebuggingEnabled())
-    {
-      const ARM64Reg branch_watch = EncodeRegTo64(reg_cycle_count);
-      MOVP2R(branch_watch, &m_branch_watch);
-      LDRB(IndexType::Unsigned, WB, branch_watch, Core::BranchWatch::GetOffsetOfRecordingActive());
-      FixupBranch branch_over = CBZ(WB);
-
-      FixupBranch branch_in = B();
-      SwitchToFarCode();
-      SetJumpTarget(branch_in);
-
-      const BitSet32 gpr_caller_save =
-          gpr.GetCallerSavedUsed() &
-          ~BitSet32{DecodeReg(WB), DecodeReg(reg_cycle_count), DecodeReg(reg_downcount)};
-      ABI_PushRegisters(gpr_caller_save);
-      const ARM64Reg float_emit_tmp = EncodeRegTo64(WB);
-      const BitSet32 fpr_caller_save = fpr.GetCallerSavedUsed();
-      m_float_emit.ABI_PushRegisters(fpr_caller_save, float_emit_tmp);
-      const PPCAnalyst::CodeOp& op = js.op[2];
-      ABI_CallFunction(m_ppc_state.msr.IR ? &Core::BranchWatch::HitVirtualTrue_fk_n :
-                                            &Core::BranchWatch::HitPhysicalTrue_fk_n,
-                       branch_watch, Core::FakeBranchWatchCollectionKey{op.address, op.branchTo},
-                       op.inst.hex, WA);
-      m_float_emit.ABI_PopRegisters(fpr_caller_save, float_emit_tmp);
-      ABI_PopRegisters(gpr_caller_save);
-
-      FixupBranch branch_out = B();
-      SwitchToNearCode();
-      SetJumpTarget(branch_out);
-      SetJumpTarget(branch_over);
-    }
   }
 
   constexpr ARM64Reg effective_addr = WB;
@@ -957,10 +973,38 @@ void JitArm64::dcbt(UGeckoInstruction inst)
   // This is important because invalidating the block cache when we don't
   // need to is terrible for performance.
   // (Invalidating the jit block cache on dcbst is a heuristic.)
-  if (CanMergeNextInstructions(1) && js.op[1].inst.OPCD == 31 && js.op[1].inst.SUBOP10 == 54 &&
-      js.op[1].inst.RA == inst.RA && js.op[1].inst.RB == inst.RB)
+  const bool followedByDcbst =
+      (CanMergeNextInstructions(1) && js.op[1].inst.OPCD == 31 && js.op[1].inst.SUBOP10 == 54 &&
+       js.op[1].inst.RA == inst.RA && js.op[1].inst.RB == inst.RB);
+
+  if (followedByDcbst)
   {
     js.skipInstructions = 1;
+  }
+
+  const u32 i = followedByDcbst;
+  // Check if the next instructions match a known looping pattern:
+  // - dcbt rX
+  // - dcbst rX (optional)
+  // - addi rX,rX,32
+  // - bdnz+ -8 (or -12 if dcbst)
+  const bool make_loop = inst.RA == 0 && inst.RB != 0 && CanMergeNextInstructions(2 + i) &&
+                         (js.op[1 + i].inst.hex & 0xfc00'ffff) == 0x38000020 &&
+                         js.op[1 + i].inst.RA_6 == inst.RB && js.op[1 + i].inst.RD_2 == inst.RB &&
+                         js.op[2 + i].inst.hex == 0x42010000 - (4 * (2 + i));
+
+  if (make_loop)
+  {
+    u32 cycle_count_per_loop = 0;
+    for (u32 j = 0; j < 3 + i; j++)
+      cycle_count_per_loop += js.op[j].opinfo->num_cycles;
+    constexpr ARM64Reg WA = ARM64Reg::W0, WB = ARM64Reg::W1, loop_counter = ARM64Reg::W2;
+    gpr.Lock(WA, WB, loop_counter);
+    gpr.BindToRegister(inst.RB, true);
+
+    WriteInitCacheLoop(cycle_count_per_loop, loop_counter, WA, WB);
+
+    ADD(gpr.R(inst.RB), gpr.R(inst.RB), WA, ArithOption(WA, ShiftType::LSL, 5));  // Rb += (WA * 32)
   }
 }
 


### PR DESCRIPTION
While the performance improvement is very small, the commit is simple as well (and IMO, separating part of `dcbx` into a separate function makes it less daunting to read).
Tested only on x86.