### PR TITLE
ExpressionParser: Support saving newline characters to ini file.

### DIFF
--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -321,4 +321,11 @@ struct CaseInsensitiveLess
 };
 
 std::string BytesToHexString(std::span<const u8> bytes);
+
+// Escape/unescape newlines and backslashes by default.
+std::string EscapeString(std::string str, std::string_view find_chars = "\n\\",
+                         std::string_view replace_with_chars = "n\\", char escape_char = '\\');
+std::string UnescapeString(std::string str, std::string_view original_chars = "\n\\",
+                           std::string_view replaced_chars = "n\\", char escape_char = '\\');
+
 }  // namespace Common

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -203,4 +203,7 @@ private:
 ParseResult ParseExpression(const std::string& expr);
 ParseResult ParseTokens(const std::vector<Token>& tokens);
 
+std::string PrepareForIniFile(std::string expr);
+std::string AdjustFromIniFile(std::string expr);
+
 }  // namespace ciface::ExpressionParser

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
@@ -61,7 +61,8 @@ void Attachments::LoadConfig(Common::IniFile::Section* sec, const std::string& b
 
   // First assume attachment string is a valid expression.
   // If it instead matches one of the names of our attachments it is overridden below.
-  GetSelectionSetting().GetInputReference().SetExpression(attachment_text);
+  GetSelectionSetting().GetInputReference().SetExpression(
+      ciface::ExpressionParser::PrepareForIniFile(attachment_text));
 
   u32 n = 0;
   for (auto& ai : GetAttachmentList())
@@ -85,9 +86,9 @@ void Attachments::SaveConfig(Common::IniFile::Section* sec, const std::string& b
   }
   else
   {
-    std::string expression = GetSelectionSetting().GetInputReference().GetExpression();
-    ReplaceBreaksWithSpaces(expression);
-    sec->Set(base + name, expression, "None");
+    std::string expression = ciface::ExpressionParser::AdjustFromIniFile(
+        GetSelectionSetting().GetInputReference().GetExpression());
+    sec->Set(base + name, std::move(expression), "None");
   }
 
   for (auto& ai : GetAttachmentList())

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -72,7 +72,7 @@ void ControlGroup::LoadConfig(Common::IniFile::Section* sec, const std::string& 
       // control expression
       std::string expression;
       sec->Get(group + c->name, &expression, "");
-      c->control_ref->SetExpression(std::move(expression));
+      c->control_ref->SetExpression(ciface::ExpressionParser::AdjustFromIniFile(expression));
     }
 
     // range
@@ -95,10 +95,9 @@ void ControlGroup::SaveConfig(Common::IniFile::Section* sec, const std::string& 
   for (auto& c : controls)
   {
     // control expression
-    std::string expression = c->control_ref->GetExpression();
-    // We can't save line breaks in a single line config. Restoring them is too complicated.
-    ReplaceBreaksWithSpaces(expression);
-    sec->Set(group + c->name, expression, "");
+    std::string expression =
+        ciface::ExpressionParser::PrepareForIniFile(c->control_ref->GetExpression());
+    sec->Set(group + c->name, std::move(expression), "");
 
     // range
     sec->Set(group + c->name + "/Range", c->control_ref->range * 100.0, 100.0);

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -123,7 +123,7 @@ public:
     std::string str_value;
     if (section.Get(group_name + m_details.ini_name, &str_value))
     {
-      m_value.m_input.SetExpression(std::move(str_value));
+      m_value.m_input.SetExpression(ciface::ExpressionParser::AdjustFromIniFile(str_value));
       SimplifyIfPossible();
     }
     else
@@ -140,10 +140,9 @@ public:
     }
     else
     {
-      // We can't save line breaks in a single line config. Restoring them is too complicated.
-      std::string expression = m_value.m_input.GetExpression();
-      ReplaceBreaksWithSpaces(expression);
-      section.Set(group_name + m_details.ini_name, expression, "");
+      std::string expression =
+          ciface::ExpressionParser::PrepareForIniFile(m_value.m_input.GetExpression());
+      section.Set(group_name + m_details.ini_name, std::move(expression), "");
     }
   }
 

--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -256,3 +256,22 @@ TEST(StringUtil, CaseInsensitiveContains_OverlappingMatches)
   EXPECT_TRUE(Common::CaseInsensitiveContains("aaaaaa", "aa"));
   EXPECT_TRUE(Common::CaseInsensitiveContains("ababababa", "bABa"));
 }
+
+TEST(StringUtil, EscapeAndUnescape)
+{
+  EXPECT_EQ(Common::EscapeString("\n\\"), "\\n\\\\");
+  EXPECT_EQ(Common::EscapeString("\\\nfoo\n\\bar\\\\"), "\\\\\\nfoo\\n\\\\bar\\\\\\\\");
+
+  EXPECT_EQ(Common::UnescapeString("\\n\\\\test"), "\n\\test");
+  EXPECT_EQ(Common::UnescapeString("\\n\\\\"), "\n\\");
+
+  // No change for unexpected escaped char.
+  EXPECT_EQ(Common::UnescapeString("\\7"), "\\7");
+
+  // Edge cases.
+  EXPECT_EQ(Common::UnescapeString("\\\\n"), "\\n");
+  EXPECT_EQ(Common::UnescapeString("\\\\\\"), "\\\\");
+  EXPECT_EQ(Common::UnescapeString("\\"), "\\");
+  EXPECT_EQ(Common::UnescapeString("7"), "7");
+  EXPECT_EQ(Common::UnescapeString(""), "");
+}


### PR DESCRIPTION
This enables newlines to be saved in input expressions.

Newlines within multi-line comments `/**/` are escaped and unescaped with backslash.

Loose newlines are escaped and placed within a multi-line comment `/*\n*/`
On load, multi-line comments containing just `\n` are translated back to just newline characters.

<img width="282" height="92" alt="image" src="https://github.com/user-attachments/assets/bf4af8f0-d4ef-4613-aeaf-9b7407f44f91" />

```ini
[Wiimote1]
Buttons/A = `Z` ?/*\n*/ 0.6 : 0.4 /*\n*//* My Fancy\n  Expression */
```
Newlines saved in this manner will be interpreted by older versions of dolphin as an ugly multi-line comment but will otherwise function all the way back to #7663 (5.0-11004 or so).
<img width="281" height="91" alt="image" src="https://github.com/user-attachments/assets/f8fe6793-03d8-4fd8-8bf0-53850f082969" />

Existing configs containing multi-line comments with `\\` or `\n` are unlikely, but will show as single-backslash or newline-character on load.