### PR TITLE
WiimoteReal/IOLinux: Improvements, fixes, and code cleanups.

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(common
   JsonUtil.cpp
   Lazy.h
   LinearDiskCache.h
+  UnixUtil.h
   Logging/ConsoleListener.h
   Logging/Log.h
   Logging/LogManager.cpp

--- a/Source/Core/Common/CommonFuncs.cpp
+++ b/Source/Core/Common/CommonFuncs.cpp
@@ -43,13 +43,18 @@ const char* StrErrorWrapper(int error, char* buffer, std::size_t length)
 #endif
 }
 
+std::string StrerrorString(int error)
+{
+  char error_message[BUFFER_SIZE];
+
+  return StrErrorWrapper(error, error_message, BUFFER_SIZE);
+}
+
 // Wrapper function to get last strerror(errno) string.
 // This function might change the error code.
 std::string LastStrerrorString()
 {
-  char error_message[BUFFER_SIZE];
-
-  return StrErrorWrapper(errno, error_message, BUFFER_SIZE);
+  return StrerrorString(errno);
 }
 
 #ifdef _WIN32

--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -45,8 +45,9 @@ namespace Common
 // strerror_r wrapper to handle XSI and GNU versions.
 const char* StrErrorWrapper(int error, char* buffer, std::size_t length);
 
-// Wrapper function to get last strerror(errno) string.
-// This function might change the error code.
+// Wrapper functions to get strerror(errno) string, which itself is not threadsafe.
+// These functions might change the error code.
+std::string StrerrorString(int error);
 std::string LastStrerrorString();
 
 #ifdef _WIN32

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -86,6 +86,21 @@ std::optional<MACAddress> StringToMacAddress(std::string_view mac_string)
   return std::make_optional(mac);
 }
 
+std::string BluetoothAddressToString(BluetoothAddress bdaddr)
+{
+  std::ranges::reverse(bdaddr);
+  return MacAddressToString(std::bit_cast<MACAddress>(bdaddr));
+}
+
+std::optional<BluetoothAddress> StringToBluetoothAddress(std::string_view str)
+{
+  auto result = StringToMacAddress(str);
+  if (!result)
+    return std::nullopt;
+  std::ranges::reverse(*result);
+  return std::bit_cast<BluetoothAddress>(*result);
+}
+
 EthernetHeader::EthernetHeader() = default;
 
 EthernetHeader::EthernetHeader(u16 ether_type) : ethertype(htons(ether_type))

--- a/Source/Core/Common/Network.h
+++ b/Source/Core/Common/Network.h
@@ -36,6 +36,12 @@ enum DHCPConst
 };
 
 using MACAddress = std::array<u8, MAC_ADDRESS_SIZE>;
+
+// Note: Bluetooth address display order is reverse of the storage order.
+struct BluetoothAddress : std::array<u8, MAC_ADDRESS_SIZE>
+{
+};
+
 constexpr std::size_t IPV4_ADDR_LEN = 4;
 using IPAddress = std::array<u8, IPV4_ADDR_LEN>;
 constexpr IPAddress IP_ADDR_ANY = {0, 0, 0, 0};
@@ -259,8 +265,13 @@ struct NetworkErrorState
 };
 
 MACAddress GenerateMacAddress(MACConsumer type);
+
 std::string MacAddressToString(const MACAddress& mac);
 std::optional<MACAddress> StringToMacAddress(std::string_view mac_string);
+
+std::string BluetoothAddressToString(BluetoothAddress bdaddr);
+std::optional<BluetoothAddress> StringToBluetoothAddress(std::string_view str);
+
 u16 ComputeNetworkChecksum(const void* data, u16 length, u32 initial_value = 0);
 u16 ComputeTCPNetworkChecksum(const IPAddress& from, const IPAddress& to, const void* data,
                               u16 length, u8 protocol);

--- a/Source/Core/Common/UnixUtil.h
+++ b/Source/Core/Common/UnixUtil.h
@@ -1,0 +1,62 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <pthread.h>
+#include <sys/eventfd.h>
+
+#include "Common/CommonFuncs.h"
+#include "Common/Logging/Log.h"
+
+namespace UnixUtil
+{
+inline int CreateEventFD(unsigned int count, int flags)
+{
+  const int result = eventfd(count, flags);
+  if (result == -1)
+  {
+    ERROR_LOG_FMT(COMMON, "eventfd failed: {}", Common::LastStrerrorString());
+    std::abort();
+  }
+  return result;
+}
+
+// Repeatedly call a function that can erroneously produce EINTR.
+auto RetryOnEINTR(auto func, auto... args)
+{
+  while (true)
+  {
+    const int result = func(args...);
+    if (result >= 0 || errno != EINTR)
+      return result;
+  }
+}
+
+// This is a very low-effort wrapper for pthread.
+// It allows creating a pthread from any callable (e.g. a lambda).
+// The wrapper object must exist for the lifetime of the thread.
+template <typename Func>
+struct PThreadWrapper
+{
+  Func func;
+  pthread_t handle{};
+
+  explicit PThreadWrapper(Func&& f) : func(std::move(f))
+  {
+    if (int result = pthread_create(
+            &handle, nullptr,
+            [](void* arg) -> void* {
+              static_cast<PThreadWrapper*>(arg)->func();
+              return nullptr;
+            },
+            this);
+        result != 0)
+    {
+      ERROR_LOG_FMT(COMMON, "pthread_create: {}", Common::StrerrorString(result));
+      std::abort();
+    }
+  }
+};
+
+}  // namespace UnixUtil

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
@@ -4,16 +4,26 @@
 #include "Core/HW/WiimoteReal/IOLinux.h"
 
 #include <ranges>
+#include <vector>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
 #include <bluetooth/l2cap.h>
+
+#include <sys/eventfd.h>
+#include <sys/ioctl.h>
 #include <sys/poll.h>
+#include <sys/signalfd.h>
+
 #include <unistd.h>
 
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/Network.h"
+#include "Common/ScopeGuard.h"
+#include "Common/UnixUtil.h"
 #include "Core/Config/MainSettings.h"
 
 namespace WiimoteReal
@@ -21,68 +31,195 @@ namespace WiimoteReal
 constexpr u16 L2CAP_PSM_HID_CNTL = 0x0011;
 constexpr u16 L2CAP_PSM_HID_INTR = 0x0013;
 
-WiimoteScannerLinux::WiimoteScannerLinux() : m_device_id(-1), m_device_sock(-1)
+static void AddAutoConnectAddresses(std::vector<Wiimote*>& found_wiimotes)
 {
+  std::string entries = Config::Get(Config::MAIN_WIIMOTE_AUTO_CONNECT_ADDRESSES);
+  for (auto& bt_address_str : SplitString(entries, ','))
+  {
+    const auto bt_addr = Common::StringToBluetoothAddress(bt_address_str);
+    if (!bt_addr.has_value())
+    {
+      WARN_LOG_FMT(WIIMOTE, "Bad Auto Connect Bluetooth Address: {}", bt_address_str);
+      continue;
+    }
+
+    Common::ToLower(&bt_address_str);
+    if (!IsNewWiimote(bt_address_str))
+      continue;
+
+    found_wiimotes.push_back(new WiimoteLinux(*bt_addr));
+    NOTICE_LOG_FMT(WIIMOTE, "Added Wiimote with fixed address ({}).", bt_address_str);
+  }
+}
+
+WiimoteScannerLinux::WiimoteScannerLinux()
+{
+  Open();
+}
+
+bool WiimoteScannerLinux::Open()
+{
+  if (IsReady())
+    return true;
+
   // Get the id of the first Bluetooth device.
   m_device_id = hci_get_route(nullptr);
   if (m_device_id < 0)
   {
-    NOTICE_LOG_FMT(WIIMOTE, "Bluetooth not found.");
-    return;
+    NOTICE_LOG_FMT(WIIMOTE, "Bluetooth not found. hci_get_route: {}", Common::LastStrerrorString());
+    return false;
   }
 
   // Create a socket to the device
   m_device_sock = hci_open_dev(m_device_id);
   if (m_device_sock < 0)
   {
-    ERROR_LOG_FMT(WIIMOTE, "Unable to open Bluetooth.");
-    return;
+    ERROR_LOG_FMT(WIIMOTE, "Unable to open Bluetooth. hci_open_dev: {}",
+                  Common::LastStrerrorString());
+    return false;
   }
+
+  m_is_device_open.store(true, std::memory_order_relaxed);
+  return true;
 }
 
 WiimoteScannerLinux::~WiimoteScannerLinux()
 {
-  if (IsReady())
-    close(m_device_sock);
+  Close();
+}
+
+void WiimoteScannerLinux::Close()
+{
+  if (!IsReady())
+    return;
+
+  m_is_device_open.store(false, std::memory_order_relaxed);
+
+  close(std::exchange(m_device_sock, -1));
+  m_device_id = -1;
 }
 
 bool WiimoteScannerLinux::IsReady() const
 {
-  return m_device_sock > 0;
+  return m_is_device_open.load(std::memory_order_relaxed);
+}
+
+struct InquiryRequest : hci_inquiry_req
+{
+  static constexpr int MAX_INFOS = 255;
+  std::array<inquiry_info, MAX_INFOS> scan_infos;
+};
+static_assert(sizeof(InquiryRequest) ==
+              sizeof(hci_inquiry_req) + sizeof(inquiry_info) * InquiryRequest::MAX_INFOS);
+
+// Returns 0 on success or some error number on failure.
+static int HciInquiry(int device_socket, InquiryRequest* request)
+{
+  const auto done_event = UnixUtil::CreateEventFD(0, 0);
+  Common::ScopeGuard close_guard([&] { close(done_event); });
+
+  int hci_inquiry_errorno = 0;
+
+  // Unplugging a BT adapter causes `hci_inquiry` to block forever (inside `ioctl`).
+  // Fortunately it does produce a signal on the socket so we can poll for that.
+  // Performing the inquiry on thread lets us interrupt `ioctl` if the socket signals.
+
+  // Using `pthread_cancel` with `std::thread` isn't technically correct so we use `pthread_create`.
+  UnixUtil::PThreadWrapper hci_inquiry_thread{[&] {
+    // We're manually doing the `ioctl` because `hci_inquiry` isn't pthread_cancel-safe.
+    // It uses `malloc` and whatnot.
+    const int ret = ioctl(device_socket, HCIINQUIRY, reinterpret_cast<unsigned long>(request));
+    if (ret < 0)
+      hci_inquiry_errorno = errno;
+
+    // Signal doneness to `poll`.
+    u64 val = 1;
+    write(done_event, &val, sizeof(val));
+  }};
+  Common::ScopeGuard join_guard([&] { pthread_join(hci_inquiry_thread.handle, nullptr); });
+
+  // Wait for the above thread or some socket signal.
+  std::array<pollfd, 2> pollfds{
+      pollfd{.fd = device_socket},
+      pollfd{.fd = done_event, .events = POLLIN},
+  };
+  UnixUtil::RetryOnEINTR(poll, pollfds.data(), pollfds.size(), -1);
+
+  if (pollfds[0].revents != 0)
+  {
+    ERROR_LOG_FMT(WIIMOTE, "HciInquiry device socket had error. Cancelling thread.");
+    // I am not entirely sure if this is foolproof, depending on where `ioctl` is internally?
+    // It's worked every time in testing though, and it's better than *always* freezing.
+    pthread_cancel(hci_inquiry_thread.handle);
+    return ENODEV;
+  }
+
+  return hci_inquiry_errorno;
 }
 
 void WiimoteScannerLinux::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wiimote*& found_board)
 {
-  WiimoteScannerLinux::AddAutoConnectAddresses(found_wiimotes);
-
-  int const wait_len = BLUETOOTH_INQUIRY_LENGTH;
-  int const max_infos = 255;
-  inquiry_info scan_infos[max_infos] = {};
-  auto* scan_infos_ptr = scan_infos;
   found_board = nullptr;
-  // Use Limited Dedicated Inquiry Access Code (LIAC) to query, since third-party Wiimotes
-  // cannot be discovered without it.
-  const u8 lap[3] = {0x00, 0x8b, 0x9e};
 
-  // Scan for Bluetooth devices
-  int const found_devices =
-      hci_inquiry(m_device_id, wait_len, max_infos, lap, &scan_infos_ptr, IREQ_CACHE_FLUSH);
-  if (found_devices < 0)
+  if (!Open())
+    return;
+
+  AddAutoConnectAddresses(found_wiimotes);
+
+  InquiryRequest request{};
+  request.dev_id = m_device_id;
+  request.flags = IREQ_CACHE_FLUSH;
+  request.length = BLUETOOTH_INQUIRY_LENGTH;
+  request.num_rsp = InquiryRequest::MAX_INFOS;
+  // Use Limited Dedicated Inquiry Access Code (LIAC) like the Wii does.
+  // Third-party Wiimotes cannot be discovered without it.
+  std::ranges::copy(std::to_array({0x00, 0x8b, 0x9e}), request.lap);
+
+  const int hci_inquiry_result = HciInquiry(m_device_sock, &request);
+  switch (hci_inquiry_result)
   {
-    ERROR_LOG_FMT(WIIMOTE, "Error searching for Bluetooth devices.");
+  case 0:
+    break;
+  case ENODEV:
+    Close();
+    [[fallthrough]];
+  default:
+    ERROR_LOG_FMT(WIIMOTE, "Error searching for Bluetooth devices: {}",
+                  Common::StrerrorString(hci_inquiry_result));
     return;
   }
 
-  DEBUG_LOG_FMT(WIIMOTE, "Found {} Bluetooth device(s).", found_devices);
+  DEBUG_LOG_FMT(WIIMOTE, "Found {} Bluetooth device(s).", request.num_rsp);
 
-  // Display discovered devices
-  for (auto& scan_info : scan_infos | std::ranges::views::take(found_devices))
+  for (auto& scan_info : request.scan_infos | std::ranges::views::take(request.num_rsp))
   {
-    // BT names are a maximum of 248 bytes apparently
-    char name[255] = {};
-    if (hci_read_remote_name(m_device_sock, &scan_info.bdaddr, sizeof(name), name, 1000) < 0)
+    const auto bdaddr_str =
+        BluetoothAddressToString(std::bit_cast<Common::BluetoothAddress>(scan_info.bdaddr));
+
+    // Did AddAutoConnectAddresses already add this remote?
+    const auto eq_this_bdaddr = [&](auto* wm) { return wm->GetId() == bdaddr_str; };
+    if (std::ranges::any_of(found_wiimotes, eq_this_bdaddr))
+      continue;
+
+    if (!IsNewWiimote(bdaddr_str))
     {
-      ERROR_LOG_FMT(WIIMOTE, "Bluetooth read remote name failed.");
+      WARN_LOG_FMT(WIIMOTE, "Discovered already connected device: {}", bdaddr_str);
+      continue;
+    }
+
+    // The Wii can actually connect remotes with a 10 second name response time.
+    // We won't wait quite so long since we're doing this in a blocking manner right now.
+    // Note that waiting just 1 second can be problematic sometimes.
+    const int read_name_timeout_ms = 3000;
+
+    // BT names are a maximum of 248 bytes.
+    char name[255]{};
+    if (hci_read_remote_name_with_clock_offset(m_device_sock, &scan_info.bdaddr,
+                                               scan_info.pscan_rep_mode, scan_info.clock_offset,
+                                               sizeof(name), name, read_name_timeout_ms) < 0)
+    {
+      ERROR_LOG_FMT(WIIMOTE, "Bluetooth read remote name failed. hci_read_remote_name: {}",
+                    Common::LastStrerrorString());
       continue;
     }
 
@@ -91,131 +228,91 @@ void WiimoteScannerLinux::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wi
     if (!IsValidDeviceName(name))
       continue;
 
-    char bdaddr_str[18] = {};
-    ba2str(&scan_info.bdaddr, bdaddr_str);
-
-    if (!IsNewWiimote(bdaddr_str))
-      continue;
-
     // Found a new device
-    Wiimote* wm = new WiimoteLinux(scan_info.bdaddr);
+    auto wm =
+        std::make_unique<WiimoteLinux>(std::bit_cast<Common::BluetoothAddress>(scan_info.bdaddr));
     if (IsBalanceBoardName(name))
     {
-      found_board = wm;
+      delete std::exchange(found_board, wm.release());
       NOTICE_LOG_FMT(WIIMOTE, "Found balance board ({}).", bdaddr_str);
     }
     else
     {
-      found_wiimotes.push_back(wm);
+      found_wiimotes.push_back(wm.release());
       NOTICE_LOG_FMT(WIIMOTE, "Found Wiimote ({}).", bdaddr_str);
     }
   }
 }
 
-void WiimoteScannerLinux::AddAutoConnectAddresses(std::vector<Wiimote*>& found_wiimotes)
-{
-  std::string entries = Config::Get(Config::MAIN_WIIMOTE_AUTO_CONNECT_ADDRESSES);
-  if (entries.empty())
-    return;
-  for (const auto& bt_address_str : SplitString(entries, ','))
-  {
-    bdaddr_t bt_addr;
-    if (str2ba(bt_address_str.c_str(), &bt_addr) < 0)
-    {
-      WARN_LOG_FMT(WIIMOTE, "Bad Known Bluetooth Address: {}", bt_address_str);
-      continue;
-    }
-    if (!IsNewWiimote(bt_address_str))
-      continue;
-    Wiimote* wm = new WiimoteLinux(bt_addr);
-    found_wiimotes.push_back(wm);
-    NOTICE_LOG_FMT(WIIMOTE, "Added Wiimote with fixed address ({}).", bt_address_str);
-  }
+void WiimoteScannerLinux::Update()
+{  // Nothing needed on Linux.
 }
 
-WiimoteLinux::WiimoteLinux(bdaddr_t bdaddr) : m_bdaddr(bdaddr)
+void WiimoteScannerLinux::RequestStopSearching()
+{  // Nothing needed on Linux.
+}
+
+WiimoteLinux::WiimoteLinux(Common::BluetoothAddress bdaddr)
+    : m_bdaddr{bdaddr}, m_wakeup_fd{UnixUtil::CreateEventFD(0, 0)}
 {
   m_really_disconnect = true;
-
-  m_cmd_sock = -1;
-  m_int_sock = -1;
-
-  int fds[2];
-  if (pipe(fds))
-  {
-    ERROR_LOG_FMT(WIIMOTE, "pipe failed");
-    abort();
-  }
-  m_wakeup_pipe_w = fds[1];
-  m_wakeup_pipe_r = fds[0];
 }
 
 WiimoteLinux::~WiimoteLinux()
 {
   Shutdown();
-  close(m_wakeup_pipe_w);
-  close(m_wakeup_pipe_r);
+  close(m_wakeup_fd);
+}
+
+std::string WiimoteLinux::GetId() const
+{
+  return BluetoothAddressToString(m_bdaddr);
 }
 
 // Connect to a Wiimote with a known address.
 bool WiimoteLinux::ConnectInternal()
 {
-  sockaddr_l2 addr = {};
-  addr.l2_family = AF_BLUETOOTH;
-  addr.l2_bdaddr = m_bdaddr;
-  addr.l2_cid = 0;
+  sockaddr_l2 addr{
+      .l2_family = AF_BLUETOOTH,
+      .l2_bdaddr = std::bit_cast<bdaddr_t>(m_bdaddr),
+      .l2_cid = 0,
+  };
 
-  // Control channel
-  addr.l2_psm = htobs(L2CAP_PSM_HID_CNTL);
-  if ((m_cmd_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP)))
-  {
-    int retry = 0;
-    while (connect(m_cmd_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
+  const auto open_channel = [&](u16 l2_psm) {
+    addr.l2_psm = htobs(l2_psm);
+
+    constexpr int total_tries = 3;
+    for (int i = 0; i != total_tries; ++i)
     {
-      // If opening channel fails sleep and try again
-      if (retry == 3)
+      const int descriptor = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
+      if (descriptor == -1)
       {
-        WARN_LOG_FMT(WIIMOTE, "Unable to connect control channel of Wiimote: {}", strerror(errno));
-        close(m_cmd_sock);
-        m_cmd_sock = -1;
-        return false;
+        WARN_LOG_FMT(WIIMOTE, "Failed to create L2CAP socket: {}", Common::LastStrerrorString());
+        return -1;
       }
-      retry++;
-      sleep(1);
+
+      if (connect(descriptor, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) == 0)
+        return descriptor;
+
+      // If connecting fails sleep and try again.
+      WARN_LOG_FMT(WIIMOTE, "Failed to connect L2CAP PSM({}) socket: {}", l2_psm,
+                   Common::LastStrerrorString());
+      // A socket state is unspecified after connect() fails, so close and recreate it.
+      close(descriptor);
+      std::this_thread::sleep_for(std::chrono::milliseconds{500});
     }
-  }
-  else
-  {
-    WARN_LOG_FMT(WIIMOTE, "Unable to open control socket to Wiimote: {}", strerror(errno));
+
+    return -1;
+  };
+
+  m_cmd_sock = open_channel(L2CAP_PSM_HID_CNTL);
+  if (m_cmd_sock == -1)
     return false;
-  }
 
-  // Interrupt channel
-  addr.l2_psm = htobs(L2CAP_PSM_HID_INTR);
-  if ((m_int_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP)))
+  m_int_sock = open_channel(L2CAP_PSM_HID_INTR);
+  if (m_int_sock == -1)
   {
-    int retry = 0;
-    while (connect(m_int_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
-    {
-      // If opening channel fails sleep and try again
-      if (retry == 3)
-      {
-        WARN_LOG_FMT(WIIMOTE, "Unable to connect interrupt channel of Wiimote: {}",
-                     strerror(errno));
-        close(m_int_sock);
-        close(m_cmd_sock);
-        m_int_sock = m_cmd_sock = -1;
-        return false;
-      }
-      retry++;
-      sleep(1);
-    }
-  }
-  else
-  {
-    WARN_LOG_FMT(WIIMOTE, "Unable to open interrupt socket to Wiimote: {}", strerror(errno));
-    close(m_cmd_sock);
-    m_int_sock = m_cmd_sock = -1;
+    close(std::exchange(m_cmd_sock, -1));
     return false;
   }
 
@@ -224,11 +321,8 @@ bool WiimoteLinux::ConnectInternal()
 
 void WiimoteLinux::DisconnectInternal()
 {
-  close(m_cmd_sock);
-  close(m_int_sock);
-
-  m_cmd_sock = -1;
-  m_int_sock = -1;
+  close(std::exchange(m_cmd_sock, -1));
+  close(std::exchange(m_int_sock, -1));
 }
 
 bool WiimoteLinux::IsConnected() const
@@ -238,10 +332,10 @@ bool WiimoteLinux::IsConnected() const
 
 void WiimoteLinux::IOWakeup()
 {
-  char c = 0;
-  if (write(m_wakeup_pipe_w, &c, 1) != 1)
+  u64 counter = 1;
+  if (write(m_wakeup_fd, &counter, sizeof(counter)) != sizeof(counter))
   {
-    ERROR_LOG_FMT(WIIMOTE, "Unable to write to wakeup pipe.");
+    ERROR_LOG_FMT(WIIMOTE, "failed to write to wakeup eventfd: {}", Common::LastStrerrorString());
   }
 }
 
@@ -250,60 +344,47 @@ void WiimoteLinux::IOWakeup()
 // zero = error
 int WiimoteLinux::IORead(u8* buf)
 {
-  std::array<pollfd, 2> pollfds = {};
+  std::array<pollfd, 2> pollfds{
+      pollfd{.fd = m_wakeup_fd, .events = POLLIN},
+      pollfd{.fd = m_int_sock, .events = POLLIN},
+  };
+  UnixUtil::RetryOnEINTR(poll, pollfds.data(), pollfds.size(), -1);
 
-  auto& poll_wakeup = pollfds[0];
-  poll_wakeup.fd = m_wakeup_pipe_r;
-  poll_wakeup.events = POLLIN;
-
-  auto& poll_sock = pollfds[1];
-  poll_sock.fd = m_int_sock;
-  poll_sock.events = POLLIN;
-
-  if (poll(pollfds.data(), pollfds.size(), -1) == -1)
+  // Handle IOWakeup.
+  if (pollfds[0].revents != 0)
   {
-    ERROR_LOG_FMT(WIIMOTE, "Unable to poll Wiimote {} input socket.", m_index + 1);
-    return -1;
-  }
-
-  if (poll_wakeup.revents & POLLIN)
-  {
-    char c;
-    if (read(m_wakeup_pipe_r, &c, 1) != 1)
+    DEBUG_LOG_FMT(WIIMOTE, "IOWakeup");
+    u64 counter{};
+    if (read(m_wakeup_fd, &counter, sizeof(counter)) != sizeof(counter))
     {
-      ERROR_LOG_FMT(WIIMOTE, "Unable to read from wakeup pipe.");
+      ERROR_LOG_FMT(WIIMOTE, "Failed to read from wakeup eventfd: {}",
+                    Common::LastStrerrorString());
+      return 0;
     }
     return -1;
   }
 
-  if (!(poll_sock.revents & POLLIN))
-    return -1;
-
-  // Read the pending message into the buffer
-  int r = read(m_int_sock, buf, MAX_PAYLOAD);
-  if (r == -1)
+  // Handle event on interrupt channel.
+  auto result = int(read(m_int_sock, buf, MAX_PAYLOAD));
+  if (result == -1)
   {
-    // Error reading data
-    ERROR_LOG_FMT(WIIMOTE, "Receiving data from Wiimote {}.", m_index + 1);
-
-    if (errno == ENOTCONN)
-    {
-      // This can happen if the Bluetooth dongle is disconnected
-      ERROR_LOG_FMT(WIIMOTE,
-                    "Bluetooth appears to be disconnected.  "
-                    "Wiimote {} will be disconnected.",
-                    m_index + 1);
-    }
-
-    r = 0;
+    ERROR_LOG_FMT(WIIMOTE, "Wiimote {} read failed: {}", m_index + 1, Common::LastStrerrorString());
+    result = 0;
   }
 
-  return r;
+  return result;
 }
 
 int WiimoteLinux::IOWrite(u8 const* buf, size_t len)
 {
-  return write(m_int_sock, buf, (int)len);
+  auto result = int(write(m_int_sock, buf, int(len)));
+  if (result == -1)
+  {
+    ERROR_LOG_FMT(WIIMOTE, "Wiimote {} write failed: {}", m_index + 1,
+                  Common::LastStrerrorString());
+  }
+
+  return result;
 }
 
-};  // namespace WiimoteReal
+}  // namespace WiimoteReal

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
@@ -55,9 +55,7 @@ void WiimoteScannerLinux::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wi
 {
   WiimoteScannerLinux::AddAutoConnectAddresses(found_wiimotes);
 
-  // supposedly 1.28 seconds
-  int const wait_len = 1;
-
+  int const wait_len = BLUETOOTH_INQUIRY_LENGTH;
   int const max_infos = 255;
   inquiry_info scan_infos[max_infos] = {};
   auto* scan_infos_ptr = scan_infos;

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.h
@@ -4,8 +4,10 @@
 #pragma once
 
 #if defined(__linux__) && HAVE_BLUEZ
-#include <bluetooth/bluetooth.h>
 
+#include <atomic>
+
+#include "Common/Network.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 
 namespace WiimoteReal
@@ -13,14 +15,10 @@ namespace WiimoteReal
 class WiimoteLinux final : public Wiimote
 {
 public:
-  WiimoteLinux(bdaddr_t bdaddr);
+  explicit WiimoteLinux(Common::BluetoothAddress bdaddr);
   ~WiimoteLinux() override;
-  std::string GetId() const override
-  {
-    char bdaddr_str[18] = {};
-    ba2str(&m_bdaddr, bdaddr_str);
-    return bdaddr_str;
-  }
+
+  std::string GetId() const override;
 
 protected:
   bool ConnectInternal() override;
@@ -31,11 +29,10 @@ protected:
   int IOWrite(u8 const* buf, size_t len) override;
 
 private:
-  bdaddr_t m_bdaddr;  // Bluetooth address
-  int m_cmd_sock;     // Command socket
-  int m_int_sock;     // Interrupt socket
-  int m_wakeup_pipe_w;
-  int m_wakeup_pipe_r;
+  const Common::BluetoothAddress m_bdaddr;
+  const int m_wakeup_fd{-1};  // Used to kick the read thread.
+  int m_cmd_sock{-1};         // Command socket
+  int m_int_sock{-1};         // Interrupt socket
 };
 
 class WiimoteScannerLinux final : public WiimoteScannerBackend
@@ -43,16 +40,23 @@ class WiimoteScannerLinux final : public WiimoteScannerBackend
 public:
   WiimoteScannerLinux();
   ~WiimoteScannerLinux() override;
+
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
-  void Update() override {}                // not needed on Linux
-  void RequestStopSearching() override {}  // not needed on Linux
-private:
-  int m_device_id;
-  int m_device_sock;
+  void Update() override;
+  void RequestStopSearching() override;
 
-  void AddAutoConnectAddresses(std::vector<Wiimote*>&);
+private:
+  bool Open();
+  void Close();
+
+  int m_device_id{-1};
+  int m_device_sock{-1};
+
+  // FYI: Atomic because UI calls IsReady.
+  std::atomic<bool> m_is_device_open{};
 };
+
 }  // namespace WiimoteReal
 
 #else

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -33,6 +33,9 @@ constexpr int REPORT_HID_HEADER_SIZE = 1;
 
 constexpr u32 WIIMOTE_DEFAULT_TIMEOUT = 1000;
 
+// Multiple of 1.28 seconds. Wii games use a value of 3.
+constexpr u8 BLUETOOTH_INQUIRY_LENGTH = 3;
+
 // The 4 most significant bits of the first byte of an outgoing command must be
 // 0x50 if sending on the command channel and 0xA0 if sending on the interrupt
 // channel. On Mac and Linux we use interrupt channel; on Windows, command.

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -175,7 +175,10 @@ class WiimoteScannerBackend
 {
 public:
   virtual ~WiimoteScannerBackend() = default;
+
+  // Note: Invoked from UI thread.
   virtual bool IsReady() const = 0;
+
   virtual void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) = 0;
   // function called when not looking for more Wiimotes
   virtual void Update() = 0;


### PR DESCRIPTION
This improves WiimoteReal (the `Emulate the Wii's Bluetooth adapter` and `Connect Wii Remotes for Emulated Controllers` paths) mainly on Linux.

Increased the inquiry length parameter to 3.84 seconds.
It was previously 1.28s on Linux (and still 2.56s on Windows).
It's now the value that Wii games use and it seems to be much more reliable on Linux.

Majorly cleaned up and fixed bugs in the WiimoteReal/IOLinux code.

Fixed the issue where a Wii remote could not be reconnected after being disconnected.
`WiimoteLinux::IORead` failed to account for `poll` returning signals on the interrupt socket.
https://bugs.dolphin-emu.org/issues/13615

Bluetooth adapters can now be unplugged/replugged while Dolphin is running.
It previously would fail forever if an adapter was unplugged at any point.

Increased `hci_read_remote_name` timeout from 1 to 3 seconds.
Previously, it would frequently fail if a remote took a bit longer than a second.
`hci_read_remote_name_with_clock_offset` is now used which is apparently a bit more reliable by using clock information from the previous inquiry.

Improved error checking and logging.

Connecting remotes on Linux is much improved.
Both `Continuous Scanning` and `Refresh` are able to connect remotes much more reliably.