### PR TITLE
MI: add option to log call stack on bp hit

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -23,6 +23,7 @@ struct TBreakPoint
   bool is_enabled = false;
   bool log_on_hit = false;
   bool break_on_hit = false;
+  bool log_call_stack = false;
   std::optional<Expression> condition;
 };
 
@@ -39,6 +40,8 @@ struct TMemCheck
 
   bool log_on_hit = false;
   bool break_on_hit = false;
+
+  bool log_call_stack = false;
 
   u32 num_hits = 0;
 
@@ -74,7 +77,8 @@ public:
   const TBreakPoint* GetRegularBreakpoint(u32 address) const;
 
   // Add BreakPoint. If one already exists on the same address, replace it.
-  void Add(u32 address, bool break_on_hit, bool log_on_hit, std::optional<Expression> condition);
+  void Add(u32 address, bool break_on_hit, bool log_on_hit, bool log_call_stack,
+           std::optional<Expression> condition);
   void Add(u32 address);
   void Add(TBreakPoint bp);
   // Add temporary breakpoint (e.g., Step Over, Run to Here)

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -20,6 +20,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
+#include "Core/Debugger/Debugger_SymbolMap.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/Host.h"
@@ -644,6 +645,15 @@ bool PowerPCManager::CheckBreakPoints()
                    m_ppc_state.gpr[4], m_ppc_state.gpr[5], m_ppc_state.gpr[6], m_ppc_state.gpr[7],
                    m_ppc_state.gpr[8], m_ppc_state.gpr[9], m_ppc_state.gpr[10], m_ppc_state.gpr[11],
                    m_ppc_state.gpr[12], LR(m_ppc_state));
+
+    if (bp->log_call_stack)
+    {
+      auto& system = Core::System::GetInstance();
+      ASSERT(Core::IsCPUThread());
+      Core::CPUThreadGuard guard(system);
+      Dolphin_Debugger::PrintCallstack(guard, Common::Log::LogType::MEMMAP,
+                                       Common::Log::LogLevel::LNOTICE);
+    }
   }
   if (bp->break_on_hit)
     return true;

--- a/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BranchWatchDialog.cpp
@@ -1159,7 +1159,7 @@ void BranchWatchDialog::SetBreakpoints(bool break_on_hit, bool log_on_hit) const
   for (const QModelIndex& index : m_index_list_temp)
   {
     const u32 address = m_table_proxy->data(index, UserRole::ClickRole).value<u32>();
-    breakpoints.Add(address, break_on_hit, log_on_hit, {});
+    breakpoints.Add(address, break_on_hit, log_on_hit, false, {});
   }
   emit Host::GetInstance()->PPCBreakpointsChanged();
 }

--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
@@ -47,6 +47,8 @@ BreakpointDialog::BreakpointDialog(BreakpointWidget* parent, const TBreakPoint* 
   m_do_log->setChecked(!breakpoint->break_on_hit && breakpoint->log_on_hit);
   m_do_log_and_break->setChecked(breakpoint->break_on_hit && breakpoint->log_on_hit);
 
+  m_call_stack_checkbox->setChecked(breakpoint->log_call_stack);
+
   OnBPTypeChanged();
   OnAddressTypeChanged();
 }
@@ -80,6 +82,8 @@ BreakpointDialog::BreakpointDialog(BreakpointWidget* parent, const TMemCheck* me
   m_do_break->setChecked(memcheck->break_on_hit && !memcheck->log_on_hit);
   m_do_log->setChecked(!memcheck->break_on_hit && memcheck->log_on_hit);
   m_do_log_and_break->setChecked(memcheck->break_on_hit && memcheck->log_on_hit);
+
+  m_call_stack_checkbox->setChecked(memcheck->log_call_stack);
 
   OnBPTypeChanged();
   OnAddressTypeChanged();
@@ -175,6 +179,11 @@ void BreakpointDialog::CreateWidgets()
   conditional_layout->addWidget(new QLabel(tr("Condition:")));
   conditional_layout->addWidget(m_conditional);
 
+  // add a checkbox to support printing call stacks on membps
+  QHBoxLayout* call_stack_layout = new QHBoxLayout;
+  m_call_stack_checkbox = new QCheckBox(tr("Log Call Stack"));
+  call_stack_layout->addWidget(m_call_stack_checkbox);
+
   auto* action_layout = new QHBoxLayout;
   action_layout->addWidget(m_do_log);
   action_layout->addWidget(m_do_break);
@@ -183,6 +192,7 @@ void BreakpointDialog::CreateWidgets()
   auto* action_vlayout = new QVBoxLayout;
   action_vlayout->addLayout(conditional_layout);
   action_vlayout->addLayout(action_layout);
+  action_vlayout->addLayout(call_stack_layout);
 
   action_box->setLayout(action_vlayout);
 
@@ -263,6 +273,7 @@ void BreakpointDialog::accept()
   // Actions
   bool do_log = m_do_log->isChecked() || m_do_log_and_break->isChecked();
   bool do_break = m_do_break->isChecked() || m_do_log_and_break->isChecked();
+  bool log_call_stack = m_call_stack_checkbox->isChecked();
 
   bool good;
 
@@ -286,7 +297,7 @@ void BreakpointDialog::accept()
       return;
     }
 
-    m_parent->AddBP(address, do_break, do_log, condition);
+    m_parent->AddBP(address, do_break, do_log, log_call_stack, condition);
   }
   else
   {
@@ -307,11 +318,12 @@ void BreakpointDialog::accept()
         return;
       }
 
-      m_parent->AddRangedMBP(from, to, on_read, on_write, do_log, do_break, condition);
+      m_parent->AddRangedMBP(from, to, on_read, on_write, do_log, do_break, log_call_stack,
+                             condition);
     }
     else
     {
-      m_parent->AddAddressMBP(from, on_read, on_write, do_log, do_break, condition);
+      m_parent->AddAddressMBP(from, on_read, on_write, do_log, do_break, log_call_stack, condition);
     }
   }
 

--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.h
@@ -66,6 +66,8 @@ private:
   QRadioButton* m_do_break;
   QRadioButton* m_do_log_and_break;
 
+  QCheckBox* m_call_stack_checkbox;
+
   QLineEdit* m_conditional;
   QPushButton* m_cond_help_btn;
 

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -597,13 +597,14 @@ void BreakpointWidget::OnItemChanged(QTableWidgetItem* item)
 
 void BreakpointWidget::AddBP(u32 addr)
 {
-  AddBP(addr, true, true, {});
+  AddBP(addr, true, true, false, {});
 }
 
-void BreakpointWidget::AddBP(u32 addr, bool break_on_hit, bool log_on_hit, const QString& condition)
+void BreakpointWidget::AddBP(u32 addr, bool break_on_hit, bool log_on_hit, bool log_call_stack,
+                             const QString& condition)
 {
   m_system.GetPowerPC().GetBreakPoints().Add(
-      addr, break_on_hit, log_on_hit,
+      addr, break_on_hit, log_on_hit, log_call_stack,
       !condition.isEmpty() ? Expression::TryParse(condition.toUtf8().constData()) : std::nullopt);
 
   emit Host::GetInstance()->PPCBreakpointsChanged();
@@ -644,7 +645,7 @@ void BreakpointWidget::EditBreakpoint(u32 address, int edit, std::optional<QStri
 }
 
 void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool do_log,
-                                     bool do_break, const QString& condition)
+                                     bool do_break, bool log_call_stack, const QString& condition)
 {
   TMemCheck check;
 
@@ -655,6 +656,7 @@ void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool
   check.is_break_on_write = on_write;
   check.log_on_hit = do_log;
   check.break_on_hit = do_break;
+  check.log_call_stack = log_call_stack;
   check.condition =
       !condition.isEmpty() ? Expression::TryParse(condition.toUtf8().constData()) : std::nullopt;
   {
@@ -666,7 +668,7 @@ void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool
 }
 
 void BreakpointWidget::AddRangedMBP(u32 from, u32 to, bool on_read, bool on_write, bool do_log,
-                                    bool do_break, const QString& condition)
+                                    bool do_break, bool log_call_stack, const QString& condition)
 {
   TMemCheck check;
 
@@ -677,6 +679,7 @@ void BreakpointWidget::AddRangedMBP(u32 from, u32 to, bool on_read, bool on_writ
   check.is_break_on_write = on_write;
   check.log_on_hit = do_log;
   check.break_on_hit = do_break;
+  check.log_call_stack = log_call_stack;
   check.condition =
       !condition.isEmpty() ? Expression::TryParse(condition.toUtf8().constData()) : std::nullopt;
   {

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -34,11 +34,14 @@ public:
   ~BreakpointWidget() override;
 
   void AddBP(u32 addr);
-  void AddBP(u32 addr, bool break_on_hit, bool log_on_hit, const QString& condition);
+  void AddBP(u32 addr, bool break_on_hit, bool log_on_hit, bool log_call_stack,
+             const QString& condition);
   void AddAddressMBP(u32 addr, bool on_read = true, bool on_write = true, bool do_log = true,
-                     bool do_break = true, const QString& condition = {});
+                     bool do_break = true, bool log_call_stack = false,
+                     const QString& condition = {});
   void AddRangedMBP(u32 from, u32 to, bool do_read = true, bool do_write = true, bool do_log = true,
-                    bool do_break = true, const QString& condition = {});
+                    bool do_break = true, bool log_call_stack = false,
+                    const QString& condition = {});
   void UpdateButtonsEnabled();
   void Update();
 


### PR DESCRIPTION
This feature adds an option to log out a call stack when bps are hit. I've used this a fair amount in the past when debugging things for Melee and thought it might be a good idea to make it into a more fleshed out feature.

The motivation is sometimes you want to use a membp on a memory location that gets written to a lot from a deeply nested function. This makes it extremely hard to find the function up the chain you actually care about. Using breaks is useless since it would take forever to skip through to the one you need and logging is also useless because the function doing the write is a helper function.

I've never used this on an address bp but I supported that too as maybe it could be useful.

<img width="329" height="384" alt="Dolphin_1QoJbQKO9X" src="https://github.com/user-attachments/assets/8ebd1eff-791b-4f51-8563-962d13f82d8f" />
<img width="1920" height="1032" alt="Dolphin_Sl8soge5bv" src="https://github.com/user-attachments/assets/89faf518-5ea2-44c6-8d6f-81640b1be47c" />
<img width="1920" height="1032" alt="Dolphin_r9iACjkAqR" src="https://github.com/user-attachments/assets/e7ef99ac-013d-4596-9d70-d20e12170080" />
