### PR TITLE
macoS: update QoSSession with SO_NET_SERVICE_TYPE.

### DIFF
--- a/Source/Core/Common/QoSSession.cpp
+++ b/Source/Core/Common/QoSSession.cpp
@@ -54,6 +54,15 @@ QoSSession::~QoSSession()
 #else
 QoSSession::QoSSession(ENetPeer* peer, int tos_val)
 {
+// Apple systems don't support SO_PRIORITY on BSD sockets, but they do support a flag for
+// marking sockets as a specific type of traffic. `NET_SERVICE_TYPE_RV` should roughly
+// correspond to "low delay tolerant, low-medium loss tolerant, elastic flow, variable
+// packet interval, rate and size".
+#if defined(__APPLE__)
+  constexpr int srv_type = NET_SERVICE_TYPE_RV;
+  setsockopt(peer->host->socket, SOL_SOCKET, SO_NET_SERVICE_TYPE, &srv_type, sizeof(srv_type));
+#endif
+
 #if defined(__linux__)
   constexpr int priority = 7;
   setsockopt(peer->host->socket, SOL_SOCKET, SO_PRIORITY, &priority, sizeof(priority));


### PR DESCRIPTION
macOS does not support `SO_PRIORITY` on BSD sockets, but it does apparently support configuring sockets with a priority flag via a parameter called `SO_NET_SERVICE_TYPE`. It doesn't appear to be especially well documented, but it seems to exist as far back as 10.11 (El Capitan).

This patch sets QoSSession to treat connections as "responsive multimedia audio/video", which some docs appear to describe as "low delay tolerant, low-medium, loss tolerant, elastic flow, variable packet interval, rate and size".

[This page](https://developer.cisco.com/codeexchange/github/repo/CiscoDevNet/fastlane-udp-client-app/) has an easy list of the available `NET_SERVICE_TYPE_*` values, if anyone wants to consider a different value. `NET_SERVICE_TYPE_RV` seemed the most appropriate to me for a netplay connection but I defer to anyone who might have more insight.