### PR TITLE
Remove calls to Analytics when disabled at compile time

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -40,7 +40,9 @@
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
@@ -566,7 +568,9 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Initialize(J
   UICommon::CreateDirectories();
   Common::RegisterMsgAlertHandler(&MsgAlert);
   Common::AndroidSetReportHandler(&ReportSend);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
   DolphinAnalytics::AndroidSetGetValFunc(&GetAnalyticValue);
+#endif
 
   WiimoteReal::InitAdapterClass();
   UICommon::Init();
@@ -576,13 +580,17 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Initialize(J
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ReportStartToAnalytics(JNIEnv*,
                                                                                            jclass)
 {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
   DolphinAnalytics::Instance().ReportDolphinStart(GetAnalyticValue("DEVICE_TYPE"));
+#endif
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GenerateNewStatisticsId(JNIEnv*,
                                                                                             jclass)
 {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
   DolphinAnalytics::Instance().GenerateNewIdentity();
+#endif
 }
 
 // Returns the scale factor for imgui rendering.

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -39,7 +39,9 @@
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/Core.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/FifoPlayer/FifoDataFile.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HW/DVD/DVDInterface.h"
@@ -247,8 +249,10 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
 
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
   if (is_running_or_starting)
     DolphinAnalytics::Instance().ReportGameStart();
+#endif
 }
 
 void SConfig::OnESTitleChanged()

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -46,7 +46,9 @@
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/DSPEmulator.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/FreeLookManager.h"
 #include "Core/HLE/HLE.h"
@@ -355,8 +357,10 @@ static void CpuThread(Core::System& system, const std::optional<std::string>& sa
   else
     Common::SetCurrentThreadName("CPU-GPU thread");
 
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
   // This needs to be delayed until after the video backend is ready.
   DolphinAnalytics::Instance().ReportGameStart();
+#endif
 
   // Clear performance data collected from previous threads.
   g_perf_metrics.Reset();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -16,7 +16,9 @@
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
 #include "Core/Core.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/MailHandler.h"
@@ -180,7 +182,9 @@ void AXUCode::HandleCommandList()
       break;
 
     case CMD_UNK_08:
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesUnimplementedAXCommand);
+#endif
       curr_idx += 10;
       break;  // TODO: check
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -18,7 +18,9 @@
 
 #include "Common/CommonTypes.h"
 #include "Core/DSP/DSPAccelerator.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/UCodes/AX.h"
 #include "Core/HW/DSPHLE/UCodes/AXStructs.h"
@@ -536,7 +538,9 @@ void ProcessVoice(HLEAccelerator* accelerator, PB_TYPE& pb, const AXBuffers& buf
   if (pb.initial_time_delay.on)
   {
     // TODO
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesAXInitialTimeDelay);
+#endif
   }
 
 #ifdef AX_WII
@@ -548,12 +552,16 @@ void ProcessVoice(HLEAccelerator* accelerator, PB_TYPE& pb, const AXBuffers& buf
       // Only one filter at most for Wiimotes.
       if (pb.remote_iir.on == 2)
       {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
         DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesAXWiimoteBiquad);
+#endif
         BiquadFilter(samples, count, pb.remote_iir.biquad);
       }
       else
       {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
         DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesAXWiimoteLowPass);
+#endif
         LowPassFilter(samples, count, pb.remote_iir.lpf);
       }
     }

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -25,7 +25,9 @@
 #include "Core/Config/SessionSettings.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/AudioInterface.h"
 #include "Core/HW/DVD/DVDMath.h"
 #include "Core/HW/DVD/DVDThread.h"
@@ -885,14 +887,18 @@ void DVDInterface::ExecuteCommand(ReplyType reply_type)
   // Wii-exclusive
   case DICommand::StopLaser:
     ERROR_LOG_FMT(DVDINTERFACE, "DVDLowStopLaser");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDVDLowStopLaser);
+#endif
     SetDriveError(DriveError::InvalidCommand);
     interrupt_type = DIInterruptType::DEINT;
     break;
   // Wii-exclusive
   case DICommand::Offset:
     ERROR_LOG_FMT(DVDINTERFACE, "DVDLowOffset");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDVDLowOffset);
+#endif
     SetDriveError(DriveError::InvalidCommand);
     interrupt_type = DIInterruptType::DEINT;
     break;
@@ -900,7 +906,9 @@ void DVDInterface::ExecuteCommand(ReplyType reply_type)
   case DICommand::ReadBCA:
   {
     WARN_LOG_FMT(DVDINTERFACE, "DVDLowReadDiskBca - supplying dummy data to appease NSMBW");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDVDLowReadDiskBCA);
+#endif
     // NSMBW checks that the first 0x33 bytes of the BCA are 0, then it expects a 1.
     // Most (all?) other games have 0x34 0's at the start of the BCA, but don't actually
     // read it.  NSMBW doesn't care about the other 12 bytes (which contain manufacturing data?)
@@ -915,14 +923,18 @@ void DVDInterface::ExecuteCommand(ReplyType reply_type)
   // Wii-exclusive
   case DICommand::RequestDiscStatus:
     ERROR_LOG_FMT(DVDINTERFACE, "DVDLowRequestDiscStatus");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDVDLowRequestDiscStatus);
+#endif
     SetDriveError(DriveError::InvalidCommand);
     interrupt_type = DIInterruptType::DEINT;
     break;
   // Wii-exclusive
   case DICommand::RequestRetryNumber:
     ERROR_LOG_FMT(DVDINTERFACE, "DVDLowRequestRetryNumber");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDVDLowRequestRetryNumber);
+#endif
     SetDriveError(DriveError::InvalidCommand);
     interrupt_type = DIInterruptType::DEINT;
     break;
@@ -935,7 +947,9 @@ void DVDInterface::ExecuteCommand(ReplyType reply_type)
   // Wii-exclusive
   case DICommand::SerMeasControl:
     ERROR_LOG_FMT(DVDINTERFACE, "DVDLowSerMeasControl");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDVDLowSerMeasControl);
+#endif
     SetDriveError(DriveError::InvalidCommand);
     interrupt_type = DIInterruptType::DEINT;
     break;

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -13,7 +13,9 @@
 #include "Common/MsgHandler.h"
 #include "Core/Config/SessionSettings.h"
 #include "Core/CoreTiming.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/DVD/DVDThread.h"
 #include "Core/HW/MMIO.h"
@@ -261,7 +263,9 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   case DIIoctl::DVDLowMaskCoverInterrupt:
     INFO_LOG_FMT(IOS_DI, "DVDLowMaskCoverInterrupt");
     system.GetDVDInterface().SetInterruptEnabled(DVD::DIInterruptType::CVRINT, false);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDIInterruptMaskCommand);
+#endif
     return DIResult::Success;
   case DIIoctl::DVDLowClearCoverInterrupt:
     DEBUG_LOG_FMT(IOS_DI, "DVDLowClearCoverInterrupt");
@@ -269,7 +273,9 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return DIResult::Success;
   case DIIoctl::DVDLowUnmaskStatusInterrupts:
     INFO_LOG_FMT(IOS_DI, "DVDLowUnmaskStatusInterrupts");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDIInterruptMaskCommand);
+#endif
     // Dummied out
     return DIResult::Success;
   case DIIoctl::DVDLowGetCoverStatus:
@@ -282,7 +288,9 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   case DIIoctl::DVDLowUnmaskCoverInterrupt:
     INFO_LOG_FMT(IOS_DI, "DVDLowUnmaskCoverInterrupt");
     system.GetDVDInterface().SetInterruptEnabled(DVD::DIInterruptType::CVRINT, true);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDIInterruptMaskCommand);
+#endif
     return DIResult::Success;
   case DIIoctl::DVDLowReset:
   {
@@ -319,7 +327,9 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowOpenPartition:
     ERROR_LOG_FMT(IOS_DI, "DVDLowOpenPartition as an ioctl - rejecting");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     return DIResult::SecurityError;
   case DIIoctl::DVDLowClosePartition:
     INFO_LOG_FMT(IOS_DI, "DVDLowClosePartition");
@@ -372,23 +382,33 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   // Dolphin as games are unlikely to use them.
   case DIIoctl::DVDLowGetNoDiscOpenPartitionParams:
     ERROR_LOG_FMT(IOS_DI, "DVDLowGetNoDiscOpenPartitionParams as an ioctl - rejecting");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     return DIResult::SecurityError;
   case DIIoctl::DVDLowNoDiscOpenPartition:
     ERROR_LOG_FMT(IOS_DI, "DVDLowNoDiscOpenPartition as an ioctl - rejecting");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     return DIResult::SecurityError;
   case DIIoctl::DVDLowGetNoDiscBufferSizes:
     ERROR_LOG_FMT(IOS_DI, "DVDLowGetNoDiscBufferSizes as an ioctl - rejecting");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     return DIResult::SecurityError;
   case DIIoctl::DVDLowOpenPartitionWithTmdAndTicket:
     ERROR_LOG_FMT(IOS_DI, "DVDLowOpenPartitionWithTmdAndTicket as an ioctl - rejecting");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     return DIResult::SecurityError;
   case DIIoctl::DVDLowOpenPartitionWithTmdAndTicketView:
     ERROR_LOG_FMT(IOS_DI, "DVDLowOpenPartitionWithTmdAndTicketView as an ioctl - rejecting");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     return DIResult::SecurityError;
   case DIIoctl::DVDLowGetStatusRegister:
   {
@@ -721,14 +741,18 @@ std::optional<IPCReply> DIDevice::IOCtlV(const IOCtlVRequest& request)
     {
       ERROR_LOG_FMT(IOS_DI,
                     "DVDLowOpenPartition with ticket - not implemented, ignoring ticket parameter");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     }
     if (request.in_vectors[2].address != 0)
     {
       ERROR_LOG_FMT(
           IOS_DI,
           "DVDLowOpenPartition with cert chain - not implemented, ignoring certs parameter");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     }
 
     const u64 partition_offset =
@@ -752,26 +776,36 @@ std::optional<IPCReply> DIDevice::IOCtlV(const IOCtlVRequest& request)
   }
   case DIIoctl::DVDLowGetNoDiscOpenPartitionParams:
     ERROR_LOG_FMT(IOS_DI, "DVDLowGetNoDiscOpenPartitionParams - dummied out");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     request.DumpUnknown(system, GetDeviceName(), Common::Log::LogType::IOS_DI);
     break;
   case DIIoctl::DVDLowNoDiscOpenPartition:
     ERROR_LOG_FMT(IOS_DI, "DVDLowNoDiscOpenPartition - dummied out");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     request.DumpUnknown(system, GetDeviceName(), Common::Log::LogType::IOS_DI);
     break;
   case DIIoctl::DVDLowGetNoDiscBufferSizes:
     ERROR_LOG_FMT(IOS_DI, "DVDLowGetNoDiscBufferSizes - dummied out");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     request.DumpUnknown(system, GetDeviceName(), Common::Log::LogType::IOS_DI);
     break;
   case DIIoctl::DVDLowOpenPartitionWithTmdAndTicket:
     ERROR_LOG_FMT(IOS_DI, "DVDLowOpenPartitionWithTmdAndTicket - not implemented");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     break;
   case DIIoctl::DVDLowOpenPartitionWithTmdAndTicketView:
     ERROR_LOG_FMT(IOS_DI, "DVDLowOpenPartitionWithTmdAndTicketView - not implemented");
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesDifferentPartitionCommand);
+#endif
     break;
   default:
     ERROR_LOG_FMT(IOS_DI, "Unknown ioctlv {:#04x}", request.request);

--- a/Source/Core/Core/IOS/Network/WD/Command.cpp
+++ b/Source/Core/Core/IOS/Network/WD/Command.cpp
@@ -11,7 +11,9 @@
 #include "Common/Logging/Log.h"
 #include "Common/Network.h"
 #include "Common/Swap.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/MACUtils.h"
 #include "Core/System.h"
@@ -198,7 +200,9 @@ std::optional<IPCReply> NetWDCommandDevice::Open(const OpenRequest& request)
     if (mode != WD::Mode::DSCommunications && mode != WD::Mode::AOSSAccessPointScan)
     {
       ERROR_LOG_FMT(IOS_NET, "Unsupported WD operating mode: {}", mode);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesUncommonWDMode);
+#endif
       return IPCReply(s32(ResultCode::UnavailableCommand));
     }
 
@@ -390,7 +394,9 @@ std::optional<IPCReply> NetWDCommandDevice::IOCtlV(const IOCtlVRequest& request)
   case IOCTLV_WD_CHANGE_GAMEINFO:
   case IOCTLV_WD_CHANGE_VTSF:
   default:
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesWDUnimplementedIOCtl);
+#endif
     request.Dump(GetSystem(), GetDeviceName(), Common::Log::LogType::IOS_NET,
                  Common::Log::LogLevel::LWARNING);
   }

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -20,7 +20,9 @@
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
 #include "Core/Core.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/Host.h"
 #include "Core/System.h"
 
@@ -306,7 +308,9 @@ int main(const int argc, char* argv[])
   sigaction(SIGTERM, &sa, nullptr);
 #endif
 
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
   DolphinAnalytics::Instance().ReportDolphinStart("nogui");
+#endif
 
   if (!BootManager::BootCore(Core::System::GetInstance(), std::move(boot), wsi))
   {

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -28,7 +28,9 @@
 #include "Core/Boot/Boot.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/System.h"
 
 #include "DolphinQt/Host.h"
@@ -254,7 +256,9 @@ int main(int argc, char* argv[])
   }
   else
   {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportDolphinStart("qt");
+#endif
 
     Settings::Instance().InitDefaultPalette();
     Settings::Instance().ApplyStyle();

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -20,7 +20,9 @@
 #include "Core/Config/UISettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -15,7 +15,9 @@
 #include "Common/Logging/Log.h"
 
 #include "Core/CoreTiming.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/Memmap.h"
@@ -785,7 +787,9 @@ static void BPWritten(PixelShaderManager& pixel_shader_manager, XFStateManager& 
     break;
   }
 
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
   DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesUnknownBPCommand);
+#endif
   WARN_LOG_FMT(VIDEO, "Unknown BP opcode: address = {:#010x} value = {:#010x}", bp.address,
                bp.newvalue);
 }

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -9,7 +9,9 @@
 #include "Common/ChunkFile.h"
 #include "Common/EnumUtils.h"
 #include "Common/Logging/Log.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/System.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/VertexLoaderManager.h"
@@ -99,7 +101,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
     if (!(sub_cmd == UNKNOWN_20 && value == 0))
     {
       // All titles using libogc or the official SDK issue 0x20 with value=0 on startup
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesCPPerfCommand);
+#endif
       DEBUG_LOG_FMT(VIDEO, "Unknown CP command possibly relating to perf queries used: {:02x}",
                     sub_cmd);
     }
@@ -108,7 +112,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
   case MATINDEX_A:
     if (sub_cmd != MATINDEX_A)
     {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesMaybeInvalidCPCommand);
+#endif
       WARN_LOG_FMT(VIDEO,
                    "CP MATINDEX_A: an exact value of {:02x} was expected "
                    "but instead a value of {:02x} was seen",
@@ -121,7 +127,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
   case MATINDEX_B:
     if (sub_cmd != MATINDEX_B)
     {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesMaybeInvalidCPCommand);
+#endif
       WARN_LOG_FMT(VIDEO,
                    "CP MATINDEX_B: an exact value of {:02x} was expected "
                    "but instead a value of {:02x} was seen",
@@ -134,7 +142,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
   case VCD_LO:
     if (sub_cmd != VCD_LO)  // Stricter than YAGCD
     {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesMaybeInvalidCPCommand);
+#endif
       WARN_LOG_FMT(VIDEO,
                    "CP VCD_LO: an exact value of {:02x} was expected "
                    "but instead a value of {:02x} was seen",
@@ -147,7 +157,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
   case VCD_HI:
     if (sub_cmd != VCD_HI)  // Stricter than YAGCD
     {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesMaybeInvalidCPCommand);
+#endif
       WARN_LOG_FMT(VIDEO,
                    "CP VCD_HI: an exact value of {:02x} was expected "
                    "but instead a value of {:02x} was seen",
@@ -160,7 +172,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
   case CP_VAT_REG_A:
     if ((sub_cmd - CP_VAT_REG_A) >= CP_NUM_VAT_REG)
     {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesMaybeInvalidCPCommand);
+#endif
       WARN_LOG_FMT(VIDEO, "CP_VAT_REG_A: Invalid VAT {}", sub_cmd - CP_VAT_REG_A);
     }
     vtx_attr[sub_cmd & CP_VAT_MASK].g0.Hex = value;
@@ -169,7 +183,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
   case CP_VAT_REG_B:
     if ((sub_cmd - CP_VAT_REG_B) >= CP_NUM_VAT_REG)
     {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesMaybeInvalidCPCommand);
+#endif
       WARN_LOG_FMT(VIDEO, "CP_VAT_REG_B: Invalid VAT {}", sub_cmd - CP_VAT_REG_B);
     }
     vtx_attr[sub_cmd & CP_VAT_MASK].g1.Hex = value;
@@ -178,7 +194,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
   case CP_VAT_REG_C:
     if ((sub_cmd - CP_VAT_REG_C) >= CP_NUM_VAT_REG)
     {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesMaybeInvalidCPCommand);
+#endif
       WARN_LOG_FMT(VIDEO, "CP_VAT_REG_C: Invalid VAT {}", sub_cmd - CP_VAT_REG_C);
     }
     vtx_attr[sub_cmd & CP_VAT_MASK].g2.Hex = value;
@@ -195,7 +213,9 @@ void CPState::LoadCPReg(u8 sub_cmd, u32 value)
     break;
 
   default:
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesUnknownCPCommand);
+#endif
     WARN_LOG_FMT(VIDEO, "Unknown CP register {:02x} set to {:08x}", sub_cmd, value);
   }
 }

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -6,7 +6,9 @@
 #include <map>
 
 #include "Common/Logging/LogManager.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 
 namespace DriverDetails
 {
@@ -312,6 +314,7 @@ void OverrideBug(Bug bug, bool new_value)
       bug, BugInfo{m_api, m_os, m_vendor, m_driver, m_family, bug, -1, -1, false});
   if (it->second.m_hasbug != new_value)
   {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics& analytics = DolphinAnalytics::Instance();
     Common::AnalyticsReportBuilder builder(analytics.BaseBuilder());
     builder.AddData("type", "gpu-bug-override");
@@ -322,7 +325,7 @@ void OverrideBug(Bug bug, bool new_value)
     builder.AddData("driver", to_string(m_driver));
     builder.AddData("version", std::to_string(m_version));
     analytics.Send(builder);
-
+#endif
     it->second.m_hasbug = new_value;
   }
 }

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -8,7 +8,9 @@
 
 #include <imgui.h>
 
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/SystemTimers.h"
 #include "Core/System.h"
 
@@ -24,11 +26,13 @@ static Common::EventHook s_before_frame_event =
 
 static Common::EventHook s_after_frame_event = AfterFrameEvent::Register(
     [](const Core::System& system) {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportPerformanceInfo({
           .speed_ratio = system.GetSystemTimers().GetEstimatedEmulationPerformance(),
           .num_prims = g_stats.this_frame.num_prims + g_stats.this_frame.num_dl_prims,
           .num_draw_calls = g_stats.this_frame.num_draw_calls,
       });
+#endif
     },
     "Statistics::PerformanceSample");
 

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -17,7 +17,9 @@
 #include "Common/EnumMap.h"
 #include "Common/Logging/Log.h"
 
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/Memmap.h"
 #include "Core/System.h"
 
@@ -298,6 +300,7 @@ static void CheckCPConfiguration(int vtx_attr_group)
 
     // Analytics reporting so we can discover which games have this problem, that way when we
     // eventually simulate the behavior we have test cases for it.
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     if (num_cp_colors != xfmem.invtxspec.numcolors) [[unlikely]]
     {
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::MismatchedGPUColorsBetweenCPAndXF);
@@ -310,7 +313,7 @@ static void CheckCPConfiguration(int vtx_attr_group)
     {
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::MismatchedGPUTexCoordsBetweenCPAndXF);
     }
-
+#endif
     // Don't bail out, though; we can still render something successfully
     // (real hardware seems to hang in this case, though)
   }
@@ -323,8 +326,10 @@ static void CheckCPConfiguration(int vtx_attr_group)
                  "index A: {:08x}/{:08x}, index B {:08x}/{:08x}.",
                  g_main_cp_state.matrix_index_a.Hex, xfmem.MatrixIndexA.Hex,
                  g_main_cp_state.matrix_index_b.Hex, xfmem.MatrixIndexB.Hex);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(
         GameQuirk::MismatchedGPUMatrixIndicesBetweenCPAndXF);
+#endif
   }
 
   if (g_main_cp_state.vtx_attr[vtx_attr_group].g0.PosFormat >= ComponentFormat::InvalidFloat5)
@@ -334,7 +339,9 @@ static void CheckCPConfiguration(int vtx_attr_group)
                  g_main_cp_state.vtx_attr[vtx_attr_group].g0.Hex,
                  g_main_cp_state.vtx_attr[vtx_attr_group].g1.Hex,
                  g_main_cp_state.vtx_attr[vtx_attr_group].g2.Hex);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::InvalidPositionComponentFormat);
+#endif
   }
   if (g_main_cp_state.vtx_attr[vtx_attr_group].g0.NormalFormat >= ComponentFormat::InvalidFloat5)
   {
@@ -343,7 +350,9 @@ static void CheckCPConfiguration(int vtx_attr_group)
                  g_main_cp_state.vtx_attr[vtx_attr_group].g0.Hex,
                  g_main_cp_state.vtx_attr[vtx_attr_group].g1.Hex,
                  g_main_cp_state.vtx_attr[vtx_attr_group].g2.Hex);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::InvalidNormalComponentFormat);
+#endif
   }
   for (size_t i = 0; i < 8; i++)
   {
@@ -355,8 +364,10 @@ static void CheckCPConfiguration(int vtx_attr_group)
                    g_main_cp_state.vtx_attr[vtx_attr_group].g0.Hex,
                    g_main_cp_state.vtx_attr[vtx_attr_group].g1.Hex,
                    g_main_cp_state.vtx_attr[vtx_attr_group].g2.Hex);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(
           GameQuirk::InvalidTextureCoordinateComponentFormat);
+#endif
     }
   }
   for (size_t i = 0; i < 2; i++)
@@ -368,7 +379,9 @@ static void CheckCPConfiguration(int vtx_attr_group)
                    g_main_cp_state.vtx_attr[vtx_attr_group].g0.Hex,
                    g_main_cp_state.vtx_attr[vtx_attr_group].g1.Hex,
                    g_main_cp_state.vtx_attr[vtx_attr_group].g2.Hex);
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::InvalidColorComponentFormat);
+#endif
     }
   }
 }

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -15,7 +15,9 @@
 #include "Common/MathUtil.h"
 #include "Common/SmallVector.h"
 
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/SystemTimers.h"
 #include "Core/System.h"
 
@@ -457,6 +459,7 @@ void VertexManagerBase::Flush()
 
     // Analytics reporting so we can discover which games have this problem, that way when we
     // eventually simulate the behavior we have test cases for it.
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
     if (xfmem.numTexGen.numTexGens != bpmem.genMode.numtexgens)
     {
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::MismatchedGPUTexGensBetweenXFAndBP);
@@ -465,6 +468,7 @@ void VertexManagerBase::Flush()
     {
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::MismatchedGPUColorsBetweenXFAndBP);
     }
+#endif
 
     return;
   }

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -20,7 +20,9 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/System.h"
 
 // TODO: ugly
@@ -125,8 +127,9 @@ u32 VideoBackendBase::Video_GetQueryResult(PerfQueryType type)
 
 u16 VideoBackendBase::Video_GetBoundingBox(int index)
 {
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
   DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::ReadsBoundingBox);
-
+#endif
   if (!g_ActiveConfig.bBBoxEnable)
   {
     static bool warn_once = true;

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -9,7 +9,9 @@
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
 
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
 #include "Core/DolphinAnalytics.h"
+#endif
 #include "Core/HW/Memmap.h"
 #include "Core/System.h"
 
@@ -47,12 +49,14 @@ static void XFRegWritten(Core::System& system, XFStateManager& xf_state_manager,
     case XFMEM_CLIPDISABLE:
     {
       ClipDisable setting{.hex = value};
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       if (setting.disable_clipping_detection)
         DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::SetsXFClipDisableBit0);
       if (setting.disable_trivial_rejection)
         DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::SetsXFClipDisableBit1);
       if (setting.disable_cpoly_clipping_acceleration)
         DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::SetsXFClipDisableBit2);
+#endif
       break;
     }
 
@@ -180,7 +184,9 @@ static void XFRegWritten(Core::System& system, XFStateManager& xf_state_manager,
     case 0x104d:
     case 0x104e:
     case 0x104f:
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesUnknownXFCommand);
+#endif
       DEBUG_LOG_FMT(VIDEO, "Possible Normal Mtx XF reg?: {:x}={:x}", address, value);
       break;
 
@@ -191,7 +197,9 @@ static void XFRegWritten(Core::System& system, XFStateManager& xf_state_manager,
     case 0x1017:
 
     default:
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
       DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::UsesUnknownXFCommand);
+#endif
       WARN_LOG_FMT(VIDEO, "Unknown XF Reg: {:x}={:x}", address, value);
       break;
     }


### PR DESCRIPTION
When setting the option in CMakeLists.txt ENABLE_ANALYTICS to OFF, this can sometimes cause random crashes in libretro port.

This removes it completely when disabled at compile time.

e.g.

```
********** Crash dump: **********
Build fingerprint: 'samsung/xx/xx:15/xx/xx:user/release-keys'
Abort message: 'bad_function_call was thrown in -fno-exceptions mode'
#00 0x0000000000096080 /apex/com.android.runtime/lib64/bionic/libc.so (abort+172) (BuildId: d02d1c3363b4a4418dcd98f4845bd7a4)
#01 0x0000000000aea290 /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
std::__ndk1::__libcpp_verbose_abort(char const*, ...)
??:0:0
#02 0x0000000000433500 /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
std::__ndk1::__throw_bad_function_call[abi:nn180000]()
/home/cscd98/Android/Sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__functional/function.h:80:3
#03 0x000000000049ff14 /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
std::__ndk1::__function::__value_func<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>)>::operator()[abi:nn180000](std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>&&) const
/home/cscd98/Android/Sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__functional/function.h:424:7
std::__ndk1::function<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>)>::operator()(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>) const
/home/cscd98/Android/Sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__functional/function.h:978:10
DolphinAnalytics::MakeBaseBuilder()
/home/cscd98/Developer/dolphin-fml/Source/Core/Core/DolphinAnalytics.cpp:0:0
#04 0x000000000049ff68 /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
DolphinAnalytics::Instance()
/home/cscd98/Developer/dolphin-fml/Source/Core/Core/DolphinAnalytics.cpp:65:27
#05 0x00000000004a4634 /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
DSP::HLE::AXWii::(anonymous namespace)::ProcessVoice(DSP::HLE::AXWii::(anonymous namespace)::HLEAccelerator*, DSP::HLE::AXPBWii&, DSP::HLE::AXWii::(anonymous namespace)::AXBuffers const&, unsigned short, DSP::HLE::AXMixControl, short const*, bool)
/home/cscd98/Developer/dolphin-fml/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h:554:9
#06 0x00000000004a0efc /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
DSP::HLE::AXWiiUCode::ProcessPBList(unsigned int)
/home/cscd98/Developer/dolphin-fml/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp:475:7
#07 0x00000000004a0a9c /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
DSP::HLE::AXWiiUCode::HandleCommandList()
/home/cscd98/Developer/dolphin-fml/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp:187:9
#08 0x000000000049ef14 /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
DSP::HLE::AXUCode::HandleMail(unsigned int)
/home/cscd98/Developer/dolphin-fml/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp:745:5
#09 0x0000000000492aac /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
DSP::HLE::DSPHLE::SendMailToDSP(unsigned int)
/home/cscd98/Developer/dolphin-fml/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp:68:14
DSP::HLE::DSPHLE::DSP_WriteMailBoxLow(bool, unsigned short)
/home/cscd98/Developer/dolphin-fml/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp:184:5
#10 0x000000000060073c /data/user/0/com.retroarch.aarch64/cores/dolphin_libretro_android.so
std::__ndk1::__function::__value_func<void (Core::System&, unsigned int, unsigned short)>::operator()[abi:nn180000](Core::System&, unsigned int&&, unsigned short&&) const
/home/cscd98/Android/Sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__functional/function.h:425:12
std::__ndk1::function<void (Core::System&, unsigned int, unsigned short)>::operator()(Core::System&, unsigned int, unsigned short) const
/home/cscd98/Android/Sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__functional/function.h:978:10
void Arm64Gen::ARM64XEmitter::CallLambdaTrampoline<void, Core::System&, unsigned int, unsigned short>(std::__ndk1::function<void (Core::System&, unsigned int, unsigned short)> const*, Core::System&, unsigned int, unsigned short)
/home/cscd98/Developer/dolphin-fml/Source/Core/Common/Arm64Emitter.h:1193:12
#11 0x00000000080e5608 <anonymous:72a4000000>
Crash dump is completed

```