### PR TITLE
RealtekFirmwareLoader: Alternate USB PID for Ugreen CM390

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/RealtekFirmwareLoader.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/RealtekFirmwareLoader.cpp
@@ -143,6 +143,7 @@ bool IsKnownRealtekBluetoothDevice(u16 vid, u16 pid)
       {0x6655, 0x8771},
       {0x7392, 0xc611},
       {0x2b89, 0x8761},
+      {0x2b89, 0x6275},
       // Additional Realtek 8821AE Bluetooth devices
       {0x0b05, 0x17dc},
       {0x13d3, 0x3414},


### PR DESCRIPTION
Ugreen CM390 USB Bluetooth adapter can be found under VID/PID {0x2b89, 0x8761} but also {0x2b89, 0x6275}. This commit add the missing second flavor to the already existing one.