### PR TITLE
Jit64: Fix dcbz regression

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -474,18 +474,9 @@ void Jit64::dcbz(UGeckoInstruction inst)
     FixupBranch slow = J_CC(CC_Z, Jump::Near);
 
     // Fast path: compute full address, then zero out 32 bytes of memory.
-    if (cpu_info.bAVX)
-    {
-      VXORPS(XMM0, XMM0, R(XMM0));
-      VMOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 0), YMM0);
-      VZEROUPPER();
-    }
-    else
-    {
-      XORPS(XMM0, R(XMM0));
-      MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 16), XMM0);
-      MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 0), XMM0);
-    }
+    XORPS(XMM0, R(XMM0));
+    MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 0), XMM0);
+    MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 16), XMM0);
 
     // Slow path: call the general-case code.
     SwitchToFarCode();


### PR DESCRIPTION
Fix a regression from d1ba84987 that caused freezes or graphical/audio glitches in various games.

Examples:
`Super Mario Galaxy 2` and `Super Mario Sunshine` freeze on startup with accompanying audio glitches.
`IKARUGA` has a bunch of graphical static-squares in the intro Atari sequence.
`Super Mario Galaxy` has an audio glitch on startup.