### PR TITLE
Crash fix: Add debug check to JIT Profiling bool.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -197,7 +197,7 @@ public:
   JitBase& operator=(JitBase&&) = delete;
   ~JitBase() override;
 
-  bool IsProfilingEnabled() const { return m_enable_profiling; }
+  bool IsProfilingEnabled() const { return m_enable_profiling && m_enable_debugging; }
   bool IsDebuggingEnabled() const { return m_enable_debugging; }
 
   static const u8* Dispatch(JitBase& jit);


### PR DESCRIPTION
Add check to see if debugging is enabled in Jit's IsProfilingEnabled().

Enable JIT Block Profiling = On with Enable Debugging UI = Off, will crash dolphin when starting a game.