### PR TITLE
SDL: Disable DirectInput handling to work around hangs on shutdown.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -16,6 +16,7 @@
 #include "Common/Event.h"
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
+#include "Common/Thread.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/SDL/SDLGamepad.h"
@@ -139,6 +140,8 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED, "0");
 
   m_hotplug_thread = std::thread([this] {
+    Common::SetCurrentThreadName("SDL Hotplug Thread");
+
     Common::ScopeGuard quit_guard([] {
       // TODO: there seems to be some sort of memory leak with SDL, quit isn't freeing everything up
       SDL_Quit();

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -139,6 +139,12 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
   // Disable DualSense Player LEDs; We already colorize the Primary LED
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED, "0");
 
+  // Disabling DirectInput support apparently solves hangs on shutdown for users with
+  //  "8BitDo Ultimate 2" controllers.
+  // It also works around a possibly related random hang on a IDirectInputDevice8_Acquire
+  //  call within SDL.
+  SDL_SetHint(SDL_HINT_JOYSTICK_DIRECTINPUT, "0");
+
   m_hotplug_thread = std::thread([this] {
     Common::SetCurrentThreadName("SDL Hotplug Thread");
 


### PR DESCRIPTION
Multiple users have reported hangs on shutdown when having an 8BitDo Ultimate 2 controller connected.

I cannot reproduce this issue but the testing of one user makes it seem like this is a promising workaround for it.
https://bugs.dolphin-emu.org/issues/13866

We have our own DirectInput backend and few game controllers require it these days anyways.

If a true fix is found we can revert this.

Users that "need" SDL DirectInput handling in the interim can manually set an environment variable: `SDL_JOYSTICK_DIRECTINPUT=1`