### PR TITLE
Qt Settings: Transfer OSD settings to a new OSD pane.

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -419,6 +419,7 @@ const Info<bool> MAIN_USE_HIGH_CONTRAST_TOOLTIPS{
 const Info<bool> MAIN_USE_PANIC_HANDLERS{{System::Main, "Interface", "UsePanicHandlers"}, true};
 const Info<bool> MAIN_ABORT_ON_PANIC_ALERT{{System::Main, "Interface", "AbortOnPanicAlert"}, false};
 const Info<bool> MAIN_OSD_MESSAGES{{System::Main, "Interface", "OnScreenDisplayMessages"}, true};
+const Info<int> MAIN_OSD_FONT_SIZE{{System::GFX, "Settings", "OSDFontSize"}, 13};
 const Info<bool> MAIN_SKIP_NKIT_WARNING{{System::Main, "Interface", "SkipNKitWarning"}, false};
 const Info<bool> MAIN_CONFIRM_ON_STOP{{System::Main, "Interface", "ConfirmStop"}, true};
 const Info<ShowCursor> MAIN_SHOW_CURSOR{{System::Main, "Interface", "CursorVisibility"},

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -241,6 +241,7 @@ extern const Info<bool> MAIN_USE_HIGH_CONTRAST_TOOLTIPS;
 extern const Info<bool> MAIN_USE_PANIC_HANDLERS;
 extern const Info<bool> MAIN_ABORT_ON_PANIC_ALERT;
 extern const Info<bool> MAIN_OSD_MESSAGES;
+extern const Info<int> MAIN_OSD_FONT_SIZE;
 extern const Info<bool> MAIN_SKIP_NKIT_WARNING;
 extern const Info<bool> MAIN_CONFIRM_ON_STOP;
 

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -362,6 +362,8 @@ add_executable(dolphin-emu
   Settings/GeneralPane.h
   Settings/InterfacePane.cpp
   Settings/InterfacePane.h
+	Settings/OnScreenDisplayPane.cpp
+	Settings/OnScreenDisplayPane.h
   Settings/PathPane.cpp
   Settings/PathPane.h
   Settings/USBDevicePicker.cpp

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -46,36 +46,6 @@ void AdvancedWidget::CreateWidgets()
 
   auto* main_layout = new QVBoxLayout;
 
-  // Performance
-  auto* performance_box = new QGroupBox(tr("Performance Statistics"));
-  auto* performance_layout = new QGridLayout();
-  performance_box->setLayout(performance_layout);
-
-  m_show_fps = new ConfigBool(tr("Show FPS"), Config::GFX_SHOW_FPS, m_game_layer);
-  m_show_ftimes = new ConfigBool(tr("Show Frame Times"), Config::GFX_SHOW_FTIMES, m_game_layer);
-  m_show_vps = new ConfigBool(tr("Show VPS"), Config::GFX_SHOW_VPS, m_game_layer);
-  m_show_vtimes = new ConfigBool(tr("Show VBlank Times"), Config::GFX_SHOW_VTIMES, m_game_layer);
-  m_show_graphs =
-      new ConfigBool(tr("Show Performance Graphs"), Config::GFX_SHOW_GRAPHS, m_game_layer);
-  m_show_speed = new ConfigBool(tr("Show % Speed"), Config::GFX_SHOW_SPEED, m_game_layer);
-  m_show_speed_colors =
-      new ConfigBool(tr("Show Speed Colors"), Config::GFX_SHOW_SPEED_COLORS, m_game_layer);
-  m_perf_samp_window = new ConfigInteger(0, 10000, Config::GFX_PERF_SAMP_WINDOW, m_game_layer, 100);
-  m_perf_samp_window->SetTitle(tr("Performance Sample Window (ms)"));
-  m_log_render_time = new ConfigBool(tr("Log Render Time to File"),
-                                     Config::GFX_LOG_RENDER_TIME_TO_FILE, m_game_layer);
-
-  performance_layout->addWidget(m_show_fps, 0, 0);
-  performance_layout->addWidget(m_show_ftimes, 0, 1);
-  performance_layout->addWidget(m_show_vps, 1, 0);
-  performance_layout->addWidget(m_show_vtimes, 1, 1);
-  performance_layout->addWidget(m_show_speed, 2, 0);
-  performance_layout->addWidget(m_show_graphs, 2, 1);
-  performance_layout->addWidget(new QLabel(tr("Performance Sample Window (ms):")), 3, 0);
-  performance_layout->addWidget(m_perf_samp_window, 3, 1);
-  performance_layout->addWidget(m_log_render_time, 4, 0);
-  performance_layout->addWidget(m_show_speed_colors, 4, 1);
-
   // Debugging
   auto* debugging_box = new QGroupBox(tr("Debugging"));
   auto* debugging_layout = new QGridLayout();
@@ -226,7 +196,6 @@ void AdvancedWidget::CreateWidgets()
   experimental_layout->addWidget(m_defer_efb_access_invalidation, 0, 0);
   experimental_layout->addWidget(m_manual_texture_sampling, 0, 1);
 
-  main_layout->addWidget(performance_box);
   main_layout->addWidget(debugging_box);
   main_layout->addWidget(utility_box);
   main_layout->addWidget(texture_dump_box);
@@ -269,44 +238,6 @@ void AdvancedWidget::OnEmulationStateChanged(bool running)
 
 void AdvancedWidget::AddDescriptions()
 {
-  static const char TR_SHOW_FPS_DESCRIPTION[] =
-      QT_TR_NOOP("Shows the number of distinct frames rendered per second as a measure of "
-                 "visual smoothness.<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
-  static const char TR_SHOW_FTIMES_DESCRIPTION[] =
-      QT_TR_NOOP("Shows the average time in ms between each distinct rendered frame alongside "
-                 "the standard deviation.<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
-  static const char TR_SHOW_VPS_DESCRIPTION[] =
-      QT_TR_NOOP("Shows the number of frames rendered per second as a measure of "
-                 "emulation speed.<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
-  static const char TR_SHOW_VTIMES_DESCRIPTION[] =
-      QT_TR_NOOP("Shows the average time in ms between each rendered frame alongside "
-                 "the standard deviation.<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
-  static const char TR_SHOW_GRAPHS_DESCRIPTION[] =
-      QT_TR_NOOP("Shows frametime graph along with statistics as a representation of "
-                 "emulation performance.<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
-  static const char TR_SHOW_SPEED_DESCRIPTION[] =
-      QT_TR_NOOP("Shows the % speed of emulation compared to full speed."
-                 "<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
-  static const char TR_SHOW_SPEED_COLORS_DESCRIPTION[] =
-      QT_TR_NOOP("Changes the color of the FPS counter depending on emulation speed."
-                 "<br><br><dolphin_emphasis>If unsure, leave this "
-                 "checked.</dolphin_emphasis>");
-  static const char TR_PERF_SAMP_WINDOW_DESCRIPTION[] =
-      QT_TR_NOOP("The amount of time the FPS and VPS counters will sample over."
-                 "<br><br>The higher the value, the more stable the FPS/VPS counter will be, "
-                 "but the slower it will be to update."
-                 "<br><br><dolphin_emphasis>If unsure, leave this "
-                 "at 1000ms.</dolphin_emphasis>");
-  static const char TR_LOG_RENDERTIME_DESCRIPTION[] = QT_TR_NOOP(
-      "Logs the render time of every frame to User/Logs/render_time.txt.<br><br>Use this "
-      "feature to measure Dolphin's performance.<br><br><dolphin_emphasis>If "
-      "unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_WIREFRAME_DESCRIPTION[] =
       QT_TR_NOOP("Renders the scene as a wireframe.<br><br><dolphin_emphasis>If unsure, leave "
                  "this unchecked.</dolphin_emphasis>");
@@ -443,21 +374,11 @@ void AdvancedWidget::AddDescriptions()
   static const char IF_UNSURE_UNCHECKED[] =
       QT_TR_NOOP("<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
-  m_show_fps->SetDescription(tr(TR_SHOW_FPS_DESCRIPTION));
-  m_show_ftimes->SetDescription(tr(TR_SHOW_FTIMES_DESCRIPTION));
-  m_show_vps->SetDescription(tr(TR_SHOW_VPS_DESCRIPTION));
-  m_show_vtimes->SetDescription(tr(TR_SHOW_VTIMES_DESCRIPTION));
-  m_show_graphs->SetDescription(tr(TR_SHOW_GRAPHS_DESCRIPTION));
-  m_show_speed->SetDescription(tr(TR_SHOW_SPEED_DESCRIPTION));
-  m_log_render_time->SetDescription(tr(TR_LOG_RENDERTIME_DESCRIPTION));
-  m_show_speed_colors->SetDescription(tr(TR_SHOW_SPEED_COLORS_DESCRIPTION));
-
   m_enable_wireframe->SetDescription(tr(TR_WIREFRAME_DESCRIPTION));
   m_show_statistics->SetDescription(tr(TR_SHOW_STATS_DESCRIPTION));
   m_show_proj_statistics->SetDescription(tr(TR_SHOW_PROJ_STATS_DESCRIPTION));
   m_enable_format_overlay->SetDescription(tr(TR_TEXTURE_FORMAT_DESCRIPTION));
   m_enable_api_validation->SetDescription(tr(TR_VALIDATION_LAYER_DESCRIPTION));
-  m_perf_samp_window->SetDescription(tr(TR_PERF_SAMP_WINDOW_DESCRIPTION));
   m_dump_textures->SetDescription(tr(TR_DUMP_TEXTURE_DESCRIPTION));
   m_dump_mip_textures->SetDescription(tr(TR_DUMP_MIP_TEXTURE_DESCRIPTION));
   m_dump_base_textures->SetDescription(tr(TR_DUMP_BASE_TEXTURE_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -34,15 +34,6 @@ private:
   ConfigBool* m_show_proj_statistics;
   ConfigBool* m_enable_format_overlay;
   ConfigBool* m_enable_api_validation;
-  ConfigBool* m_show_fps;
-  ConfigBool* m_show_ftimes;
-  ConfigBool* m_show_vps;
-  ConfigBool* m_show_vtimes;
-  ConfigBool* m_show_graphs;
-  ConfigBool* m_show_speed;
-  ConfigBool* m_show_speed_colors;
-  ConfigInteger* m_perf_samp_window;
-  ConfigBool* m_log_render_time;
 
   // Utility
   ConfigBool* m_prefetch_custom_textures;

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -108,22 +108,15 @@ void GeneralWidget::CreateWidgets()
   auto* m_options_box = new QGroupBox(tr("Other"));
   auto* m_options_layout = new QGridLayout();
 
-  m_show_ping =
-      new ConfigBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING, m_game_layer);
   m_autoadjust_window_size = new ConfigBool(tr("Auto-Adjust Window Size"),
                                             Config::MAIN_RENDER_WINDOW_AUTOSIZE, m_game_layer);
-  m_show_messages =
-      new ConfigBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES, m_game_layer);
   m_render_main_window =
       new ConfigBool(tr("Render to Main Window"), Config::MAIN_RENDER_TO_MAIN, m_game_layer);
 
   m_options_box->setLayout(m_options_layout);
 
   m_options_layout->addWidget(m_render_main_window, 0, 0);
-  m_options_layout->addWidget(m_autoadjust_window_size, 1, 0);
-
-  m_options_layout->addWidget(m_show_messages, 0, 1);
-  m_options_layout->addWidget(m_show_ping, 1, 1);
+  m_options_layout->addWidget(m_autoadjust_window_size, 0, 1);
 
   // Other
   auto* shader_compilation_box = new QGroupBox(tr("Shader Compilation"));
@@ -268,13 +261,6 @@ void GeneralWidget::AddDescriptions()
       "if emulation speed is below 100%.<br><br><dolphin_emphasis>If unsure, leave "
       "this "
       "unchecked.</dolphin_emphasis>");
-  static const char TR_SHOW_NETPLAY_PING_DESCRIPTION[] = QT_TR_NOOP(
-      "Shows the player's maximum ping while playing on "
-      "NetPlay.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
-  static const char TR_SHOW_NETPLAY_MESSAGES_DESCRIPTION[] =
-      QT_TR_NOOP("Shows chat messages, buffer changes, and desync alerts "
-                 "while playing NetPlay.<br><br><dolphin_emphasis>If unsure, leave "
-                 "this unchecked.</dolphin_emphasis>");
   static const char TR_SHADER_COMPILE_SPECIALIZED_DESCRIPTION[] =
       QT_TR_NOOP("Ubershaders are never used. Stuttering will occur during shader "
                  "compilation, but GPU demands are low.<br><br>Recommended for low-end hardware. "
@@ -320,11 +306,7 @@ void GeneralWidget::AddDescriptions()
 
   m_enable_fullscreen->SetDescription(tr(TR_FULLSCREEN_DESCRIPTION));
 
-  m_show_ping->SetDescription(tr(TR_SHOW_NETPLAY_PING_DESCRIPTION));
-
   m_autoadjust_window_size->SetDescription(tr(TR_AUTOSIZE_DESCRIPTION));
-
-  m_show_messages->SetDescription(tr(TR_SHOW_NETPLAY_MESSAGES_DESCRIPTION));
 
   m_render_main_window->SetDescription(tr(TR_RENDER_TO_MAINWINDOW_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -52,10 +52,9 @@ private:
   ConfigBool* m_enable_fullscreen;
 
   // Options
-  ConfigBool* m_show_ping;
   ConfigBool* m_autoadjust_window_size;
-  ConfigBool* m_show_messages;
   ConfigBool* m_render_main_window;
+
   std::array<ConfigRadioInt*, 4> m_shader_compilation_mode{};
   ConfigBool* m_wait_for_shaders;
   int m_previous_backend = 0;

--- a/Source/Core/DolphinQt/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.cpp
@@ -22,6 +22,7 @@
 #include "DolphinQt/Settings/GameCubePane.h"
 #include "DolphinQt/Settings/GeneralPane.h"
 #include "DolphinQt/Settings/InterfacePane.h"
+#include "DolphinQt/Settings/OnScreenDisplayPane.h"
 #include "DolphinQt/Settings/PathPane.h"
 #include "DolphinQt/Settings/WiiPane.h"
 
@@ -129,6 +130,7 @@ SettingsWindow::SettingsWindow(MainWindow* parent) : StackedSettingsWindow{paren
   AddPane(new GraphicsPane{parent, nullptr}, tr("Graphics"));
   AddWrappedPane(new ControllersPane, tr("Controllers"));
   AddWrappedPane(new InterfacePane, tr("Interface"));
+  AddWrappedPane(new OnScreenDisplayPane, tr("On Screen Display"));
   AddWrappedPane(new AudioPane, tr("Audio"));
   AddWrappedPane(new PathPane, tr("Paths"));
   AddWrappedPane(new GameCubePane, tr("GameCube"));

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -218,6 +218,7 @@
     <ClCompile Include="Settings\GameCubePane.cpp" />
     <ClCompile Include="Settings\GeneralPane.cpp" />
     <ClCompile Include="Settings\InterfacePane.cpp" />
+    <ClCompile Include="Settings\OnScreenDisplayPane.cpp" />
     <ClCompile Include="Settings\PathPane.cpp" />
     <ClCompile Include="Settings\USBDevicePicker.cpp" />
     <ClCompile Include="Settings\WiiPane.cpp" />
@@ -268,6 +269,7 @@
     <ClInclude Include="QtUtils\WrapInScrollArea.h" />
     <ClInclude Include="ResourcePackManager.h" />
     <ClInclude Include="Resources.h" />
+    <ClInclude Include="Settings\OnScreenDisplayPane.h" />
     <ClInclude Include="SkylanderPortal\SkylanderModifyDialog.h" />
     <ClInclude Include="TAS\TASControlState.h" />
     <ClInclude Include="TAS\TASSlider.h" />

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -27,6 +27,7 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
+#include "DolphinQt/Config/ConfigControls/ConfigInteger.h"
 #include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
@@ -198,6 +199,14 @@ void InterfacePane::CreateInGame()
       new ConfigBool(tr("Use Panic Handlers"), Config::MAIN_USE_PANIC_HANDLERS);
   m_checkbox_enable_osd =
       new ConfigBool(tr("Show On-Screen Display Messages"), Config::MAIN_OSD_MESSAGES);
+
+  m_osd_font_size = new ConfigInteger(12, 40, Config::MAIN_OSD_FONT_SIZE);
+  m_osd_font_size->setMinimumWidth(m_osd_font_size->sizeHint().width() * 2);
+  auto* font_size_layout = new QHBoxLayout;
+  font_size_layout->addWidget(new QLabel(tr("On-Screen Display Font Size: ")));
+  font_size_layout->addWidget(m_osd_font_size);
+  font_size_layout->addStretch();
+
   m_checkbox_show_active_title =
       new ConfigBool(tr("Show Active Title in Window Title"), Config::MAIN_SHOW_ACTIVE_TITLE);
   m_checkbox_pause_on_focus_lost =
@@ -228,6 +237,7 @@ void InterfacePane::CreateInGame()
   groupbox_layout->addWidget(m_checkbox_confirm_on_stop);
   groupbox_layout->addWidget(m_checkbox_use_panic_handlers);
   groupbox_layout->addWidget(m_checkbox_enable_osd);
+  groupbox_layout->addLayout(font_size_layout);
   groupbox_layout->addWidget(m_checkbox_show_active_title);
   groupbox_layout->addWidget(m_checkbox_pause_on_focus_lost);
   groupbox_layout->addWidget(mouse_groupbox);
@@ -372,6 +382,10 @@ void InterfacePane::AddDescriptions()
       QT_TR_NOOP("Shows on-screen display messages over the render window. These messages "
                  "disappear after several seconds."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static const char TR_OSD_FONT_SIZE_DESCRIPTION[] = QT_TR_NOOP(
+      "Changes the font size of the On Screen Display. Affects features such as performance "
+      "statistics, frame counter, and netplay chat.<br><br><dolphin_emphasis>If "
+      "unsure, leave this at 14.</dolphin_emphasis>");
   static constexpr char TR_SHOW_ACTIVE_TITLE_DESCRIPTION[] =
       QT_TR_NOOP("Shows the active game title in the render window's title bar."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
@@ -420,6 +434,8 @@ void InterfacePane::AddDescriptions()
   m_checkbox_use_panic_handlers->SetDescription(tr(TR_USE_PANIC_HANDLERS_DESCRIPTION));
 
   m_checkbox_enable_osd->SetDescription(tr(TR_ENABLE_OSD_DESCRIPTION));
+
+  m_osd_font_size->SetDescription(tr(TR_OSD_FONT_SIZE_DESCRIPTION));
 
   m_checkbox_show_active_title->SetDescription(tr(TR_SHOW_ACTIVE_TITLE_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -27,7 +27,6 @@
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/Config/ConfigControls/ConfigChoice.h"
-#include "DolphinQt/Config/ConfigControls/ConfigInteger.h"
 #include "DolphinQt/Config/ConfigControls/ConfigRadio.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
@@ -197,16 +196,6 @@ void InterfacePane::CreateInGame()
   m_checkbox_confirm_on_stop = new ConfigBool(tr("Confirm on Stop"), Config::MAIN_CONFIRM_ON_STOP);
   m_checkbox_use_panic_handlers =
       new ConfigBool(tr("Use Panic Handlers"), Config::MAIN_USE_PANIC_HANDLERS);
-  m_checkbox_enable_osd =
-      new ConfigBool(tr("Show On-Screen Display Messages"), Config::MAIN_OSD_MESSAGES);
-
-  m_osd_font_size = new ConfigInteger(12, 40, Config::MAIN_OSD_FONT_SIZE);
-  m_osd_font_size->setMinimumWidth(m_osd_font_size->sizeHint().width() * 2);
-  auto* font_size_layout = new QHBoxLayout;
-  font_size_layout->addWidget(new QLabel(tr("On-Screen Display Font Size: ")));
-  font_size_layout->addWidget(m_osd_font_size);
-  font_size_layout->addStretch();
-
   m_checkbox_show_active_title =
       new ConfigBool(tr("Show Active Title in Window Title"), Config::MAIN_SHOW_ACTIVE_TITLE);
   m_checkbox_pause_on_focus_lost =
@@ -236,8 +225,6 @@ void InterfacePane::CreateInGame()
   groupbox_layout->addWidget(m_checkbox_top_window);
   groupbox_layout->addWidget(m_checkbox_confirm_on_stop);
   groupbox_layout->addWidget(m_checkbox_use_panic_handlers);
-  groupbox_layout->addWidget(m_checkbox_enable_osd);
-  groupbox_layout->addLayout(font_size_layout);
   groupbox_layout->addWidget(m_checkbox_show_active_title);
   groupbox_layout->addWidget(m_checkbox_pause_on_focus_lost);
   groupbox_layout->addWidget(mouse_groupbox);
@@ -378,14 +365,6 @@ void InterfacePane::AddDescriptions()
                  "present choices on how to proceed. With this option disabled, Dolphin will "
                  "\"ignore\" all errors. Emulation will not be halted and you will not be notified."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
-  static constexpr char TR_ENABLE_OSD_DESCRIPTION[] =
-      QT_TR_NOOP("Shows on-screen display messages over the render window. These messages "
-                 "disappear after several seconds."
-                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
-  static const char TR_OSD_FONT_SIZE_DESCRIPTION[] = QT_TR_NOOP(
-      "Changes the font size of the On Screen Display. Affects features such as performance "
-      "statistics, frame counter, and netplay chat.<br><br><dolphin_emphasis>If "
-      "unsure, leave this at 14.</dolphin_emphasis>");
   static constexpr char TR_SHOW_ACTIVE_TITLE_DESCRIPTION[] =
       QT_TR_NOOP("Shows the active game title in the render window's title bar."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
@@ -432,10 +411,6 @@ void InterfacePane::AddDescriptions()
   m_checkbox_confirm_on_stop->SetDescription(tr(TR_CONFIRM_ON_STOP_DESCRIPTION));
 
   m_checkbox_use_panic_handlers->SetDescription(tr(TR_USE_PANIC_HANDLERS_DESCRIPTION));
-
-  m_checkbox_enable_osd->SetDescription(tr(TR_ENABLE_OSD_DESCRIPTION));
-
-  m_osd_font_size->SetDescription(tr(TR_OSD_FONT_SIZE_DESCRIPTION));
 
   m_checkbox_show_active_title->SetDescription(tr(TR_SHOW_ACTIVE_TITLE_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -6,7 +6,6 @@
 #include <QWidget>
 
 class ConfigBool;
-class ConfigInteger;
 class ConfigRadioInt;
 class ConfigStringChoice;
 class QLabel;
@@ -54,8 +53,6 @@ private:
 
   ConfigBool* m_checkbox_confirm_on_stop;
   ConfigBool* m_checkbox_use_panic_handlers;
-  ConfigBool* m_checkbox_enable_osd;
-  ConfigInteger* m_osd_font_size;
   ConfigBool* m_checkbox_show_active_title;
   ConfigBool* m_checkbox_pause_on_focus_lost;
   ConfigRadioInt* m_radio_cursor_visible_movement;

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -6,6 +6,7 @@
 #include <QWidget>
 
 class ConfigBool;
+class ConfigInteger;
 class ConfigRadioInt;
 class ConfigStringChoice;
 class QLabel;
@@ -54,6 +55,7 @@ private:
   ConfigBool* m_checkbox_confirm_on_stop;
   ConfigBool* m_checkbox_use_panic_handlers;
   ConfigBool* m_checkbox_enable_osd;
+  ConfigInteger* m_osd_font_size;
   ConfigBool* m_checkbox_show_active_title;
   ConfigBool* m_checkbox_pause_on_focus_lost;
   ConfigRadioInt* m_radio_cursor_visible_movement;

--- a/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.cpp
+++ b/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.cpp
@@ -1,0 +1,202 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Settings/OnScreenDisplayPane.h"
+
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "Core/Config/GraphicsSettings.h"
+#include "Core/Config/MainSettings.h"
+
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
+#include "DolphinQt/Config/ConfigControls/ConfigInteger.h"
+
+OnScreenDisplayPane::OnScreenDisplayPane(QWidget* parent) : QWidget(parent)
+{
+  CreateLayout();
+  AddDescriptions();
+}
+
+void OnScreenDisplayPane::CreateLayout()
+{
+  // General
+  auto* general_box = new QGroupBox(tr("General"));
+  auto* general_layout = new QGridLayout();
+  general_box->setLayout(general_layout);
+
+  m_enable_osd = new ConfigBool(tr("Show Messages"), Config::MAIN_OSD_MESSAGES, m_game_layer);
+  m_font_size = new ConfigInteger(12, 40, Config::MAIN_OSD_FONT_SIZE);
+  // m_font_size->setMinimumWidth(m_font_size->sizeHint().width() * 2);
+
+  general_layout->setAlignment(Qt::AlignLeft);
+  general_layout->addWidget(m_enable_osd, 0, 0);
+  general_layout->addWidget(new QLabel(tr("Font Size:")), 1, 0);
+  general_layout->addWidget(m_font_size, 1, 1);
+
+  // Performance
+  auto* performance_box = new QGroupBox(tr("Performance Statistics"));
+  auto* performance_layout = new QGridLayout();
+  performance_box->setLayout(performance_layout);
+
+  m_show_fps = new ConfigBool(tr("Show FPS"), Config::GFX_SHOW_FPS, m_game_layer);
+  m_show_ftimes = new ConfigBool(tr("Show Frame Times"), Config::GFX_SHOW_FTIMES, m_game_layer);
+  m_show_vps = new ConfigBool(tr("Show VPS"), Config::GFX_SHOW_VPS, m_game_layer);
+  m_show_vtimes = new ConfigBool(tr("Show VBlank Times"), Config::GFX_SHOW_VTIMES, m_game_layer);
+  m_show_speed = new ConfigBool(tr("Show % Speed"), Config::GFX_SHOW_SPEED, m_game_layer);
+  m_show_speed_colors =
+      new ConfigBool(tr("Show Speed Colors"), Config::GFX_SHOW_SPEED_COLORS, m_game_layer);
+  m_log_render_time = new ConfigBool(tr("Log Render Time to File"),
+                                     Config::GFX_LOG_RENDER_TIME_TO_FILE, m_game_layer);
+  m_show_graphs =
+      new ConfigBool(tr("Show Performance Graphs"), Config::GFX_SHOW_GRAPHS, m_game_layer);
+  m_perf_samp_window = new ConfigInteger(0, 10000, Config::GFX_PERF_SAMP_WINDOW, m_game_layer, 100);
+  m_perf_samp_window->SetTitle(tr("Performance Sample Window (ms)"));
+
+  performance_layout->setAlignment(Qt::AlignLeft);
+  performance_layout->addWidget(m_show_fps, 0, 0);
+  performance_layout->addWidget(m_show_ftimes, 0, 1);
+  performance_layout->addWidget(m_show_vps, 1, 0);
+  performance_layout->addWidget(m_show_vtimes, 1, 1);
+  performance_layout->addWidget(m_show_speed, 2, 0);
+  performance_layout->addWidget(m_show_speed_colors, 2, 1);
+  performance_layout->addWidget(m_log_render_time, 3, 0);
+  performance_layout->addWidget(m_show_graphs, 4, 0);
+  performance_layout->addWidget(new QLabel(tr("Update Rate (ms):")), 5, 0);
+  performance_layout->addWidget(m_perf_samp_window, 5, 1);
+
+  // Movie
+  auto* movie_box = new QGroupBox(tr("Other Statistics"));
+  auto* movie_layout = new QGridLayout();
+  movie_box->setLayout(movie_layout);
+
+  m_rerecord_counter =
+      new ConfigBool(tr("Show Rerecord Counter"), Config::MAIN_MOVIE_SHOW_RERECORD, m_game_layer);
+  m_lag_counter = new ConfigBool(tr("Show Lag Counter"), Config::MAIN_SHOW_LAG, m_game_layer);
+  m_frame_counter =
+      new ConfigBool(tr("Show Frame Counter"), Config::MAIN_SHOW_FRAME_COUNT, m_game_layer);
+  m_input_display =
+      new ConfigBool(tr("Show Input Display"), Config::MAIN_MOVIE_SHOW_INPUT_DISPLAY, m_game_layer);
+  m_system_clock =
+      new ConfigBool(tr("Show System Clock"), Config::MAIN_MOVIE_SHOW_RTC, m_game_layer);
+
+  movie_layout->addWidget(m_rerecord_counter, 0, 0);
+  movie_layout->addWidget(m_lag_counter, 0, 1);
+  movie_layout->addWidget(m_frame_counter, 1, 0);
+  movie_layout->addWidget(m_input_display, 1, 1);
+  movie_layout->addWidget(m_system_clock, 2, 0);
+  movie_layout->setAlignment(Qt::AlignLeft);
+
+  // NetPlay
+  auto* netplay_box = new QGroupBox(tr("Netplay"));
+  auto* netplay_layout = new QGridLayout();
+  netplay_box->setLayout(netplay_layout);
+
+  m_show_ping =
+      new ConfigBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING, m_game_layer);
+  m_show_chat =
+      new ConfigBool(tr("Show NetPlay Chat"), Config::GFX_SHOW_NETPLAY_MESSAGES, m_game_layer);
+
+  netplay_layout->setAlignment(Qt::AlignLeft);
+  netplay_layout->addWidget(m_show_ping, 0, 0);
+  netplay_layout->addWidget(m_show_chat, 0, 1);
+
+  // Align all GroupBox columns according to widest items.
+  const int width = m_show_graphs->sizeHint().width();
+  general_layout->setColumnMinimumWidth(0, width);
+  movie_layout->setColumnMinimumWidth(0, width);
+  netplay_layout->setColumnMinimumWidth(0, width);
+
+  const int width2 = m_show_vtimes->sizeHint().width();
+  general_layout->setColumnMinimumWidth(1, width2);
+  movie_layout->setColumnMinimumWidth(1, width2);
+  netplay_layout->setColumnMinimumWidth(1, width2);
+
+  // Stack GroupBoxes
+  auto* main_layout = new QVBoxLayout;
+  main_layout->addWidget(general_box);
+  main_layout->addWidget(performance_box);
+  main_layout->addWidget(movie_box);
+  main_layout->addWidget(netplay_box);
+  main_layout->addStretch();
+
+  setLayout(main_layout);
+}
+
+void OnScreenDisplayPane::AddDescriptions()
+{
+  static constexpr char TR_ENABLE_OSD_DESCRIPTION[] =
+      QT_TR_NOOP("Shows on-screen display messages over the render window. These messages "
+                 "disappear after several seconds."
+                 "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
+  static const char TR_OSD_FONT_SIZE_DESCRIPTION[] = QT_TR_NOOP(
+      "Changes the font size of the On Screen Display. Affects features such as performance "
+      "statistics, frame counter, and netplay chat.<br><br><dolphin_emphasis>If "
+      "unsure, leave this at 14.</dolphin_emphasis>");
+
+  static const char TR_SHOW_FPS_DESCRIPTION[] =
+      QT_TR_NOOP("Shows the number of distinct frames rendered per second as a measure of "
+                 "visual smoothness.<br><br><dolphin_emphasis>If unsure, leave this "
+                 "unchecked.</dolphin_emphasis>");
+  static const char TR_SHOW_FTIMES_DESCRIPTION[] =
+      QT_TR_NOOP("Shows the average time in ms between each distinct rendered frame alongside "
+                 "the standard deviation.<br><br><dolphin_emphasis>If unsure, leave this "
+                 "unchecked.</dolphin_emphasis>");
+  static const char TR_SHOW_VPS_DESCRIPTION[] =
+      QT_TR_NOOP("Shows the number of frames rendered per second as a measure of "
+                 "emulation speed.<br><br><dolphin_emphasis>If unsure, leave this "
+                 "unchecked.</dolphin_emphasis>");
+  static const char TR_SHOW_VTIMES_DESCRIPTION[] =
+      QT_TR_NOOP("Shows the average time in ms between each rendered frame alongside "
+                 "the standard deviation.<br><br><dolphin_emphasis>If unsure, leave this "
+                 "unchecked.</dolphin_emphasis>");
+  static const char TR_SHOW_GRAPHS_DESCRIPTION[] =
+      QT_TR_NOOP("Shows frametime graph along with statistics as a representation of "
+                 "emulation performance.<br><br><dolphin_emphasis>If unsure, leave this "
+                 "unchecked.</dolphin_emphasis>");
+  static const char TR_SHOW_SPEED_DESCRIPTION[] =
+      QT_TR_NOOP("Shows the % speed of emulation compared to full speed."
+                 "<br><br><dolphin_emphasis>If unsure, leave this "
+                 "unchecked.</dolphin_emphasis>");
+  static const char TR_SHOW_SPEED_COLORS_DESCRIPTION[] =
+      QT_TR_NOOP("Changes the color of the FPS counter depending on emulation speed."
+                 "<br><br><dolphin_emphasis>If unsure, leave this "
+                 "checked.</dolphin_emphasis>");
+  static const char TR_PERF_SAMP_WINDOW_DESCRIPTION[] =
+      QT_TR_NOOP("The amount of time the FPS and VPS counters will sample over."
+                 "<br><br>The higher the value, the more stable the FPS/VPS counter will be, "
+                 "but the slower it will be to update."
+                 "<br><br><dolphin_emphasis>If unsure, leave this "
+                 "at 1000ms.</dolphin_emphasis>");
+  static const char TR_LOG_RENDERTIME_DESCRIPTION[] = QT_TR_NOOP(
+      "Logs the render time of every frame to User/Logs/render_time.txt.<br><br>Use this "
+      "feature to measure Dolphin's performance.<br><br><dolphin_emphasis>If "
+      "unsure, leave this unchecked.</dolphin_emphasis>");
+
+  static const char TR_SHOW_NETPLAY_PING_DESCRIPTION[] = QT_TR_NOOP(
+      "Shows the player's maximum ping while playing on "
+      "NetPlay.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static const char TR_SHOW_NETPLAY_MESSAGES_DESCRIPTION[] =
+      QT_TR_NOOP("Shows chat messages, buffer changes, and desync alerts "
+                 "while playing NetPlay.<br><br><dolphin_emphasis>If unsure, leave "
+                 "this unchecked.</dolphin_emphasis>");
+
+  m_enable_osd->SetDescription(tr(TR_ENABLE_OSD_DESCRIPTION));
+  m_font_size->SetDescription(tr(TR_OSD_FONT_SIZE_DESCRIPTION));
+
+  m_show_fps->SetDescription(tr(TR_SHOW_FPS_DESCRIPTION));
+  m_show_ftimes->SetDescription(tr(TR_SHOW_FTIMES_DESCRIPTION));
+  m_show_vps->SetDescription(tr(TR_SHOW_VPS_DESCRIPTION));
+  m_show_vtimes->SetDescription(tr(TR_SHOW_VTIMES_DESCRIPTION));
+  m_show_graphs->SetDescription(tr(TR_SHOW_GRAPHS_DESCRIPTION));
+  m_show_speed->SetDescription(tr(TR_SHOW_SPEED_DESCRIPTION));
+  m_perf_samp_window->SetDescription(tr(TR_PERF_SAMP_WINDOW_DESCRIPTION));
+  m_log_render_time->SetDescription(tr(TR_LOG_RENDERTIME_DESCRIPTION));
+  m_show_speed_colors->SetDescription(tr(TR_SHOW_SPEED_COLORS_DESCRIPTION));
+
+  m_show_ping->SetDescription(tr(TR_SHOW_NETPLAY_PING_DESCRIPTION));
+  m_show_chat->SetDescription(tr(TR_SHOW_NETPLAY_MESSAGES_DESCRIPTION));
+}

--- a/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.h
+++ b/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <QWidget>
+
+class ConfigBool;
+class ConfigInteger;
+
+namespace Config
+{
+class Layer;
+}  // namespace Config
+
+class OnScreenDisplayPane final : public QWidget
+{
+public:
+  explicit OnScreenDisplayPane(QWidget* parent = nullptr);
+
+private:
+  void CreateLayout();
+  void AddDescriptions();
+
+  // General
+  ConfigBool* m_enable_osd;
+  ConfigInteger* m_font_size;
+
+  // Performance
+  ConfigBool* m_show_fps;
+  ConfigBool* m_show_ftimes;
+  ConfigBool* m_show_vps;
+  ConfigBool* m_show_vtimes;
+  ConfigBool* m_show_graphs;
+  ConfigBool* m_show_speed;
+  ConfigBool* m_show_speed_colors;
+  ConfigInteger* m_perf_samp_window;
+  ConfigBool* m_log_render_time;
+
+  // Movie window
+  ConfigBool* m_rerecord_counter;
+  ConfigBool* m_lag_counter;
+  ConfigBool* m_frame_counter;
+  ConfigBool* m_input_display;
+  ConfigBool* m_system_clock;
+
+  // Netplay
+  ConfigBool* m_show_ping;
+  ConfigBool* m_show_chat;
+
+  Config::Layer* m_game_layer = nullptr;
+};

--- a/Source/Core/VideoCommon/OnScreenUI.cpp
+++ b/Source/Core/VideoCommon/OnScreenUI.cpp
@@ -263,11 +263,12 @@ void OnScreenUI::DrawDebugText()
   {
     // Position under the FPS display.
     ImGui::SetNextWindowPos(
-        ImVec2(ImGui::GetIO().DisplaySize.x - 10.f * m_backbuffer_scale, 80.f * m_backbuffer_scale),
+        ImVec2(ImGui::GetIO().DisplaySize.x - ImGui::GetFontSize() * m_backbuffer_scale,
+               80.f * m_backbuffer_scale),
         ImGuiCond_FirstUseEver, ImVec2(1.0f, 0.0f));
-    ImGui::SetNextWindowSizeConstraints(
-        ImVec2(150.0f * m_backbuffer_scale, 20.0f * m_backbuffer_scale),
-        ImGui::GetIO().DisplaySize);
+    ImGui::SetNextWindowSizeConstraints(ImVec2(5.0f * ImGui::GetFontSize() * m_backbuffer_scale,
+                                               2.1f * ImGui::GetFontSize() * m_backbuffer_scale),
+                                        ImGui::GetIO().DisplaySize);
     if (ImGui::Begin("Movie", nullptr, ImGuiWindowFlags_NoFocusOnAppearing))
     {
       auto& movie = Core::System::GetInstance().GetMovie();
@@ -394,6 +395,12 @@ void OnScreenUI::Finalize()
   OSD::DrawMessages();
   DrawChallengesAndLeaderboards();
   ImGui::Render();
+
+  // Check for font changes
+  ImGuiStyle& style = ImGui::GetStyle();
+  const int size = Config::Get(Config::MAIN_OSD_FONT_SIZE);
+  if (size != style.FontSizeBase)
+    style.FontSizeBase = static_cast<float>(size);
 
   // Create or update fonts.
   ImDrawData* draw_data = ImGui::GetDrawData();

--- a/Source/Core/VideoCommon/PerformanceMetrics.cpp
+++ b/Source/Core/VideoCommon/PerformanceMetrics.cpp
@@ -127,7 +127,6 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
   }
 
   const float window_padding = 8.f * backbuffer_scale;
-  const float window_width = 93.f * backbuffer_scale;
 
   const ImVec2& display_size = ImGui::GetIO().DisplaySize;
   const bool display_size_changed =
@@ -161,9 +160,8 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
       ImGui::SetWindowPos(ImVec2(clamped_window_x, clamped_window_y), ImGuiCond_Always);
   };
 
-  const float graph_width = 50.f * backbuffer_scale + 3.f * window_width + 2.f * window_padding;
-  const float graph_height =
-      std::min(200.f * backbuffer_scale, display_size.y - 85.f * backbuffer_scale);
+  const float graph_width = display_size.x / 4.0;
+  const float graph_height = display_size.y / 4.0;
 
   const bool stack_vertically = !g_ActiveConfig.bShowGraphs;
 
@@ -171,17 +169,20 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
   ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 14.f * backbuffer_scale);
   if (g_ActiveConfig.bShowGraphs)
   {
+    // Force smaller font
+    ImGui::PushFont(NULL, 13.0f);
+    ImGui::PushStyleColor(ImGuiCol_ResizeGrip, 0);
+    const auto graph_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings |
+                             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav | movable_flag |
+                             ImGuiWindowFlags_NoFocusOnAppearing;
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 4.f * backbuffer_scale));
 
     // Position in the top-right corner of the screen.
-
     ImGui::SetNextWindowPos(ImVec2(window_x, window_y), set_next_position_condition,
                             ImVec2(1.0f, 0.0f));
-    ImGui::SetNextWindowSize(ImVec2(graph_width, graph_height));
+    ImGui::SetNextWindowSize(ImVec2(graph_width, graph_height), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowBgAlpha(bg_alpha);
-    window_y += graph_height + window_padding;
-
-    if (ImGui::Begin("PerformanceGraphs", nullptr, imgui_flags))
+    if (ImGui::Begin("PerformanceGraphs", nullptr, graph_flags))
     {
       static constexpr std::size_t num_ticks = 17;
       static constexpr std::array<double, num_ticks> tick_marks = {0.0,
@@ -203,6 +204,7 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
                                                                    2000.0};
 
       clamp_window_position();
+      window_y += ImGui::GetWindowHeight();
 
       const DT vblank_time = m_vps_counter.GetDtAvg() + 2 * m_vps_counter.GetDtStd();
       const DT frame_time = m_fps_counter.GetDtAvg() + 2 * m_fps_counter.GetDtStd();
@@ -245,25 +247,23 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
       ImGui::PopStyleVar();
     }
     ImGui::End();
+    ImGui::PopFont();
+    ImGui::PopStyleColor();
   }
 
   if (g_ActiveConfig.bShowSpeed)
   {
     // Position in the top-right corner of the screen.
-    float window_height = 47.f * backbuffer_scale;
-
     ImGui::SetNextWindowPos(ImVec2(window_x, window_y), set_next_position_condition,
                             ImVec2(1.0f, 0.0f));
-    ImGui::SetNextWindowSize(ImVec2(window_width, window_height));
     ImGui::SetNextWindowBgAlpha(bg_alpha);
-
-    if (stack_vertically)
-      window_y += window_height + window_padding;
-    else
-      window_x -= window_width + window_padding;
 
     if (ImGui::Begin("SpeedStats", nullptr, imgui_flags))
     {
+      if (stack_vertically)
+        window_y += ImGui::GetWindowHeight() + window_padding;
+      else
+        window_x -= ImGui::GetWindowWidth() + window_padding;
       clamp_window_position();
       ImGui::TextColored(ImVec4(r, g, b, 1.0f), "Speed:%4.0lf%%", 100.0 * speed);
       ImGui::TextColored(ImVec4(r, g, b, 1.0f), "Max:%6.0lf%%", 100.0 * GetMaxSpeed());
@@ -273,22 +273,17 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
 
   if (g_ActiveConfig.bShowFPS || g_ActiveConfig.bShowFTimes)
   {
-    int count = g_ActiveConfig.bShowFPS + 2 * g_ActiveConfig.bShowFTimes;
-    float window_height = (12.f + 17.f * count) * backbuffer_scale;
-
     // Position in the top-right corner of the screen.
     ImGui::SetNextWindowPos(ImVec2(window_x, window_y), set_next_position_condition,
                             ImVec2(1.0f, 0.0f));
-    ImGui::SetNextWindowSize(ImVec2(window_width, window_height));
     ImGui::SetNextWindowBgAlpha(bg_alpha);
-
-    if (stack_vertically)
-      window_y += window_height + window_padding;
-    else
-      window_x -= window_width + window_padding;
 
     if (ImGui::Begin("FPSStats", nullptr, imgui_flags))
     {
+      if (stack_vertically)
+        window_y += ImGui::GetWindowHeight() + window_padding;
+      else
+        window_x -= ImGui::GetWindowWidth() + window_padding;
       clamp_window_position();
       if (g_ActiveConfig.bShowFPS)
         ImGui::TextColored(ImVec4(r, g, b, 1.0f), "FPS:%7.2lf", fps);
@@ -305,22 +300,17 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
 
   if (g_ActiveConfig.bShowVPS || g_ActiveConfig.bShowVTimes)
   {
-    int count = g_ActiveConfig.bShowVPS + 2 * g_ActiveConfig.bShowVTimes;
-    float window_height = (12.f + 17.f * count) * backbuffer_scale;
-
     // Position in the top-right corner of the screen.
     ImGui::SetNextWindowPos(ImVec2(window_x, window_y), set_next_position_condition,
                             ImVec2(1.0f, 0.0f));
-    ImGui::SetNextWindowSize(ImVec2(window_width, (12.f + 17.f * count) * backbuffer_scale));
     ImGui::SetNextWindowBgAlpha(bg_alpha);
-
-    if (stack_vertically)
-      window_y += window_height + window_padding;
-    else
-      window_x -= window_width + window_padding;
 
     if (ImGui::Begin("VPSStats", nullptr, imgui_flags))
     {
+      if (stack_vertically)
+        window_y += ImGui::GetWindowHeight() + window_padding;
+      else
+        window_x -= ImGui::GetWindowWidth() + window_padding;
       clamp_window_position();
       if (g_ActiveConfig.bShowVPS)
         ImGui::TextColored(ImVec4(r, g, b, 1.0f), "VPS:%7.2lf", vps);


### PR DESCRIPTION
Collects many scattered OSD options into one place. I also did a little more than usual to align the group box columns so the QSpinBoxes look better.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/11676abb-e105-47a6-9b8d-ac1f1c4de86c" />

Looking for feedback.  There are a few OSD options left in Graphics -> Advanced, such as Show Projection Stats.  Not sure if those should stay in the debugging group box in Advanced or be moved. I'm thinking they should stay.

Graphics -> General -> Other only has two items in it now. Maybe those could just be moved to the Box above?

There could be multiple font size options for the various groups. Font size also scales everything up, so not sure if it should be called something else.

The Other Statistics (Movie window) feels like a collection of random stuff. Maybe that could get improved later.