### PR TITLE
dcbz: Fix AVX path

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -3036,7 +3036,7 @@ void XEmitter::VPXOR(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)
 
 void XEmitter::VMOVAPS(const OpArg& arg, X64Reg regOp)
 {
-  WriteAVXOp(0x00, 0x29, X64Reg::INVALID_REG, regOp, arg);
+  WriteAVXOp(0x00, 0x29, regOp, X64Reg::INVALID_REG, arg);
 }
 
 void XEmitter::VZEROUPPER()

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -474,9 +474,18 @@ void Jit64::dcbz(UGeckoInstruction inst)
     FixupBranch slow = J_CC(CC_Z, Jump::Near);
 
     // Fast path: compute full address, then zero out 32 bytes of memory.
-    XORPS(XMM0, R(XMM0));
-    MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 0), XMM0);
-    MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 16), XMM0);
+    if (cpu_info.bAVX)
+    {
+      VXORPS(XMM0, XMM0, R(XMM0));
+      VMOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 0), YMM0);
+      VZEROUPPER();
+    }
+    else
+    {
+      XORPS(XMM0, R(XMM0));
+      MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 0), XMM0);
+      MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 16), XMM0);
+    }
 
     // Slow path: call the general-case code.
     SwitchToFarCode();


### PR DESCRIPTION
Reverts #13985 (itself a partial revert of #13929) with the AVX path properly fixed.
Sorry for not catching it... (it was moving YMM8 instead of YMM0)
Tested the Pikmin games.