### PR TITLE
ConfigControl: Fix bolding bugs

### DIFF
--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigControl.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigControl.h
@@ -17,6 +17,8 @@ class Info;
 struct Location;
 }  // namespace Config
 
+class QShowEvent;
+
 template <class Derived>
 class ConfigControl : public Derived
 {
@@ -44,9 +46,7 @@ protected:
   void ConnectConfig()
   {
     Derived::connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
-      QFont bf = Derived::font();
-      bf.setBold(IsConfigLocal());
-      Derived::setFont(bf);
+      UpdateBoldness();
 
       // This isn't signal blocked because the UI may need to be updated.
       m_updating = true;
@@ -91,6 +91,25 @@ protected:
   }
 
   virtual void OnConfigChanged() {}
+
+  void UpdateBoldness()
+  {
+    QFont bf = Derived::font();
+    bf.setBold(ShouldLabelBeBold());
+    Derived::setFont(bf);
+  }
+
+  virtual bool ShouldLabelBeBold() const { return IsConfigLocal(); }
+
+  void showEvent(QShowEvent* const event) override
+  {
+    // Call this here instead of in the constructor because virtual function calls are disabled in
+    // constructors, since base classes are constructed before derived classes and so the derived
+    // function would potentially use uninitialized data (as would be the case for
+    // ConfigRadioInt::UpdateBoldness).
+    UpdateBoldness();
+    Derived::showEvent(event);
+  }
 
 private:
   bool IsConfigLocal() const

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.cpp
@@ -7,7 +7,7 @@ ConfigRadioInt::ConfigRadioInt(const QString& label, const Config::Info<int>& se
                                Config::Layer* layer)
     : ConfigControl(label, setting.GetLocation(), layer), m_setting(setting), m_value(value)
 {
-  setChecked(ReadValue(setting) == value);
+  setChecked(IsSelected());
 
   connect(this, &QRadioButton::toggled, this, &ConfigRadioInt::Update);
 }
@@ -26,7 +26,17 @@ void ConfigRadioInt::Update()
   }
 }
 
+bool ConfigRadioInt::IsSelected() const
+{
+  return ReadValue(m_setting) == m_value;
+}
+
 void ConfigRadioInt::OnConfigChanged()
 {
-  setChecked(ReadValue(m_setting) == m_value);
+  setChecked(IsSelected());
+}
+
+bool ConfigRadioInt::ShouldLabelBeBold() const
+{
+  return IsSelected() && ConfigControl::ShouldLabelBeBold();
 }

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigRadio.h
@@ -23,9 +23,11 @@ signals:
 
 protected:
   void OnConfigChanged() override;
+  bool ShouldLabelBeBold() const override;
 
 private:
   void Update();
+  bool IsSelected() const;
 
   const Config::Info<int> m_setting;
   int m_value;


### PR DESCRIPTION
Fix two bugs with bold labels when IsConfigLocal is true.

First, when constructing a ConfigControl the label wouldn't be bolded until the next time a ConfigChanged signal was received. This would happen if the user started a game before opening a config window for the first time since starting Dolphin.

Second, ConfigRadioInt would bold every radio button for that setting instead of just the selected radio button.