### PR TITLE
Logging: Don't overwrite LDEBUG level in Release builds

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -419,7 +419,7 @@ Java_org_dolphinemu_dolphinemu_NativeLibrary_GetDefaultGraphicsBackendConfigName
 
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetMaxLogLevel(JNIEnv*, jclass)
 {
-  return static_cast<jint>(Common::Log::MAX_LOGLEVEL);
+  return static_cast<jint>(Common::Log::MAX_EFFECTIVE_LOGLEVEL);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_WipeJitBlockProfilingData(

--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -25,7 +25,7 @@
 #define DEBUG_ASSERT_MSG(_t_, _a_, _fmt_, ...)                                                     \
   do                                                                                               \
   {                                                                                                \
-    if constexpr (Common::Log::MAX_LOGLEVEL >= Common::Log::LogLevel::LDEBUG)                      \
+    if constexpr (Common::Log::MAX_EFFECTIVE_LOGLEVEL >= Common::Log::LogLevel::LDEBUG)            \
       ASSERT_MSG(_t_, _a_, _fmt_ __VA_OPT__(, ) __VA_ARGS__);                                      \
   } while (0)
 
@@ -45,6 +45,6 @@
 #define DEBUG_ASSERT(_a_)                                                                          \
   do                                                                                               \
   {                                                                                                \
-    if constexpr (Common::Log::MAX_LOGLEVEL >= Common::Log::LogLevel::LDEBUG)                      \
+    if constexpr (Common::Log::MAX_EFFECTIVE_LOGLEVEL >= Common::Log::LogLevel::LDEBUG)            \
       ASSERT(_a_);                                                                                 \
   } while (0)

--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -82,9 +82,9 @@ enum class LogLevel : int
 };
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
-constexpr auto MAX_LOGLEVEL = Common::Log::LogLevel::LDEBUG;
+constexpr auto MAX_EFFECTIVE_LOGLEVEL = Common::Log::LogLevel::LDEBUG;
 #else
-constexpr auto MAX_LOGLEVEL = Common::Log::LogLevel::LINFO;
+constexpr auto MAX_EFFECTIVE_LOGLEVEL = Common::Log::LogLevel::LINFO;
 #endif  // logging
 
 static const char LOG_LEVEL_TO_CHAR[7] = "-NEWID";
@@ -114,7 +114,7 @@ void GenericLogFmt(LogLevel level, LogType type, const char* file, int line, con
 #define GENERIC_LOG_FMT(t, v, format, ...)                                                         \
   do                                                                                               \
   {                                                                                                \
-    if (v <= Common::Log::MAX_LOGLEVEL)                                                            \
+    if (v <= Common::Log::MAX_EFFECTIVE_LOGLEVEL)                                                  \
     {                                                                                              \
       /* Use a macro-like name to avoid shadowing warnings */                                      \
       constexpr auto GENERIC_LOG_FMT_N = Common::CountFmtReplacementFields(format);                \

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -4,17 +4,25 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstdarg>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "Common/BitSet.h"
+#include "Common/Config/Config.h"
 #include "Common/EnumMap.h"
 #include "Common/Logging/Log.h"
 
 namespace Common::Log
 {
+// This variable should only be read to update the effective log level, and its base layer should
+// only be set when the user selects a new verbosity. Everything else should use the effective log
+// level instead. When running a release build this prevents overwriting the LDEBUG config value
+// with the clamped LINFO level.
+extern const Config::Info<LogLevel> LOGGER_VERBOSITY;
+
 // pure virtual interface
 class LogListener
 {
@@ -52,8 +60,9 @@ public:
   void LogWithFullPath(LogLevel level, LogType type, const char* file, int line,
                        const char* message);
 
-  LogLevel GetLogLevel() const;
-  void SetLogLevel(LogLevel level);
+  // Use this function instead of LOGGER_VERBOSITY to determine which logs should be printed.
+  LogLevel GetEffectiveLogLevel() const;
+  void SetConfigLogLevel(LogLevel level);
 
   void SetEnable(LogType type, bool enable);
   bool IsEnabled(LogType type, LogLevel level = LogLevel::LNOTICE) const;
@@ -78,8 +87,10 @@ private:
   LogManager& operator=(LogManager&&) = delete;
 
   static std::string GetTimestamp();
+  void SetEffectiveLogLevel();
 
-  LogLevel m_level;
+  std::atomic<LogLevel> m_effective_level;
+  Config::ConfigChangedCallbackID m_config_changed_callback_id;
   EnumMap<LogContainer, LAST_LOG_TYPE> m_log{};
   std::array<std::unique_ptr<LogListener>, LogListener::NUMBER_OF_LISTENERS> m_listeners{};
   BitSet32 m_listener_ids;

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -329,8 +329,11 @@ static void VLogInfo(std::string_view format, fmt::format_args args)
     return;
 
   const bool use_internal_log = s_use_internal_log.load(std::memory_order_relaxed);
-  if (Common::Log::MAX_LOGLEVEL < Common::Log::LogLevel::LINFO && !use_internal_log)
-    return;
+  if constexpr (Common::Log::MAX_EFFECTIVE_LOGLEVEL < Common::Log::LogLevel::LINFO)
+  {
+    if (!use_internal_log)
+      return;
+  }
 
   std::string text = fmt::vformat(format, args);
   INFO_LOG_FMT(ACTIONREPLAY, "{}", text);


### PR DESCRIPTION
Preserve the configured logging level unless the user actually changes it, rather than capping `LDEBUG` to `LINFO` on release builds (which then persisted when going back to a debug build).

Rename `LogManager::m_level` to `m_effective_level` and distinguish between the config and effective level in various function/variable names.