### PR TITLE
Core/HW: Make BBA HLE detect the subnet mask.

### DIFF
--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -9,11 +9,16 @@
 #include <vector>
 
 #ifndef _WIN32
+#include <arpa/inet.h>
 #include <cstring>
+#include <ifaddrs.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #else
 #include <WinSock2.h>
+#include <iphlpapi.h>
+
+#include "Common/Buffer.h"
 #endif
 
 #include <fmt/format.h>
@@ -310,6 +315,65 @@ std::optional<BluetoothAddress> StringToBluetoothAddress(std::string_view str)
     return std::nullopt;
   std::ranges::reverse(*result);
   return std::bit_cast<BluetoothAddress>(*result);
+}
+
+std::optional<IPAddress> GetSubnetMask(const IPAddress& address)
+{
+  std::optional<IPAddress> result;
+
+  // Android apparently does not provide getifaddrs.
+  // TODO: Provide an Android implementation.
+#if !defined(ANDROID)
+  const auto target_in_addr = std::bit_cast<in_addr>(address);
+
+#if defined(_WIN32)
+  static constexpr ULONG flags = GAA_FLAG_INCLUDE_PREFIX;
+
+  // This is basically what Microsoft recommends.
+  Common::UniqueBuffer<IP_ADAPTER_ADDRESSES> buffer(15000 / sizeof(IP_ADAPTER_ADDRESSES));
+  auto buffer_size = ULONG(buffer.size() * sizeof(IP_ADAPTER_ADDRESSES));
+
+  if (GetAdaptersAddresses(AF_INET, flags, nullptr, buffer.data(), &buffer_size) != NO_ERROR)
+    return result;
+
+  for (auto* addr = buffer.data(); addr != nullptr; addr = addr->Next)
+  {
+    for (auto* ua = addr->FirstUnicastAddress; ua != nullptr; ua = ua->Next)
+    {
+      auto* const sa = reinterpret_cast<SOCKADDR_IN*>(ua->Address.lpSockaddr);
+      if (sa->sin_addr.s_addr != target_in_addr.s_addr)
+        continue;
+
+      result = std::bit_cast<IPAddress>(htonl(u32(-1) << (32 - ua->OnLinkPrefixLength)));
+      break;
+    }
+  }
+#else
+  ifaddrs* ifaddrs{};
+  if (getifaddrs(&ifaddrs) == -1)
+    return result;
+
+  for (auto* ifa = ifaddrs; ifa != nullptr; ifa = ifa->ifa_next)
+  {
+    if (ifa->ifa_addr->sa_family != AF_INET || ifa->ifa_addr == nullptr ||
+        ifa->ifa_netmask == nullptr)
+    {
+      continue;
+    }
+
+    auto* const ifaddr = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
+    if (ifaddr->sin_addr.s_addr != target_in_addr.s_addr)
+      continue;
+
+    auto* const mask = reinterpret_cast<sockaddr_in*>(ifa->ifa_netmask);
+    result = std::bit_cast<IPAddress>(mask->sin_addr.s_addr);
+    break;
+  }
+
+  freeifaddrs(ifaddrs);
+#endif
+#endif
+  return result;
 }
 
 EthernetHeader::EthernetHeader() = default;

--- a/Source/Core/Common/Network.h
+++ b/Source/Core/Common/Network.h
@@ -306,6 +306,7 @@ std::optional<MACAddress> StringToMacAddress(std::string_view mac_string);
 std::string BluetoothAddressToString(BluetoothAddress bdaddr);
 std::optional<BluetoothAddress> StringToBluetoothAddress(std::string_view str);
 
+std::optional<IPAddress> GetSubnetMask(const IPAddress& address);
 u16 ComputeNetworkChecksum(const void* data, u16 length, u32 initial_value = 0);
 u16 ComputeTCPNetworkChecksum(const IPAddress& from, const IPAddress& to, const void* data,
                               u16 length, u8 protocol);

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -5,6 +5,9 @@
 
 #include <bit>
 #include <optional>
+
+#include <fmt/ranges.h>
+
 #include "SFML/Network/IpAddress.hpp"
 #include "SFML/Network/Socket.hpp"
 
@@ -20,6 +23,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/Network.h"
 #include "Common/ScopeGuard.h"
+
 #include "Core/HW/EXI/EXI_DeviceEthernet.h"
 
 namespace
@@ -82,15 +86,38 @@ bool CEXIETHERNET::BuiltInBBAInterface::Activate()
   // Workaround to get the host IP (might not be accurate)
   // TODO: Fix the JNI crash and use GetSystemDefaultInterface()
   //  - https://pastebin.com/BFpmnxby (see https://dolp.in/pr10920)
-  const u32 ip = sf::IpAddress::resolve(m_local_ip)
-                     .value_or(sf::IpAddress::getLocalAddress().value_or(sf::IpAddress::Any))
-                     .toInteger();
+  const auto ipaddr = sf::IpAddress::resolve(m_local_ip)
+                          .value_or(sf::IpAddress::getLocalAddress().value_or(sf::IpAddress::Any));
+  const u32 ip = ipaddr.toInteger();
+
   m_current_ip = htonl(ip);
+
+  const auto mask_result = Common::GetSubnetMask(std::bit_cast<Common::IPAddress>(m_current_ip));
+  if (!mask_result.has_value())
+    ERROR_LOG_FMT(SP1, "Failed to determine network prefix length, assuming 24.");
+
+  // Fallback to a /24 network prefix.
+  static constexpr Common::IPAddress fallback_subnet_mask = {0xff, 0xff, 0xff, 0x00};
+  m_subnet_mask = mask_result.value_or(fallback_subnet_mask);
+
+  const u32 netmask = ntohl(std::bit_cast<u32>(m_subnet_mask));
+
   m_current_mac = Common::BitCastPtr<Common::MACAddress>(&m_eth_ref->mBbaMem[BBA_NAFR_PAR0]);
   m_arp_table[m_current_ip] = m_current_mac;
-  m_router_ip = (m_current_ip & 0xFFFFFF) | 0x01000000;
+
+  // The router IP is assumed to be the first IP on the network.
+  // TODO: Properly determine the router IP.
+  m_router_ip = htonl((ip & netmask) | 1u);
   m_router_mac = Common::GenerateMacAddress(Common::MACConsumer::BBA);
   m_arp_table[m_router_ip] = m_router_mac;
+
+  const auto network_prefix_length = std::countl_one(netmask);
+  INFO_LOG_FMT(SP1, "Network: {}/{} IP: {} Router: {}",
+               fmt::join(Common::AsU8Span(htonl(ip & netmask)), "."), network_prefix_length,
+               fmt::join(Common::AsU8Span(m_current_ip), "."),
+               fmt::join(Common::AsU8Span(m_router_ip), "."));
+  INFO_LOG_FMT(SP1, "MAC: {} Router MAC: {}", Common::MacAddressToString(m_current_mac),
+               Common::MacAddressToString(m_router_mac));
 
   m_network_ref.Clear();
 
@@ -217,9 +244,8 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleDHCP(const Common::UDPPacket& pack
   to.sin_family = IPPROTO_UDP;
   to.sin_port = udp_header.source_port;
 
-  const u8* router_ip_ptr = reinterpret_cast<const u8*>(&m_router_ip);
-  const std::vector<u8> ip_part(router_ip_ptr, router_ip_ptr + sizeof(m_router_ip));
-
+  const auto router_ip = Common::AsU8Span(m_router_ip);
+  const u32 broadcast_ip = m_current_ip | ~std::bit_cast<u32>(m_subnet_mask);
   constexpr auto timeout_24h = std::to_array<u8>({0, 1, 0x51, 0x80});
 
   Common::DHCPPacket reply;
@@ -231,16 +257,16 @@ void CEXIETHERNET::BuiltInBBAInterface::HandleDHCP(const Common::UDPPacket& pack
   (dhcp.options.size() == 0 || dhcp.options[0].size() < 2 || dhcp.options[0].at(2) == 1) ?
       reply.AddOption(53, {2}) :  // default, send a suggestion
       reply.AddOption(53, {5});
-  reply.AddOption(54, ip_part);                                    // dhcp server ip
-  reply.AddOption(51, timeout_24h);                                // lease time 24h
-  reply.AddOption(58, timeout_24h);                                // renewal time
-  reply.AddOption(59, timeout_24h);                                // rebind time
-  reply.AddOption(1, {255, 255, 255, 0});                          // submask
-  reply.AddOption(28, {ip_part[0], ip_part[1], ip_part[2], 255});  // broadcast ip
-  reply.AddOption(6, ip_part);                                     // dns server
-  reply.AddOption(15, {0x6c, 0x61, 0x6e});                         // domain name "lan"
-  reply.AddOption(3, ip_part);                                     // router ip
-  reply.AddOption(255, {});                                        // end
+  reply.AddOption(54, router_ip);                       // dhcp server ip
+  reply.AddOption(51, timeout_24h);                     // lease time 24h
+  reply.AddOption(58, timeout_24h);                     // renewal time
+  reply.AddOption(59, timeout_24h);                     // rebind time
+  reply.AddOption(1, m_subnet_mask);                    // submask
+  reply.AddOption(28, Common::AsU8Span(broadcast_ip));  // broadcast ip
+  reply.AddOption(6, router_ip);                        // dns server
+  reply.AddOption(15, {0x6c, 0x61, 0x6e});              // domain name "lan"
+  reply.AddOption(3, router_ip);                        // router ip
+  reply.AddOption(255, {});                             // end
 
   const Common::UDPPacket response(m_current_mac, m_router_mac, from, to, reply.Build());
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -450,6 +450,7 @@ private:
     std::mutex m_mtx;
     std::string m_local_ip;
     u32 m_current_ip = 0;
+    Common::IPAddress m_subnet_mask{};
     Common::MACAddress m_current_mac{};
     u32 m_router_ip = 0;
     Common::MACAddress m_router_mac{};


### PR DESCRIPTION
This makes BBA HLE detect the network prefix length instead of assuming 24.

Tested on my `/16` network.

Android apparently does not provide `getifaddrs` so it will fallback to the existing behavior of assuming `/24`.

A user was trying to use BBA HLE over a VPN (with a `/8` network). This PR makes that work.
<details>
<img width="2556" height="1354" alt="image" src="https://github.com/user-attachments/assets/afec5f27-9382-451d-b421-2757801539f9" />
</details>

It often gets stuck at "Looking for Nintendo GameCube systems...", but that seems to be normal for BBA HLE in general.