### PR TITLE
GameINI: Add 60 FPS patch for NTSC version of Terminator 3.

### DIFF
--- a/Data/Sys/GameSettings/GT6E70.ini
+++ b/Data/Sys/GameSettings/GT6E70.ini
@@ -1,7 +1,39 @@
 # GT6E70 - Terminator 3: The Redemption
 
 [OnFrame]
-# Add memory patches to be applied every frame here.
+$60 FPS
+# Increasing `CPU Clock Override` is necessary for a stable FPS.
+# Higher than 60 FPS is also possible with `VBI Clock Override`.
+# This skips a busy loop immediately before a `VIWaitForRetrace`.
+0x802df4fc:dword:0x60000000
+# The rest of this scales "on foot" aiming sensitivity for variable framerates.
+# The "on rails" game sections already do this scaling.
+# This code overwrites some redundant Y axis sensitivity loading code.
+0x8009bff4:dword:0x60000000 # NOP existing X axis code (moved later).
+0x8009bff8:dword:0x60000000
+0x8009bffc:dword:0x806d9c34 
+0x8009c000:dword:0x80630008
+0x8009c004:dword:0xc0430000 # Load the elapsed time value.
+0x8009c008:dword:0xec0000b2 # Scale sensitivity value by elapsed time.
+0x8009c00c:dword:0xc0450074 # Load a convenient -30.0 value.
+0x8009c010:dword:0xfc401050 # Negate.
+0x8009c014:dword:0xec0000b2 # Scale sensitivity by 30 (the original framerate).
+0x8009c018:dword:0x60000000 # NOP redundant sensitivity loading code.
+0x8009c01c:dword:0x60000000
+0x8009c020:dword:0x60000000
+0x8009c024:dword:0x60000000
+0x8009c028:dword:0x60000000
+0x8009c02c:dword:0x60000000
+0x8009c030:dword:0x60000000
+0x8009c034:dword:0xc0460084 # Moved X axis code using different registers.
+0x8009c038:dword:0xec210032
+0x8009c03c:dword:0xec420828
+0x8009c040:dword:0xd0460084
+0x8009c044:dword:0xc0460170 # Adjusted Y axis code using different registers.
+0x8009c048:dword:0xc0250088
+0x8009c04c:dword:0x60000000
+0x8009c054:dword:0xc0460088
+0x8009c060:dword:0xd0060088
 
 [ActionReplay]
 # Add action replay cheats here.


### PR DESCRIPTION
I have very little idea of what I am doing here.

I've replaced the highlighted instruction with a nop.
<details> 
<img width="671" height="1197" alt="image" src="https://github.com/user-attachments/assets/3c29bc13-731b-4f6f-acb3-8920f1b41dd1" />
</details>

This makes the game run at 60 fps (or higher with VBI Clock Override).

I've also patched a redundant section of code to scale the aiming sensitivity based on the frame rate.
