### PR TITLE
WiimoteEmu: Require IRPassthrough has any bound inputs to operate. 

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -497,7 +497,7 @@ void Wiimote::BuildDesiredWiimoteState(DesiredWiimoteState* target_state,
       ConvertAccelData(GetTotalAcceleration(), ACCEL_ZERO_G << 2, ACCEL_ONE_G << 2);
 
   // Calculate IR camera state.
-  if (m_ir_passthrough->enabled.GetValue())
+  if (m_ir_passthrough->enabled.GetValue() && m_ir_passthrough->AreInputsBound())
   {
     target_state->camera_points = GetPassthroughCameraPoints(m_ir_passthrough);
   }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IRPassthrough.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IRPassthrough.cpp
@@ -3,15 +3,12 @@
 
 #include "InputCommon/ControllerEmu/ControlGroup/IRPassthrough.h"
 
-#include <memory>
+#include <algorithm>
 #include <string>
 
 #include "Common/Common.h"
-#include "Common/MathUtil.h"
 
-#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
-#include "InputCommon/ControllerEmu/Control/Input.h"
 
 namespace ControllerEmu
 {
@@ -46,6 +43,12 @@ ControlState IRPassthrough::GetObjectPositionY(size_t object_index) const
 ControlState IRPassthrough::GetObjectSize(size_t object_index) const
 {
   return controls[object_index * 3 + 2]->GetState();
+}
+
+bool IRPassthrough::AreInputsBound() const
+{
+  return std::ranges::any_of(
+      controls, [](const auto& control) { return control->control_ref->BoundCount() > 0; });
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IRPassthrough.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IRPassthrough.h
@@ -6,7 +6,6 @@
 #include <string>
 
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
-#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
 namespace ControllerEmu
@@ -19,5 +18,7 @@ public:
   ControlState GetObjectPositionX(size_t object_index) const;
   ControlState GetObjectPositionY(size_t object_index) const;
   ControlState GetObjectSize(size_t object_index) const;
+
+  bool AreInputsBound() const;
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
Users get confused and mistakenly enable it.

Now it operates similarly to accel/gyro, having no effect unless the configured inputs are actually present on the selected device.
And of course the `Enabled` setting must still be set.