### PR TITLE
DSPLLE: Rework external interrupt handling

### DIFF
--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -133,14 +133,66 @@ void Analyzer::FindInstructionStarts(const SDSP& dsp, u16 start_addr, u16 end_ad
     }
 #endif
 
-    // If an instruction potentially raises exceptions, mark the following
-    // instruction as needing to check for exceptions
-    if (opcode->opcode == 0x00c0 || opcode->opcode == 0x00e0 || opcode->opcode == 0x1600 ||
-        opcode->opcode == 0x1800 || opcode->opcode == 0x1880 || opcode->opcode == 0x1900 ||
-        opcode->opcode == 0x1980 || opcode->opcode == 0x1a00 || opcode->opcode == 0x1a80 ||
-        opcode->opcode == 0x1b00 || opcode->opcode == 0x1b80 || opcode->opcode == 0x2000 ||
-        opcode->opcode == 0x2800 || opcode->opcode == 0x2c00 || opcode->extended)
+    // If an instruction potentially raises exceptions, mark the following instruction as needing to
+    // check for exceptions.
+    // Reads could trigger an accelerator address overflow exception
+    const bool is_read = opcode->opcode == 0x00c0 ||  // LR
+                         opcode->opcode == 0x1800 ||  // LRR
+                         opcode->opcode == 0x1880 ||  // LRRD
+                         opcode->opcode == 0x1900 ||  // LRRI
+                         opcode->opcode == 0x1980 ||  // LRRN
+                         opcode->opcode == 0x2000 ||  // LRS
+                         opcode->extended;
+    // Writes could also trigger an accelerator address overflow exception
+    // (but we don't implement this currently)
+    const bool is_write = opcode->opcode == 0x1600 ||  // SI
+                          opcode->opcode == 0x00e0 ||  // SR
+                          opcode->opcode == 0x1a00 ||  // SRR
+                          opcode->opcode == 0x1a80 ||  // SRRD
+                          opcode->opcode == 0x1b00 ||  // SRRI
+                          opcode->opcode == 0x1b80 ||  // SRRN
+                          opcode->opcode == 0x2800 ||  // SRS
+                          opcode->opcode == 0x2c00 ||  // SRSH
+                          opcode->extended;
+    // Stack overflows trigger an exception (not emulated currently).
+    // TODO: What happens if an exception saving to the stack overflows the stack?
+    // I assume also that LOOP and LOOPI don't directly use the stack since they only run one
+    // instruction.
+    const bool pushes_stack = (opcode->opcode & 0xfff0) == 0x02b0 ||  // CALLcc
+                              (opcode->opcode & 0xfff0) == 0x1710 ||  // CALLRcc
+                              opcode->opcode == 0x0060 ||             // BLOOP
+                              opcode->opcode == 0x1100;               // BLOOPI
+    // Writes to one of the stack registers also pushes to the stack.
+    // Instructions for is_read are not listed here.
+    // $st0 through $st3 are 0x0c through 0x0f, so we can ignore the bottom 2 bits.
+    const bool pushes_stack_directly = (inst & 0xfffc) == 0x008c ||  // LRI
+                                       (inst & 0xff80) == 0x1d80;    // MRR
+    // Stack underflows trigger an exception (not emulated currently).
+    // Note that the end of a loop doesn't need to be counted here (if the stack's empty, there is
+    // no end of the loop).
+    const bool pops_stack = (opcode->opcode & 0xfff0) == 0x02d0 ||  // RETcc
+                            (opcode->opcode & 0xfff0) == 0x02f0;    // RTIcc
+    // Reads from one of the stack registers also pops the stack.
+    // Instructions for is_write are not listed here.
+    // The loop instructions can also read an arbitrary register (both BLOOP and LOOP),
+    // including the stacks, though I don't know what happens on real hardware in that case.
+    const bool pops_stack_directly = (opcode->opcode & 0xfc1c) == 0x1c0c ||  // MRR
+                                     (opcode->opcode & 0xfffc) == 0x004c ||  // LOOP
+                                     (opcode->opcode & 0xfffc) == 0x006c;    // BLOOP
+    // If an instruction can change one of the interrupt enable bits in $sr, this can cause
+    // a pending interrupt to fire. This only applies for direct loads/stores of $sr, and
+    // some of the $sr bit instructions.
+    // Instructions for is_read are not listed here, nor is RTI.
+    // $sr is register 0x13.
+    // SBSET and SBCLR add 6 to their bit, so 3 through 6 correspond to bits 9 through 12 of $sr
+    // (IE, ?, EIE, EIE2).
+    const bool updates_sr_exception = (inst & 0xffe0) == 0x1e60 ||           // MRR
+                                      (inst >= 0x1203 && inst <= 0x1206) ||  // SBSET
+                                      (inst >= 0x1303 && inst <= 0x1306);    // SBCLR
+    if (is_read || is_write || pushes_stack || pushes_stack_directly || pops_stack ||
+        pops_stack_directly || updates_sr_exception)
     {
+      // TODO: Is this appropriate for CALL and RET?
       m_code_flags[static_cast<u16>(addr + opcode->size)] |= CODE_CHECK_EXC;
     }
 

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -208,27 +208,20 @@ void SDSP::SetException(ExceptionType exception)
   exceptions |= 1 << static_cast<std::underlying_type_t<ExceptionType>>(exception);
 }
 
-void SDSP::SetExternalInterrupt(bool val)
-{
-  external_interrupt_waiting.store(val, std::memory_order_release);
-}
-
-void SDSP::CheckExternalInterrupt()
-{
-  if (!IsSRFlagSet(SR_EXT_INT_ENABLE))
-    return;
-
-  // Signal the SPU about new mail
-  SetException(ExceptionType::ExternalInterrupt);
-
-  control_reg &= ~CR_EXTERNAL_INT;
-}
-
 bool SDSP::CheckExceptions()
 {
   // Early out to skip the loop in the common case.
-  if (exceptions == 0)
+  if (exceptions == 0 && (control_reg & CR_EXTERNAL_INT) == 0)
     return false;
+
+  if ((control_reg & CR_EXTERNAL_INT) != 0)
+  {
+    if (IsSRFlagSet(SR_EXT_INT_ENABLE) && IsSRFlagSet(SR_EXT_INT_ENABLE_2))
+    {
+      SetException(ExceptionType::ExternalInterrupt);
+      control_reg &= ~CR_EXTERNAL_INT;
+    }
+  }
 
   for (int i = 7; i > 0; i--)
   {
@@ -243,10 +236,7 @@ bool SDSP::CheckExceptions()
 
         pc = static_cast<u16>(i * 2);
         exceptions &= ~(1 << i);
-        if (i == 7)
-          r.sr &= ~SR_EXT_INT_ENABLE;
-        else
-          r.sr &= ~SR_INT_ENABLE;
+        r.sr &= ~SR_EXT_INT_ENABLE_2;
         return true;
       }
       else
@@ -395,7 +385,6 @@ void SDSP::DoState(PointerWrap& p)
   p.Do(control_reg_init_code_clear_time);
   p.Do(reg_stack_ptrs);
   p.Do(exceptions);
-  p.Do(external_interrupt_waiting);
 
   for (auto& stack : reg_stacks)
   {
@@ -525,16 +514,6 @@ State DSPCore::GetState() const
 void DSPCore::SetException(ExceptionType exception)
 {
   m_dsp.SetException(exception);
-}
-
-void DSPCore::SetExternalInterrupt(bool val)
-{
-  m_dsp.SetExternalInterrupt(val);
-}
-
-void DSPCore::CheckExternalInterrupt()
-{
-  m_dsp.CheckExternalInterrupt();
 }
 
 bool DSPCore::CheckExceptions()

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -382,7 +382,8 @@ struct SDSP
   // and sets a flag in the pending exception register.
   void SetException(ExceptionType exception);
 
-  // Checks if any exceptions occurred an updates the DSP state as appropriate.
+  // Checks if any exceptions occurred and updates the DSP state as appropriate.
+  // Returns true if PC changed.
   bool CheckExceptions();
 
   // Notify that an external interrupt is pending (used by thread mode)
@@ -529,7 +530,8 @@ public:
   // Coming from the CPU
   void CheckExternalInterrupt();
 
-  // Checks if any exceptions occurred an updates the DSP state as appropriate.
+  // Checks if any exceptions occurred and updates the DSP state as appropriate.
+  // Returns true if PC changed.
   bool CheckExceptions();
 
   // Reads the current value from a particular register.

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -203,21 +203,35 @@ enum : u16
   SR_OVERFLOW = 0x0002,
   SR_ARITH_ZERO = 0x0004,
   SR_SIGN = 0x0008,
-  SR_OVER_S32 = 0x0010,  // Set when there was mod/tst/cmp on accu and result is over s32
-  SR_TOP2BITS = 0x0020,  // If the upper (ac?.m/ax?.h) 2 bits are equal
+  // Set when there was mod/tst/cmp on accu and result is over s32, i.e. the value can't fit in a
+  // s32 (the value doesn't match the sign extension from 32 bits to 40 bits, and saturation would
+  // occur on a store if enabled).
+  SR_OVER_S32 = 0x0010,
+  // If the upper (ac?.m/ax?.h) 2 bits are equal
+  SR_TOP2BITS = 0x0020,
+  // Used by ANDF/ANDCF (and also SBSET #0)
   SR_LOGIC_ZERO = 0x0040,
-  SR_OVERFLOW_STICKY =
-      0x0080,  // Set at the same time as 0x2 (under same conditions) - but not cleared the same
-  SR_100 = 0x0100,         // Unknown, always reads back as 0
-  SR_INT_ENABLE = 0x0200,  // Not 100% sure but duddie says so. This should replace the hack, if so.
-  SR_400 = 0x0400,         // Unknown
-  SR_EXT_INT_ENABLE = 0x0800,  // Appears in zelda - seems to disable external interrupts
-  SR_1000 = 0x1000,            // Unknown
-  SR_MUL_MODIFY = 0x2000,      // 1 = normal. 0 = x2   (M0, M2) (Free mul by 2)
-  SR_40_MODE_BIT = 0x4000,     // 0 = "16", 1 = "40"  (SET16, SET40)  Controls sign extension when
-                               // loading mid accums and data saturation for stores from mid accums.
-  SR_MUL_UNSIGNED = 0x8000,    // 0 = normal. 1 = unsigned  (CLR15, SET15) If set, treats ax?.l as
-                               // unsigned (MULX family only).
+  // Set at the same time as 0x2 (under same conditions) - but not cleared the same. SBSET #1.
+  SR_OVERFLOW_STICKY = 0x0080,
+  // Unknown, always reads back as 0
+  SR_100 = 0x0100,
+  // Must be set to receive exceptions other than the external interrupt. Disabled exceptions are
+  // lost (not queued). SBSET #3.
+  SR_INT_ENABLE = 0x0200,
+  // Unknown
+  SR_400 = 0x0400,
+  // Appears in zelda uCode - must be set to enable external interrupts. SBSET #5.
+  SR_EXT_INT_ENABLE = 0x0800,
+  // Also enables external interrupts, and automatically cleared after any exception (unlike the
+  // other one). SBSET #6.
+  SR_EXT_INT_ENABLE_2 = 0x1000,
+  // 1 = normal. 0 = x2 (M0, M2) (Free mul by 2)
+  SR_MUL_MODIFY = 0x2000,
+  // 0 = "16", 1 = "40" (SET16, SET40). Controls sign extension when loading mid accums and data
+  // saturation for stores from mid accums.
+  SR_40_MODE_BIT = 0x4000,
+  // 0 = normal. 1 = unsigned (CLR15, SET15). If set, treats ax?.l as unsigned (MULX family only).
+  SR_MUL_UNSIGNED = 0x8000,
 
   // This should be the bits affected by CMP. Does not include logic zero.
   SR_CMP_MASK = 0x3f
@@ -386,12 +400,6 @@ struct SDSP
   // Returns true if PC changed.
   bool CheckExceptions();
 
-  // Notify that an external interrupt is pending (used by thread mode)
-  void SetExternalInterrupt(bool val);
-
-  // Coming from the CPU
-  void CheckExternalInterrupt();
-
   // Stores a value into the specified stack
   void StoreStack(StackRegister stack_reg, u16 val);
 
@@ -429,7 +437,6 @@ struct SDSP
 
   u8 reg_stack_ptrs[4]{};
   u8 exceptions = 0;  // pending exceptions
-  std::atomic<bool> external_interrupt_waiting = false;
   bool reset_dspjit_codespace = false;
 
   // DSP hardware stacks. They're mapped to a bunch of registers, such that writes
@@ -523,12 +530,6 @@ public:
   // Indicates that a particular exception has occurred
   // and sets a flag in the pending exception register.
   void SetException(ExceptionType exception);
-
-  // Notify that an external interrupt is pending (used by thread mode)
-  void SetExternalInterrupt(bool val);
-
-  // Coming from the CPU
-  void CheckExternalInterrupt();
 
   // Checks if any exceptions occurred and updates the DSP state as appropriate.
   // Returns true if PC changed.

--- a/Source/Core/Core/DSP/Interpreter/DSPIntBranch.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntBranch.cpp
@@ -117,7 +117,7 @@ void Interpreter::rti(const UDSPInstruction opc)
     return;
 
   auto& state = m_dsp_core.DSPState();
-  state.r.sr = state.PopStack(StackRegister::Data);
+  OpWriteRegister(DSP_REG_SR, state.PopStack(StackRegister::Data));
   state.pc = state.PopStack(StackRegister::Call);
 }
 

--- a/Source/Core/Core/DSP/Interpreter/DSPIntMisc.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntMisc.cpp
@@ -125,7 +125,7 @@ void Interpreter::sbclr(const UDSPInstruction opc)
   auto& state = m_dsp_core.DSPState();
   const u8 bit = (opc & 0x7) + 6;
 
-  state.r.sr &= ~(1U << bit);
+  OpWriteRegister(DSP_REG_SR, state.r.sr & ~(1U << bit));
 }
 
 // SBSET #I
@@ -137,7 +137,7 @@ void Interpreter::sbset(const UDSPInstruction opc)
   auto& state = m_dsp_core.DSPState();
   const u8 bit = (opc & 0x7) + 6;
 
-  state.r.sr |= (1U << bit);
+  OpWriteRegister(DSP_REG_SR, state.r.sr | (1U << bit));
 }
 
 // This is a bunch of flag setters, flipping bits in SR.

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -90,11 +90,6 @@ int Interpreter::RunCyclesThread(int cycles)
     if ((state.control_reg & CR_HALT) != 0)
       return 0;
 
-    if (state.external_interrupt_waiting.exchange(false, std::memory_order_acquire))
-    {
-      m_dsp_core.CheckExternalInterrupt();
-    }
-
     Step();
     cycles--;
     if (cycles <= 0)

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -224,7 +224,12 @@ void Interpreter::WriteControlRegister(u16 val)
                  state.control_reg, val, state.pc);
   }
 
-  // The CR_EXTERNAL_INT bit is handled by DSPLLE::DSP_WriteControlRegister
+  if ((state.control_reg & CR_EXTERNAL_INT) != 0)
+  {
+    // The external interrupt can't be cleared by the CPU
+    // (and the CR_EXTERNAL_INT bit remains set until the external interrupt is sent to the DSP)
+    val |= CR_EXTERNAL_INT;
+  }
 
   // reset
   if ((val & CR_RESET) != 0)

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -105,7 +105,7 @@ static u32 CheckExceptionsThunk(DSPCore& dsp)
 }
 
 // Must go out of block if exception is detected
-void DSPEmitter::checkExceptions(u32 retval)
+void DSPEmitter::checkExceptions(u16 retval)
 {
   // Check for interrupts and exceptions
   TEST(8, M_SDSP_exceptions(), Imm8(0xff));
@@ -246,6 +246,8 @@ void DSPEmitter::Compile(u16 start_addr)
   auto& analyzer = m_dsp_core.DSPState().GetAnalyzer();
   while (m_compile_pc < start_addr + MAX_BLOCK_SIZE)
   {
+    m_block_size[start_addr]++;
+
     if (analyzer.IsCheckExceptions(m_compile_pc))
       checkExceptions(m_block_size[start_addr]);
 
@@ -254,7 +256,6 @@ void DSPEmitter::Compile(u16 start_addr)
 
     EmitInstruction(inst);
 
-    m_block_size[start_addr]++;
     m_compile_pc += opcode->size;
 
     // If the block was trying to link into itself, remove the link

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -50,12 +50,6 @@ DSPEmitter::~DSPEmitter()
 
 u16 DSPEmitter::RunCycles(u16 cycles)
 {
-  if (m_dsp_core.DSPState().external_interrupt_waiting.exchange(false, std::memory_order_acquire))
-  {
-    m_dsp_core.CheckExternalInterrupt();
-    m_dsp_core.CheckExceptions();
-  }
-
   m_cycles_left = cycles;
   auto exec_addr = (DSPCompiledCode)m_enter_dispatcher;
   exec_addr();
@@ -107,9 +101,14 @@ static u32 CheckExceptionsThunk(DSPCore& dsp)
 // Must go out of block if exception is detected
 void DSPEmitter::checkExceptions(u16 retval)
 {
-  // Check for interrupts and exceptions
+  // Check for interrupts or exceptions
   TEST(8, M_SDSP_exceptions(), Imm8(0xff));
-  FixupBranch skipCheck = J_CC(CC_Z, Jump::Near);
+  FixupBranch has_exception = J_CC(CC_NZ, Jump::Near);
+
+  TEST(16, M_SDSP_control_reg(), Imm16(CR_EXTERNAL_INT));
+  FixupBranch has_neither_exception_nor_external_interrupt = J_CC(CC_Z, Jump::Near);
+
+  SetJumpTarget(has_exception);
 
   MOV(16, M_SDSP_pc(), Imm16(m_compile_pc));
 
@@ -121,10 +120,11 @@ void DSPEmitter::checkExceptions(u16 retval)
   MOV(32, R(EAX), Imm32(retval));
   JMP(m_return_dispatcher);
   SetJumpTarget(skip_return);
+
   m_gpr.LoadRegs(false);
   m_gpr.FlushRegs(c, false);
 
-  SetJumpTarget(skipCheck);
+  SetJumpTarget(has_neither_exception_nor_external_interrupt);
 }
 
 bool DSPEmitter::FlagsNeeded() const
@@ -439,13 +439,6 @@ void DSPEmitter::CompileDispatcher()
 
   const u8* dispatcherLoop = GetCodePtr();
 
-  FixupBranch exceptionExit;
-  if (Host::OnThread())
-  {
-    CMP(8, M_SDSP_external_interrupt_waiting(), Imm8(0));
-    exceptionExit = J_CC(CC_NE);
-  }
-
   // Check for DSP halt
   TEST(8, M_SDSP_control_reg(), Imm8(CR_HALT));
   FixupBranch _halt = J_CC(CC_NE);
@@ -465,10 +458,6 @@ void DSPEmitter::CompileDispatcher()
 
   // DSP gave up the remaining cycles.
   SetJumpTarget(_halt);
-  if (Host::OnThread())
-  {
-    SetJumpTarget(exceptionExit);
-  }
   // MOV(32, M(&cyclesLeft), Imm32(0));
   ABI_PopRegistersAndAdjustStack(registers_used, 8);
   RET();
@@ -491,14 +480,6 @@ Gen::OpArg DSPEmitter::M_SDSP_exceptions()
 Gen::OpArg DSPEmitter::M_SDSP_control_reg()
 {
   return MDisp(R15, static_cast<int>(offsetof(SDSP, control_reg)));
-}
-
-Gen::OpArg DSPEmitter::M_SDSP_external_interrupt_waiting()
-{
-  static_assert(decltype(SDSP::external_interrupt_waiting)::is_always_lock_free &&
-                sizeof(SDSP::external_interrupt_waiting) == sizeof(u8));
-
-  return MDisp(R15, static_cast<int>(offsetof(SDSP, external_interrupt_waiting)));
 }
 
 Gen::OpArg DSPEmitter::M_SDSP_r_st(size_t index)

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -121,8 +121,8 @@ void DSPEmitter::checkExceptions(u16 retval)
   JMP(m_return_dispatcher);
   SetJumpTarget(skip_return);
 
-  m_gpr.LoadRegs(false);
-  m_gpr.FlushRegs(c, false);
+  m_gpr.LoadRegs(true);
+  m_gpr.FlushRegs(c, true);
 
   SetJumpTarget(has_neither_exception_nor_external_interrupt);
 }

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.h
@@ -293,7 +293,6 @@ private:
   Gen::OpArg M_SDSP_pc();
   Gen::OpArg M_SDSP_exceptions();
   Gen::OpArg M_SDSP_control_reg();
-  Gen::OpArg M_SDSP_external_interrupt_waiting();
   Gen::OpArg M_SDSP_r_st(size_t index);
   Gen::OpArg M_SDSP_reg_stack_ptrs(size_t index);
 

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.h
@@ -263,7 +263,7 @@ private:
   // Register helpers
   void setCompileSR(u16 bit);
   void clrCompileSR(u16 bit);
-  void checkExceptions(u32 retval);
+  void checkExceptions(u16 retval);
 
   // Memory helper functions
   void increment_addr_reg(int reg);

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -188,13 +188,6 @@ u16 DSPLLE::DSP_WriteControlRegister(u16 value)
       // External interrupt pending: this is the zelda ucode.
       // Disable the DSP thread because there is no performance gain.
       m_request_disable_thread = true;
-
-      m_dsp_core.SetExternalInterrupt(true);
-    }
-    else
-    {
-      m_dsp_core.CheckExternalInterrupt();
-      m_dsp_core.CheckExceptions();
     }
   }
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -95,7 +95,7 @@ struct CompressAndDumpStateArgs
 static Common::WorkQueueThreadSP<CompressAndDumpStateArgs> s_compress_and_dump_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 190;  // Last changed in PR 14448
+constexpr u32 STATE_VERSION = 191;  // Last changed in PR 13944
 
 // Increase this if the StateExtendedHeader definition changes
 constexpr u32 EXTENDED_HEADER_VERSION = 1;  // Last changed in PR 12217

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -97,7 +97,7 @@ struct CompressAndDumpStateArgs
 static Common::WorkQueueThreadSP<CompressAndDumpStateArgs> s_compress_and_dump_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 192;  // Last changed in PR 14646
+constexpr u32 STATE_VERSION = 193;  // Last changed in PR 13944
 
 // Increase this if the StateExtendedHeader definition changes
 constexpr u32 EXTENDED_HEADER_VERSION = 1;  // Last changed in PR 12217

--- a/Source/DSPSpy/ConsoleHelper.h
+++ b/Source/DSPSpy/ConsoleHelper.h
@@ -54,15 +54,9 @@ inline void CON_Clear()
   printf("\x1b[2J");
 }
 
-// libogc's clear escape codes are crappy
 inline void CON_BlankRow(const int y)
 {
-  int columns = 0, rows = 0;
-  CON_GetMetrics(&columns, &rows);
-  char blank[columns];
-  std::fill_n(blank, columns, ' ');
-  blank[columns - 1] = '\0';
-  CON_Printf(0, y, "%s", blank);
+  CON_Printf(0, y, "\x1b[2K");
 }
 
 #define CON_PrintRow(x, y, ...)                                                                    \

--- a/Source/DSPSpy/Makefile
+++ b/Source/DSPSpy/Makefile
@@ -31,7 +31,7 @@ INCLUDES	:=	include ../Core/Common .
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS	= -save-temps -O2 -Wall --no-strict-aliasing $(MACHDEP) $(INCLUDE)
+CFLAGS	= -g -save-temps -O2 -Wall --no-strict-aliasing $(MACHDEP) $(INCLUDE)
 CXXFLAGS	=	-std=c++17 -Wno-register $(CFLAGS)
 
 LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map

--- a/Source/DSPSpy/dsp_interface.h
+++ b/Source/DSPSpy/dsp_interface.h
@@ -26,6 +26,8 @@ public:
   virtual void Reset() = 0;
   virtual u32 CheckMailTo() = 0;
   virtual void SendMailTo(u32 mail) = 0;
+  virtual void SetInterrupt(bool value) = 0;
+  virtual bool CheckInterrupt() = 0;
 
   // Yeah, yeah, having a method here makes this not a pure interface - but
   // the implementation does nothing but calling the virtual methods above.

--- a/Source/DSPSpy/main_spy.cpp
+++ b/Source/DSPSpy/main_spy.cpp
@@ -25,6 +25,9 @@
 #include <ogc/consol.h>
 #include <unistd.h>
 
+// From libogc's timesupp.c (not in the header :|)
+extern "C" u32 gettick(void);
+
 #ifdef _MSC_VER
 // Just for easy looking :)
 #define HW_RVL  // HW_DOL
@@ -150,7 +153,7 @@ void print_reg_block(int x, int y, int sel, const u16* regs, const u16* compare_
     for (int i = 0; i < 8; i++)
     {
       const int reg = j * 8 + i;
-      u8 color1 = regs[reg] == compare_regs[reg] ? CON_BRIGHT_WHITE : CON_BRIGHT_RED;
+      u8 color1 = regs[reg] == compare_regs[reg] ? CON_BRIGHT_WHITE : CON_BRIGHT_CYAN;
       CON_SetColor(sel == reg ? CON_BRIGHT_YELLOW : CON_GREEN);
       CON_Printf(x + j * 9, i + y, "%s ", reg_names[reg]);
       for (int k = 0; k < 4; k++)
@@ -418,6 +421,43 @@ void handle_dsp_mail(void)
 
       // Now we can do something useful with the buffer :)
       DumpDSP_ROMs(dspbufP, &dspbufP[0x1000]);
+    }
+
+    // Request for an interrupt
+    else if (mail == 0x88885371)
+    {
+      if (real_dsp.CheckInterrupt())
+      {
+        CON_PrintRow(4, 25, "Already has interrupt?");
+      }
+      else
+      {
+        const u32 now = gettick();
+        real_dsp.SetInterrupt(true);
+        u32 end = gettick();
+        u32 tries = 0;
+        while (real_dsp.CheckInterrupt() && end - now < 1000000)
+        {
+          end = gettick();
+          tries++;
+        }
+        if (end - now < 1000000)
+        {
+          CON_PrintRow(4, 25, "Interrupt after %d ticks / %d tries", end - now, tries);
+        }
+        else
+        {
+          CON_PrintRow(4, 25, "No interrupt after %d ticks / %d tries", end - now, tries);
+        }
+      }
+    }
+    else if (mail == 0x88885370)
+    {
+      real_dsp.SetInterrupt(false);
+    }
+    else if (mail == 0x88885372)
+    {
+      real_dsp.SetInterrupt(true);
     }
 
     // SDK status mails

--- a/Source/DSPSpy/main_spy.cpp
+++ b/Source/DSPSpy/main_spy.cpp
@@ -25,8 +25,10 @@
 #include <ogc/consol.h>
 #include <unistd.h>
 
-// From libogc's timesupp.c (not in the header :|)
-extern "C" u32 gettick(void);
+static u32 gettick(void)
+{
+  return PPCMftb();
+}
 
 #ifdef _MSC_VER
 // Just for easy looking :)
@@ -67,10 +69,13 @@ u16* dspbufC;
 u32* dspbufU;
 
 u16 dspreg_in[32] = {
-    0x0410, 0x0510, 0x0610, 0x0710, 0x0810, 0x0910, 0x0a10, 0x0b10, 0xFFFF, 0xFFFF, 0xFFFF,
-    0xFFFF, 0x0855, 0x0966, 0x0a77, 0x0b88, 0x0014, 0xfff5, 0x00ff, 0x2200, 0x0000, 0x0000,
-    0x0000, 0x0000, 0x0003, 0x0004, 0x8000, 0x000C, 0x0007, 0x0008, 0x0009, 0x000a,
-};  ///            ax_h_1   ax_h_1
+    // clang-format off
+    0x0410, 0x0510, 0x0610, 0x0710, 0x0810, 0x0910, 0x0a10, 0x0b10,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x0855, 0x0966, 0x0a77, 0x0b88,
+    0x0014, 0xfff5, 0x00ff, 0x2200, 0x0000, 0x0000, 0x0000, 0x0000,
+    0x0003, 0x0004, 0x8000, 0x000C, 0x0007, 0x0008, 0x0009, 0x000a,
+    // clang-format on
+};
 
 /* ttt ?
 
@@ -141,9 +146,12 @@ int curUcode = 0, runningUcode = 1;
 int dsp_steps = 0;
 
 constexpr std::array reg_names = {
-    "ar0", "ar1", "ar2", "ar3", "ix0", "ix1", "ix2", "ix3", "wr0", "wr1", "wr2",
-    "wr3", "st0", "st1", "st2", "st3", "c0h", "c1h", "cr ", "sr ", "pl ", "pm1",
-    "ph ", "pm2", "x0l", "x1l", "x0h", "x1h", "c0l", "c1l", "c0m", "c1m",
+    // clang-format off
+    "ar0", "ar1", "ar2", "ar3", "ix0", "ix1", "ix2", "ix3",
+    "wr0", "wr1", "wr2", "wr3", "st0", "st1", "st2", "st3",
+    "c0h", "c1h", "cr ", "sr ", "pl ", "pm1", "ph ", "pm2",
+    "x0l", "x1l", "x0h", "x1h", "c0l", "c1l", "c0m", "c1m",
+    // clang-format on
 };
 
 void print_reg_block(int x, int y, int sel, const u16* regs, const u16* compare_regs)
@@ -153,7 +161,7 @@ void print_reg_block(int x, int y, int sel, const u16* regs, const u16* compare_
     for (int i = 0; i < 8; i++)
     {
       const int reg = j * 8 + i;
-      u8 color1 = regs[reg] == compare_regs[reg] ? CON_BRIGHT_WHITE : CON_BRIGHT_CYAN;
+      u8 color1 = regs[reg] == compare_regs[reg] ? CON_BRIGHT_WHITE : CON_BRIGHT_RED;
       CON_SetColor(sel == reg ? CON_BRIGHT_YELLOW : CON_GREEN);
       CON_Printf(x + j * 9, i + y, "%s ", reg_names[reg]);
       for (int k = 0; k < 4; k++)
@@ -193,7 +201,7 @@ void print_regs(int _step, int _dsp_steps)
   const u16* regs = _step == 0 ? dspreg_in : dspreg_out[_step - 1];
   const u16* regs2 = dspreg_out[_step];
 
-  print_reg_block(0, 2, _step == 0 ? cursor_reg : -1, regs, regs2);
+  print_reg_block(1, 2, _step == 0 ? cursor_reg : -1, regs, regs2);
   print_reg_block(38, 2, -1, regs2, regs);
 
   CON_SetColor(CON_WHITE);

--- a/Source/DSPSpy/real_dsp.cpp
+++ b/Source/DSPSpy/real_dsp.cpp
@@ -51,3 +51,17 @@ void RealDSP::SendMailTo(u32 mail)
 {
   DSP_SendMailTo(mail);
 }
+
+void RealDSP::SetInterrupt(bool value)
+{
+  u32 level;
+  _CPU_ISR_Disable(level);
+  _dspReg[5] = (_dspReg[5] & ~(DSPCR_AIINT | DSPCR_ARINT | DSPCR_DSPINT | DSPCR_PIINT)) |
+               (value ? DSPCR_PIINT : 0);
+  _CPU_ISR_Restore(level);
+}
+
+bool RealDSP::CheckInterrupt()
+{
+  return (_dspReg[5] & DSPCR_PIINT) != 0;
+}

--- a/Source/DSPSpy/real_dsp.h
+++ b/Source/DSPSpy/real_dsp.h
@@ -12,4 +12,6 @@ public:
   void Reset() override;
   u32 CheckMailTo() override;
   void SendMailTo(u32 mail) override;
+  void SetInterrupt(bool value) override;
+  bool CheckInterrupt() override;
 };

--- a/Source/DSPSpy/tests/external_interrupt.ds
+++ b/Source/DSPSpy/tests/external_interrupt.ds
@@ -1,0 +1,50 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBSET #5
+	SBSET #6
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_external_irq:
+	INC $ACC1
+	TST $ACC0
+	JZ wait_external_irq
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	INC $ACC0
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected output ($AX0.H (send_back num), $AC0.L (interrupt count), and $SR):
+; 1, 0, 3824 (start)
+; 3, 1, 2820 (in interrupt handler)
+; 2, 1, 3820 (back out of interrupt handler)
+; DSPSpy shows "interrupt after 20 ticks / 0 tries" (exact number of ticks varies)
+; ACC1 is 7bb40 or so (also varies, and can vary between steps 2 and 3 if the interrupt happens on the JZ)

--- a/Source/DSPSpy/tests/external_interrupt_and_regular_at_same_time_d0.ds
+++ b/Source/DSPSpy/tests/external_interrupt_and_regular_at_same_time_d0.ds
@@ -1,0 +1,99 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		accov_irq
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	; Use the accelerator to generate an IRQ by setting the start and end address to 0
+	; This will result in an interrupt on every read
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+	SI @0xffd1, #0 ; SampleFormat
+	SI @ACSAH, #0
+	SI @ACCAH, #0
+	SI @ACSAL, #0
+	SI @ACCAL, #0
+	SI @ACEAH, #0
+	SI @ACEAL, #0
+
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBSET #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	; Trigger an interrupt at the same time as external interrupts become enabled
+	LRS $AX0.L, @ARAM
+	LRIS $AX1.H, #2
+	LRIS $AX1.H, #3
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+accov_irq:
+	INC $ACC0
+	INCM $AC0.M
+
+	; Restore registers, otherwise no new interrupt will be generated
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	DECM $AC0.M
+	RTI
+
+external_irq:
+	INC $ACC0
+	INCM $AC0.M
+
+	LRIS $AX0.H, #4
+	CALL send_back
+
+	DECM $AC0.M
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, $AC0.L (interrupt count), $AC0.M (interrupt depth), and $SR):
+; 1, 1, 0, 0, 2224 (start)
+; 3, 1, 1, 1, 2a20 (overflow interrupt - comes first)
+; 4, 2, 2, 1, 2a20 (external interrupt - 1 ins executed after rti)
+; 2, 6, 2, 0, 3a25 (end)

--- a/Source/DSPSpy/tests/external_interrupt_and_regular_at_same_time_d1.ds
+++ b/Source/DSPSpy/tests/external_interrupt_and_regular_at_same_time_d1.ds
@@ -1,0 +1,99 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		accov_irq
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	; Use the accelerator to generate an IRQ by setting the start and end address to 0
+	; This will result in an interrupt on every read
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+	SI @0xffd1, #0 ; SampleFormat
+	SI @ACSAH, #0
+	SI @ACCAH, #0
+	SI @ACSAL, #0
+	SI @ACCAL, #0
+	SI @ACEAH, #0
+	SI @ACEAL, #0
+
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBSET #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	; Trigger an interrupt 1 instruction after external interrupts become enabled
+	LRIS $AX1.H, #2
+	LRS $AX0.L, @ARAM
+	LRIS $AX1.H, #3
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+accov_irq:
+	INC $ACC0
+	INCM $AC0.M
+
+	; Restore registers, otherwise no new interrupt will be generated
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	DECM $AC0.M
+	RTI
+
+external_irq:
+	INC $ACC0
+	INCM $AC0.M
+
+	LRIS $AX0.H, #4
+	CALL send_back
+
+	DECM $AC0.M
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, $AC0.L (interrupt count), $AC0.M (interrupt depth), and $SR):
+; 1, 1, 0, 0, 2224 (start)
+; 3, 2, 1, 1, 2a20 (overflow interrupt - still comes first)
+; 4, 3, 2, 1, 2a20 (external interrupt - 1 ins executed after rti)
+; 2, 6, 2, 0, 3a25 (end)

--- a/Source/DSPSpy/tests/external_interrupt_and_regular_at_same_time_d1_l.ds
+++ b/Source/DSPSpy/tests/external_interrupt_and_regular_at_same_time_d1_l.ds
@@ -1,0 +1,100 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		accov_irq
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	; Use the accelerator to generate an IRQ by setting the start and end address to 0
+	; This will result in an interrupt on every read
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+	SI @0xffd1, #0 ; SampleFormat
+	SI @ACSAH, #0
+	SI @ACCAH, #0
+	SI @ACSAL, #0
+	SI @ACCAL, #0
+	SI @ACEAH, #0
+	SI @ACEAL, #0
+
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBSET #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	; Trigger an interrupt 1 instruction after external interrupts become enabled
+	; However, LRI is used instead of LRIS, and LRI takes 2 words
+	LRI $AX1.H, #2
+	LRS $AX0.L, @ARAM
+	LRIS $AX1.H, #3
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+accov_irq:
+	INC $ACC0
+	INCM $AC0.M
+
+	; Restore registers, otherwise no new interrupt will be generated
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	DECM $AC0.M
+	RTI
+
+external_irq:
+	INC $ACC0
+	INCM $AC0.M
+
+	LRIS $AX0.H, #4
+	CALL send_back
+
+	DECM $AC0.M
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, $AC0.L (interrupt count), $AC0.M (interrupt depth), and $SR):
+; 1, 1, 0, 0, 2224 (start)
+; 4, 2, 1, 1, 2a20 (external interrupt - comes first this time, so LRI takes twice as long as LRS)
+; 3, 2, 2, 1, 2a20 (overflow interrupt - comes after, when the LRS instruction occurs)
+; 2, 6, 2, 0, 3a25 (end)

--- a/Source/DSPSpy/tests/external_interrupt_and_regular_at_same_time_d2.ds
+++ b/Source/DSPSpy/tests/external_interrupt_and_regular_at_same_time_d2.ds
@@ -1,0 +1,99 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		accov_irq
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	; Use the accelerator to generate an IRQ by setting the start and end address to 0
+	; This will result in an interrupt on every read
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+	SI @0xffd1, #0 ; SampleFormat
+	SI @ACSAH, #0
+	SI @ACCAH, #0
+	SI @ACSAL, #0
+	SI @ACCAL, #0
+	SI @ACEAH, #0
+	SI @ACEAL, #0
+
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBSET #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	; Trigger an interrupt 2 instructions after external interrupts become enabled
+	LRIS $AX1.H, #2
+	LRIS $AX1.H, #3
+	LRS $AX0.L, @ARAM
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+accov_irq:
+	INC $ACC0
+	INCM $AC0.M
+
+	; Restore registers, otherwise no new interrupt will be generated
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	DECM $AC0.M
+	RTI
+
+external_irq:
+	INC $ACC0
+	INCM $AC0.M
+
+	LRIS $AX0.H, #4
+	CALL send_back
+
+	DECM $AC0.M
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, $AC0.L (interrupt count), $AC0.M (interrupt depth), and $SR):
+; 1, 1, 0, 0, 2224 (start)
+; 4, 3, 1, 1, 2a20 (external interrupt - comes first this time)
+; 3, 3, 2, 1, 2a20 (overflow interrupt - comes after, when the LRS instruction occurs)
+; 2, 6, 2, 0, 3a25 (end)

--- a/Source/DSPSpy/tests/external_interrupt_delay_long.ds
+++ b/Source/DSPSpy/tests/external_interrupt_delay_long.ds
@@ -1,0 +1,65 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	; Wait a while (0x10000 increments)
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	LRI $AX1.H, #2
+	LRI $AX1.H, #3
+	LRI $AX1.H, #4
+	LRI $AX1.H, #5
+	LRI $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, and $SR):
+; 1, 1, 2024 (start)
+; 3, 2, 2825 (in interrupt handler - note that the interrupt happens after one LRI instruction)
+; 2, 6, 3825 (the remaining LRI instructions execute)
+; DSPSpy shows "interrupt after 131054 ticks / 37414 tries" (exact numbers vary but are close)

--- a/Source/DSPSpy/tests/external_interrupt_delay_long_short.ds
+++ b/Source/DSPSpy/tests/external_interrupt_delay_long_short.ds
@@ -1,0 +1,65 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	; Wait a while (0x10000 increments)
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	LRI $AX1.H, #2
+	LRIS $AX1.H, #3
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, and $SR):
+; 1, 1, 2024 (start)
+; 3, 2, 2825 (in interrupt handler - note that the interrupt happens after only one LRI instruction)
+; 2, 6, 3825 (the remaining LRIS instructions execute)
+; DSPSpy shows "interrupt after 131054 ticks / 37414 tries" (exact numbers vary but are close)

--- a/Source/DSPSpy/tests/external_interrupt_delay_short.ds
+++ b/Source/DSPSpy/tests/external_interrupt_delay_short.ds
@@ -1,0 +1,65 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	; Wait a while (0x10000 increments)
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	LRIS $AX1.H, #2
+	LRIS $AX1.H, #3
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, and $SR):
+; 1, 1, 2024 (start)
+; 3, 3, 2825 (in interrupt handler - note that the interrupt happens after two LRIS instructions)
+; 2, 6, 3825 (the remaining LRIS instructions execute)
+; DSPSpy shows "interrupt after 131054 ticks / 37414 tries" (exact numbers vary but are close)

--- a/Source/DSPSpy/tests/external_interrupt_delay_short_long.ds
+++ b/Source/DSPSpy/tests/external_interrupt_delay_short_long.ds
@@ -1,0 +1,65 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	; Wait a while (0x10000 increments)
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	LRIS $AX1.H, #2
+	LRI $AX1.H, #3
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, and $SR):
+; 1, 1, 2024 (start)
+; 3, 3, 2825 (in interrupt handler - note that the interrupt happens after both the LRIS and LRI instructions)
+; 2, 6, 3825 (the remaining LRIS instructions execute)
+; DSPSpy shows "interrupt after 131054 ticks / 37414 tries" (exact numbers vary but are close)

--- a/Source/DSPSpy/tests/external_interrupt_nested_rti.ds
+++ b/Source/DSPSpy/tests/external_interrupt_nested_rti.ds
@@ -1,0 +1,87 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRI $AR0, #0
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #5
+	SBSET #6
+	LRI $AR0, #2
+	LRI $AR0, #3
+	LRI $AR0, #4
+	LRI $AR0, #5
+	LRI $AR0, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	INC $ACC0
+	INCM $AC0.M
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	; Only trigger a nested interrupt the first time through.
+	CMPIS $AC0.M, #2
+	JGE exit_irq
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read_irq:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read_irq
+
+	CLR $ACC1
+second_loop_irq:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop_irq
+
+exit_irq:
+	DEC $ACC0
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AC0.L (interrupt depth), $AC0.M (interrupt count), $AR0, and $SR):
+; 1, 0, 0, 0, 2024
+; 3, 1, 1, 2, 2820
+; 3, 1, 2, 3, 2820
+; 2, 0, 2, 6, 3825

--- a/Source/DSPSpy/tests/external_interrupt_nested_sbset.ds
+++ b/Source/DSPSpy/tests/external_interrupt_nested_sbset.ds
@@ -1,0 +1,89 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRI $AR0, #0
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #5
+	SBSET #6
+	LRI $AR0, #2
+	LRI $AR0, #3
+	LRI $AR0, #4
+	LRI $AR0, #5
+	LRI $AR0, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	INC $ACC0
+	INCM $AC0.M
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	; Only trigger a nested interrupt the first time through.
+	CMPIS $AC0.M, #2
+	JGE exit_irq
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read_irq:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read_irq
+
+	CLR $ACC1
+	SBSET #6
+
+second_loop_irq:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop_irq
+
+exit_irq:
+	DEC $ACC0
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AC0.L (interrupt depth), $AC0.M (interrupt count), $AR0, and $SR):
+; 1, 0, 0, 0, 2024
+; 3, 1, 1, 2, 2820
+; 3, 2, 2, 2, 2820
+; 2, 0, 2, 6, 3825

--- a/Source/DSPSpy/tests/external_interrupt_no_delay.ds
+++ b/Source/DSPSpy/tests/external_interrupt_no_delay.ds
@@ -1,0 +1,69 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	LRI $AX1.H, #1
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	; Wait a while (0x10000 increments)
+	CLR $ACC1
+
+	SBSET #6
+	SBSET #5
+
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	LRIS $AX1.H, #2
+	LRIS $AX1.H, #3
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, and $SR):
+; 1, 1, 2024 (start)
+; 3, 1, 2820 (in interrupt handler)
+; 2, 6, 3825 (end)
+; DSPSpy shows "interrupt after 21 ticks / 0 tries" (exact numbers vary)
+; $ACC1 in the interrupt handler is approximately 15 (so it loops 15 times
+; after the CPU receives the mail before the interrupt fires)

--- a/Source/DSPSpy/tests/external_interrupt_status_bits.ds
+++ b/Source/DSPSpy/tests/external_interrupt_status_bits.ds
@@ -1,0 +1,112 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+
+	; Pop stacks to avoid issues
+	;MRR $AR0, $ST0
+	;MRR $AR1, $ST1
+	;MRR $AR2, $ST2
+	;MRR $AR3, $ST3
+
+	SBCLR #2
+	SBCLR #3
+	SBCLR #4
+	SBCLR #5
+	SBCLR #6
+
+	; We store a copy of $SR in $AR0.
+	MRR $AR0, $SR
+	; $IX0 is set to SR_100, so we can add it to $AR0 repeatedly to cycle through $SR bits.
+	LRI $IX0, #0x0100
+	; Subtract $IX0 from $AR0, so that we can add it the first time to get $SR
+	; (and have $AR0 always match $SR instead of overflowing)
+	SUBARN $AR0
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	; We're checking 5 bits in $sr, so 1 << 5 or 0x20 times.
+	BLOOPI #0x20, main_loop_last_ins
+		CLR $ACC0
+		ADDARN $AR0, $IX0
+		MRR $SR, $AR0
+
+		; Tell the CPU to set the external interrupt
+		SI @DMBH, #0x8888
+		SI @DMBL, #0x5372
+		SI @DIRQ, #0x0001
+
+		; Wait for CPU
+wait_cpu_read_1a:
+		LRS $AC1.M, @DMBH
+		ANDCF $AC1.M, #0x8000
+		JLZ wait_cpu_read_1a
+;wait_cpu_read_1b:
+;		LRS $AC1.M, @CMBH
+;		ANDCF $AC1.M, #0x8000
+;		JLZ wait_cpu_read_1b
+
+		NOP
+		NOP
+
+		;LRIS $AX0.H, #2
+		;CALL send_back
+
+		; Tell the CPU to un-set the external interrupt
+		SI @DMBH, #0x8888
+		SI @DMBL, #0x5370
+		SI @DIRQ, #0x0001
+
+wait_cpu_read_2a:
+		LRS $AC1.M, @DMBH
+		ANDCF $AC1.M, #0x8000
+		JLZ wait_cpu_read_2a
+;wait_cpu_read_2b:
+;		LRS $AC1.M, @CMBH
+;		ANDCF $AC1.M, #0x8000
+;		JLZ wait_cpu_read_2b
+
+		;LRIS $AX0.H, #3
+		;CALL send_back
+
+		NOP
+main_loop_last_ins:
+		NOP
+
+	JMP end_of_test
+
+external_irq:
+	INC $ACC0
+	MRR $AR1, $ST0
+	LRIS $AX0.H, #4
+	CALL send_back
+	MRR $ST0, $AR1
+	NOP ; this is required (probably something pipeline related)
+	RTI
+
+; Expected output:
+; st0  ar0  st1  sr   st3 ac0.l
+; 0510 1f24 0966 2024 b88 0
+; 0155 3824 3824 2820 8   1 - this one is weird (maybe you can't unrequest an interrupt, and it's happening twice); it doesn't happen in dolphin yet
+; 016X 3824 3864 2860 8   2
+; 016X 3924 3864 2860 7   1
+; 016X 3a24 3a64 2a60 6   1
+; 016X 3b24 3a64 2a60 5   1
+; 016X 3c24 3c64 2c60 4   1
+; 016X 3d24 3c64 2c60 3   1
+; 016X 3e24 3e64 2e60 2   1
+; 016X 3f24 3e64 2e60 1   1
+; X is 9 or 7 (consistently one of those). Probably around the second SI to @DMBH?

--- a/Source/DSPSpy/tests/external_interrupt_toggle_d0.ds
+++ b/Source/DSPSpy/tests/external_interrupt_toggle_d0.ds
@@ -1,0 +1,69 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #0
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	; Wait a while (0x10000 increments)
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	SBCLR #5
+	SBSET #5
+	SBCLR #5
+	SBSET #5
+	SBCLR #5
+	SBSET #5
+	SBCLR #5
+	SBSET #5
+	LRIS $AX1.H, #2
+	LRIS $AX1.H, #3
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	LRIS $AX1.H, #6
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, and $SR):
+; 1, 0, 2224
+; 3, 3, 2a25
+; 2, 6, 3a25

--- a/Source/DSPSpy/tests/external_interrupt_toggle_d1.ds
+++ b/Source/DSPSpy/tests/external_interrupt_toggle_d1.ds
@@ -1,0 +1,72 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #0
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	; Wait a while (0x10000 increments)
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	SBCLR #5
+	LRIS $AX1.H, #2
+	SBSET #5
+	SBCLR #5
+	LRIS $AX1.H, #3
+	SBSET #5
+	SBCLR #5
+	LRIS $AX1.H, #4
+	SBSET #5
+	SBCLR #5
+	LRIS $AX1.H, #5
+	SBSET #5
+	LRIS $AX1.H, #6
+	LRIS $AX1.H, #7
+	LRIS $AX1.H, #8
+	LRIS $AX1.H, #9
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, and $SR):
+; 1, 0, 2224
+; 3, 7, 2a25
+; 2, 9, 3a25

--- a/Source/DSPSpy/tests/external_interrupt_toggle_d2.ds
+++ b/Source/DSPSpy/tests/external_interrupt_toggle_d2.ds
@@ -1,0 +1,76 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		irq5
+	jmp		irq6
+	jmp		external_irq
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	CLR $ACC0
+	CLR $ACC1
+	SBCLR #5
+	SBCLR #6
+
+	LRIS $AX1.H, #0
+
+	LRIS $AX0.H, #1
+	CALL send_back
+
+	SI @DMBH, #0x8888
+	SI @DMBL, #0x5371
+
+wait_cpu_read:
+	LRS $AC1.M, @DMBH
+	ANDCF $AC1.M, #0x8000
+	JLZ wait_cpu_read
+
+	; Wait a while (0x10000 increments)
+	CLR $ACC1
+second_loop:
+	INC $ACC1
+	CMPIS $AC1.M, #1
+	JNZ second_loop
+
+	SBSET #6
+	SBSET #5
+	SBCLR #5
+	LRIS $AX1.H, #2
+	LRIS $AX1.H, #3
+	SBSET #5
+	SBCLR #5
+	LRIS $AX1.H, #4
+	LRIS $AX1.H, #5
+	SBSET #5
+	SBCLR #5
+	LRIS $AX1.H, #6
+	LRIS $AX1.H, #7
+	SBSET #5
+	SBCLR #5
+	LRIS $AX1.H, #8
+	LRIS $AX1.H, #9
+	SBSET #5
+	LRIS $AX1.H, #10
+	LRIS $AX1.H, #11
+	LRIS $AX1.H, #12
+	LRIS $AX1.H, #13
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	JMP end_of_test
+
+external_irq:
+	LRIS $AX0.H, #3
+	CALL send_back
+	RTI
+
+; Expected result ($AX0.H (send_back num), $AX1.H, and $SR):
+; 1, 0, 2224
+; 3, b, 2a25
+; 2, d, 3a25

--- a/Source/DSPSpy/tests/interrupt_nested.ds
+++ b/Source/DSPSpy/tests/interrupt_nested.ds
@@ -1,0 +1,83 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		accov_irq
+	jmp		irq6
+	jmp		irq7
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	; Use the accelerator to generate an IRQ by setting the start and end address to 0
+	; This will result in an interrupt on every read
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+	SI @0xffd1, #0 ; SampleFormat
+	SI @ACSAH, #0
+	SI @ACCAH, #0
+	SI @ACSAL, #0
+	SI @ACCAL, #0
+	SI @ACEAH, #0
+	SI @ACEAL, #0
+
+	SBSET #2
+	SBSET #3
+	SBCLR #4
+	SBSET #5
+	SBSET #6
+
+	CLR $ACC0
+	CLR $ACC1
+	LRIS $AX0.H, #1
+	LRIS $AX1.H, #0
+	CALL send_back
+
+	LRS $AX0.L, @ARAM ; Trigger interrupt
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	jmp end_of_test
+
+accov_irq:
+	; NOTE: interrupts are NOT automatically disabled here
+
+	; Restore registers, otherwise no new interrupt will be generated
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+
+	INCM $AC0.M
+	INCM $AC1.M
+
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	CMPIS $AC0.M, #1
+	IFZ
+	; Trigger second interrupt, which will happen immediately
+	LRS $AX0.L, @ARAM
+
+	LRIS $AX1.H, #2
+
+	LRIS $AX0.H, #4
+	CALL send_back
+
+	DECM $AC1.M
+
+	RTI
+
+; Expected output ($AX0.H (send_back number), $AX1.H (changed on lines after an exception fires,
+; to make sure it happens immediately), $AC0.M (interrupt count), $AC1.M (interrupt depth), and $SR):
+; 1, 0, 0, 0, 3a24 (first line)
+; 3, 0, 1, 1, 2a20 (start of interrupt handler)
+; 3, 0, 2, 2, 2a20 (nested start of interrupt handler)
+; 4, 2, 2, 2, 2a21 (nested interrupt handler exits)
+; 4, 2, 2, 1, 2a25 (interrupt handler exits)
+; 2, 1, 2, 0, 3a24 (before end_of_test)

--- a/Source/DSPSpy/tests/interrupt_suppressed.ds
+++ b/Source/DSPSpy/tests/interrupt_suppressed.ds
@@ -1,0 +1,80 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		accov_irq
+	jmp		irq6
+	jmp		irq7
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	; Use the accelerator to generate an IRQ by setting the start and end address to 0
+	; This will result in an interrupt on every read
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+	SI @0xffd1, #0 ; SampleFormat
+	SI @ACSAH, #0
+	SI @ACCAH, #0
+	SI @ACSAL, #0
+	SI @ACCAL, #0
+	SI @ACEAH, #0
+	SI @ACEAL, #0
+
+	SBSET #2
+	SBSET #3
+	SBCLR #4
+	SBSET #5
+	SBSET #6
+
+	CLR $ACC0
+	CLR $ACC1
+
+	LRIS $AC1.M, #1
+	CALL send_back
+
+	LRS $AX0.L, @ARAM ; Trigger interrupt
+
+	LRIS $AC1.M, #2
+	CALL send_back
+
+	SBCLR #3 ; Disable interrupts
+
+	LRIS $AC1.M, #3
+	CALL send_back
+
+	LRS $AX0.L, @ARAM ; Trigger interrupt while disabled
+
+	LRIS $AC1.M, #4
+	CALL send_back
+
+	SBSET #3 ; Re-enable interrupts
+
+	LRIS $AC1.M, #5
+	CALL send_back
+
+	jmp end_of_test
+
+accov_irq:
+	; Restore registers, otherwise no new interrupt will be generated
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+
+	INCM $AC0.M
+	LRIS $AC1.M, #6
+	CALL send_back
+
+	RTI
+
+; Expected output ($AC0.M (num interrupts), $AC1.M (send_back number), and $SR):
+; 0, 1, 3a24 (start)
+; 1, 6, 2a20 (in interrupt handler)
+; 1, 2, 3a24 (out of interrupt handler)
+; 1, 3, 3824 (interrupts disabled)
+; 1, 4, 3824 (no interrupt triggered)
+; 1, 5, 3a24 (interrupts enabled, still no interrupt triggered)

--- a/Source/DSPSpy/tests/interrupt_suppressed_nested_rti.ds
+++ b/Source/DSPSpy/tests/interrupt_suppressed_nested_rti.ds
@@ -1,0 +1,79 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		accov_irq
+	jmp		irq6
+	jmp		irq7
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	; Use the accelerator to generate an IRQ by setting the start and end address to 0
+	; This will result in an interrupt on every read
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+	SI @0xffd1, #0 ; SampleFormat
+	SI @ACSAH, #0
+	SI @ACCAH, #0
+	SI @ACSAL, #0
+	SI @ACCAL, #0
+	SI @ACEAH, #0
+	SI @ACEAL, #0
+
+	SBSET #2
+	SBSET #3
+	SBCLR #4
+	SBSET #5
+	SBSET #6
+
+	CLR $ACC0
+	CLR $ACC1
+	LRIS $AX0.H, #1
+	LRIS $AX1.H, #0
+	CALL send_back
+
+	LRS $AX0.L, @ARAM ; Trigger interrupt
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	jmp end_of_test
+
+accov_irq:
+	; Disable interrupts
+	SBCLR #3
+
+	; Restore registers, otherwise no new interrupt will be generated
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+
+	INCM $AC0.M
+	INCM $AC1.M
+
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	; Trigger second interrupt, which will be ignored(!)
+	LRS $AX0.L, @ARAM
+	LRIS $AX1.H, #2
+
+	LRIS $AX0.H, #4
+	CALL send_back
+
+	DECM $AC1.M
+
+	RTI
+
+; Expected output ($AX0.H (send_back number), $AX1.H (changed on lines after an exception fires,
+; to make sure it happens immediately), $AC0.M (interrupt count), $AC1.M (interrupt depth), and $SR):
+; 1, 0, 0, 0, 3a24 (first line)
+; 3, 0, 1, 1, 2820 (start of interrupt handler)
+; 4, 2, 1, 1, 2820 (end of interrupt handler)
+; 2, 1, 1, 0, 3a24 (before end_of_test)

--- a/Source/DSPSpy/tests/interrupt_suppressed_nested_sbset.ds
+++ b/Source/DSPSpy/tests/interrupt_suppressed_nested_sbset.ds
@@ -1,0 +1,87 @@
+; This test needs to manually specify IRQs
+	jmp		irq0
+	jmp		irq1
+	jmp		irq2
+	jmp		irq3
+	jmp		irq4
+	jmp		accov_irq
+	jmp		irq6
+	jmp		irq7
+
+incdir  "tests"
+include "dsp_base_noirq.inc"
+
+test_main:
+	; Use the accelerator to generate an IRQ by setting the start and end address to 0
+	; This will result in an interrupt on every read
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+	SI @0xffd1, #0 ; SampleFormat
+	SI @ACSAH, #0
+	SI @ACCAH, #0
+	SI @ACSAL, #0
+	SI @ACCAL, #0
+	SI @ACEAH, #0
+	SI @ACEAL, #0
+
+	SBSET #2
+	SBSET #3
+	SBCLR #4
+	SBSET #5
+	SBSET #6
+
+	CLR $ACC0
+	CLR $ACC1
+	LRIS $AX0.H, #1
+	LRIS $AX1.H, #0
+	CALL send_back
+
+	LRS $AX0.L, @ARAM ; Trigger interrupt
+	LRIS $AX1.H, #1
+
+	LRIS $AX0.H, #2
+	CALL send_back
+
+	jmp end_of_test
+
+accov_irq:
+	; Disable interrupts
+	SBCLR #3
+
+	; Restore registers, otherwise no new interrupt will be generated
+	SI @0xffda, #0 ; pred_scale
+	SI @0xffdb, #0 ; yn1
+	SI @0xffdc, #0 ; yn2
+
+	INCM $AC0.M
+	INCM $AC1.M
+
+	LRIS $AX0.H, #3
+	CALL send_back
+
+	; Trigger second interrupt, which will be ignored(!)
+	LRS $AX0.L, @ARAM
+	LRIS $AX1.H, #2
+
+	LRIS $AX0.H, #4
+	CALL send_back
+
+	; Re-enable interrupts - we don't get the previously triggered interrupt here.
+	SBSET #3
+	LRIS $AX1.H, #3
+
+	LRIS $AX0.H, #5
+	CALL send_back
+
+	DECM $AC1.M
+
+	RTI
+
+; Expected output ($AX0.H (send_back number), $AX1.H (changed on lines after an exception fires,
+; to make sure it happens immediately), $AC0.M (interrupt count), $AC1.M (interrupt depth), and $SR):
+; 1, 0, 0, 0, 3a24 (first line)
+; 3, 0, 1, 1, 2820 (start of interrupt handler)
+; 4, 2, 1, 1, 2820 (middle of interrupt handler)
+; 5, 3, 1, 1, 2a20 (end of interrupt handler)
+; 2, 1, 1, 0, 3a24 (before end_of_test)

--- a/docs/DSP/GameCube_DSP_Users_Manual/GameCube_DSP_Users_Manual.tex
+++ b/docs/DSP/GameCube_DSP_Users_Manual/GameCube_DSP_Users_Manual.tex
@@ -266,6 +266,7 @@ The purpose of this documentation is purely academic and it aims at understandin
 0.1.6            & 2022.06.20    & xperia64        & Accelerator documentation updates, fix register typo in ANDC and ORC descriptions        \\ \hline
 0.1.7            & 2025.04.21    & Tilka           & Fixed typos and complained about GFDL                                                    \\ \hline
 0.1.8            & 2025.07.27    & Tilka           & Fixed some bit pattern inconsistencies in the 'LDAX* opcodes                             \\ \hline
+0.1.9            & 2025.09.14    & Pokechu22       & Document memory pages and external interrupt; add a few more hyperlinks                  \\ \hline
 \end{tabular}
 \end{table}
 
@@ -417,6 +418,8 @@ There are no DSP instructions that write to IMEM; however, the \Opcode{ILRR} fam
 \end{tabular}
 \end{table}
 
+Per patent US6606689, column 14, lines 16-27, the DSP can read from IROM during a \nameref{sec:DMA} to IRAM, and can read from IRAM during a write DMA to IRAM, although simultaneous reads and writes to the same address produce a hardware conflict. Exact behavior is untested.
+
 \pagebreak{}
 
 \subsection{Data Memory}
@@ -435,6 +438,9 @@ It is possible to both read and write to DMEM, but coefficient data cannot be wr
 \begin{tabular}[c]{@{}l@{}}\texttt{0xFF00}\\ \\ \\ \\\\ \\ \\ \\  \texttt{0xFFFF}\end{tabular} & \texttt{IFX} \\ \hline
 \end{tabular}
 \end{table}
+
+Per patent US6606689, column 14, lines 28-55, data RAM is composed of 4 pages of 1024 (\texttt{0x400}) words, and data ROM is composed of a single 2048 (\texttt{0x800}) word page. Each page can be simultaneously read and written by one of the DSP's two data busses or by \nameref{sec:DMA}, but a page cannot be simultaneously written by two sources or read by two sources (behavior in this case is untested). \nameref{sec:Extended opcodes} such as \Opcode{'LD} and \Opcode{'LS} can be combined with DMA to have simultaneous transfers on up to 3 pages. Simultaneous reads or writes to an address being accessed by DMA produce a hardware conflict (exact behavior is untested).
+% TODO: The patent only specifies this for DMA; does this mean that the DSP itself can read and write to the same address using e.g. 'LS or 'SL? Do writes always happen after reads, or does the bus used matter?
 
 \pagebreak{}
 
@@ -584,7 +590,7 @@ This is an 8-bit register.  Writes to the upper 8 bits are ignored and those bit
 
 \section{Status register}
 
-Status register \Register{\$sr} reflects flags computed on accumulators after logical or arithmetic operations.
+Status register \Register{\$sr} reflects \hyperref[{sec:Flags}]{flags} computed on accumulators after logical or arithmetic operations.
 Furthermore, it also contains control bits to configure the flow of certain operations.
 
 \begin{table}[htb]
@@ -595,9 +601,9 @@ Furthermore, it also contains control bits to configure the flow of certain oper
 \texttt{15}  & \texttt{SU}   & Multiplication operands are signed (1 = unsigned)             \\ \hline
 \texttt{14}  & \texttt{SXM}  & Sign extension mode (1 = 40-bit, see \nameref{subsec:SET40})  \\ \hline
 \texttt{13}  & \texttt{AM}   & Product multiply result by 2 (when \texttt{AM = 0})           \\ \hline
-\texttt{12}  &               &                                                               \\ \hline
+\texttt{12}  & \texttt{EIE2} & External interrupt enable 2                                   \\ \hline
 \texttt{11}  & \texttt{EIE}  & External interrupt enable                                     \\ \hline
-\texttt{10}  &               &                                                               \\ \hline
+\texttt{10}  &               & Unknown                                                       \\ \hline
 \texttt{9}   & \texttt{IE}   & Interrupt enable                                              \\ \hline
 \texttt{8}   &               & Unknown, always reads back as 0                               \\ \hline
 \texttt{7}   & \texttt{OS}   & Overflow (sticky)                                             \\ \hline
@@ -639,12 +645,17 @@ If \RegisterField{\$sr.AM} is equal 0 then the result of every multiply operatio
 Exception processing happens by setting the program counter to different exception vectors.
 At exception time, the exception program counter is stored at call stack \Register{\$st0} and status register \Register{\$sr} is stored at data stack \Register{\$st1}.
 
+Exceptions only trigger when \Register{\$sr.IE} is set, other than the external interrupt, which ignores \Register{\$sr.IE}. The external interrupt only triggers when both \Register{\$sr.EIE} and \Register{\$sr.EIE2} are set. \Register{\$sr.EIE2} is automatically cleared when entering an exception vector (and will be restored when the previous \Register{\$sr} value is popped from \Register{\$st1} by \Opcode{RTI}).
+
+The external interrupt triggers when bit 1 (\Value{0x0002}) of the DSP control register (\Value{0xcc00500a}, different from the config register) is set by the PowerPC CPU. That bit will remain set until the interrupt is processed by the DSP; it cannot be cleared on the PowerPC side by writing a zero.
+
 \textbf{Operation:}
 \begin{lstlisting}[basicstyle=\ttfamily]
 PUSH_STACK($st0);
 $st0 = $pc;
 PUSH_STACK($st1);
 $st1 = $sr;
+$sr.EIE2 = 0;
 $pc = exception_nr * 2;
 \end{lstlisting}
 
@@ -724,7 +735,7 @@ Hardware registers (IFX) occupy the address space at \Address{0xFFxx} in the Dat
 
 \pagebreak{}
 
-\section{DMA}
+\section{DMA}\label{sec:DMA}
 
 The GameCube DSP is connected to the memory bus through a DMA channel. DMA can be used to transfer data between DSP memory (both instruction and data) and main memory.
 
@@ -1115,9 +1126,9 @@ The logic zero flag is only set by \Opcode{ANDCF} and \Opcode{ANDF}.
 
 \pagebreak{}
 
-\section{Flags}
+\section{Flags}\label{sec:Flags}
 
-Most opcodes update flags in the status register (\Register{\$sr}) based on their result.  (Extended opcodes do not update flags.)
+Most opcodes update flags in the status register (\Register{\$sr}) based on their result.  (\nameref{sec:Extended opcodes} do not update flags.)
 
 Overflow (\texttt{O}) occurs when the result has wrapped around.  The expression $C = A + B$ has overflown if $A > 0$ and $B > 0$ but $C \le 0$ or if $A < 0$ and $B < 0$ but $C \ge 0$.  Any instruction that sets the \texttt{O} flag will also set the \texttt{OS} flag; when the \texttt{O} flag is set, \texttt{OS} is also set, but \texttt{OS} is not cleared when \texttt{O} is cleared.
 
@@ -4378,7 +4389,7 @@ A ``-'' indicates that the flag retains its previous value, a ``0'' indicates th
   \DSPOpcodeFlags{-}{-}{X}{X}{X}{X}{0}{0}
 \end{DSPOpcode}
 
-\section{Extended opcodes}
+\section{Extended opcodes}\label{sec:Extended opcodes}
 
 Extended opcodes do not exist on their own. These opcodes can only be attached to opcodes that allow extending.
 Specifically, opcodes where the first nybble is 0, 1, or 2 cannot be extended.


### PR DESCRIPTION
This fixes the random hang on startup with Super Mario Sunshine on startup with the DSP LLE recompiler/the consistent hang with the DSP LLE interpreter (bug https://bugs.dolphin-emu.org/issues/11384). I've started SMS with the LLE recompiler 50 times (25 times single core, 25 times dual core) and the hang never happened. The problem was that if the external interrupt was disabled, we previously would never fire it when it was later enabled, and this happened during startup. Now it fires as soon as the interrupt is enabled (in practice, on real hardware it takes a few additional instructions for the interrupt to fire, but accurately emulating that would be difficult and I wasn't able to establish precise timings).

There are also a few other changes related to DSP interrupts that I found while researching. As far as I know, they are only relevant to the tests I wrote. 

This is a rebased and tidied version of #13463 with #11593 excluded. I also updated the DSP manual based on what I changed (the manual updates also cover the page information from [bug 13842](https://bugs.dolphin-emu.org/issues/13842)). I haven't re-ran any of the DSP tests I added originally, or even really looked over them again, but they all seem to be interrupt-related.