### PR TITLE
Common: add a way to serialize and deserialize matrices to json

### DIFF
--- a/Source/Core/Common/JsonUtil.cpp
+++ b/Source/Core/Common/JsonUtil.cpp
@@ -5,7 +5,32 @@
 
 #include <fstream>
 
+#include <fmt/format.h>
+
 #include "Common/FileUtil.h"
+
+namespace
+{
+template <typename M>
+picojson::object MatrixToJson(const M& mat)
+{
+  picojson::object obj;
+  for (std::size_t i = 0; i < mat.data.size(); i++)
+  {
+    obj.emplace(fmt::format("m{}", i), mat.data[i]);
+  }
+  return obj;
+}
+
+template <typename M>
+void MatrixFromJson(const picojson::object& obj, M& mat)
+{
+  for (std::size_t i = 0; i < mat.data.size(); i++)
+  {
+    mat.data[i] = ReadNumericFromJson<float>(obj, fmt::format("m{}", i)).value_or(0.0f);
+  }
+}
+}  // namespace
 
 picojson::object ToJsonObject(const Common::Vec3& vec)
 {
@@ -21,6 +46,26 @@ void FromJson(const picojson::object& obj, Common::Vec3& vec)
   vec.x = ReadNumericFromJson<float>(obj, "x").value_or(0.0f);
   vec.y = ReadNumericFromJson<float>(obj, "y").value_or(0.0f);
   vec.z = ReadNumericFromJson<float>(obj, "z").value_or(0.0f);
+}
+
+picojson::object ToJsonObject(const Common::Matrix44& mat)
+{
+  return MatrixToJson(mat);
+}
+
+void FromJson(const picojson::object& obj, Common::Matrix44& mat)
+{
+  MatrixFromJson(obj, mat);
+}
+
+picojson::object ToJsonObject(const Common::Matrix33& mat)
+{
+  return MatrixToJson(mat);
+}
+
+void FromJson(const picojson::object& obj, Common::Matrix33& mat)
+{
+  MatrixFromJson(obj, mat);
 }
 
 std::optional<std::string> ReadStringFromJson(const picojson::object& obj, const std::string& key)

--- a/Source/Core/Common/JsonUtil.h
+++ b/Source/Core/Common/JsonUtil.h
@@ -56,5 +56,11 @@ std::optional<bool> ReadBoolFromJson(const picojson::object& obj, const std::str
 picojson::object ToJsonObject(const Common::Vec3& vec);
 void FromJson(const picojson::object& obj, Common::Vec3& vec);
 
+picojson::object ToJsonObject(const Common::Matrix44& mat);
+void FromJson(const picojson::object& obj, Common::Matrix44& mat);
+
+picojson::object ToJsonObject(const Common::Matrix33& mat);
+void FromJson(const picojson::object& obj, Common::Matrix33& mat);
+
 bool JsonToFile(const std::string& filename, const picojson::value& root, bool prettify = false);
 bool JsonFromFile(const std::string& filename, picojson::value* root, std::string* error);


### PR DESCRIPTION
The 4x4 is what I used and tested but I went ahead and added 3x3 support as well.