### PR TITLE
Jit: Emit Branch Watch code only if it's enabled

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1067,13 +1067,12 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 
     if (op.skip)
     {
-      if (IsDebuggingEnabled())
+      if (IsBranchWatchEnabled())
       {
         // The only thing that currently sets op.skip is the BLR following optimization.
         // If any non-branch instruction starts setting that too, this will need to be changed.
         ASSERT(op.inst.hex == 0x4e800020);
-        WriteBranchWatch<true>(op.address, op.branchTo, op.inst, RSCRATCH, RSCRATCH2,
-                               CallerSavedRegistersInUse());
+        WriteBranchWatch<true>(op.address, op.branchTo, op.inst, CallerSavedRegistersInUse());
       }
     }
     else

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -110,10 +110,8 @@ public:
   void WriteRfiExitDestInRSCRATCH();
   void WriteIdleExit(u32 destination);
   template <bool condition>
-  void WriteBranchWatch(u32 origin, u32 destination, UGeckoInstruction inst, Gen::X64Reg reg_a,
-                        Gen::X64Reg reg_b, BitSet32 caller_save);
-  void WriteBranchWatchDestInRSCRATCH(u32 origin, UGeckoInstruction inst, Gen::X64Reg reg_a,
-                                      Gen::X64Reg reg_b, BitSet32 caller_save);
+  void WriteBranchWatch(u32 origin, u32 destination, UGeckoInstruction inst, BitSet32 caller_save);
+  void WriteBranchWatchDestInRSCRATCH(u32 origin, UGeckoInstruction inst, BitSet32 caller_save);
 
   bool Cleanup();
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -387,11 +387,7 @@ void Jit64::DoMergedBranch()
       MOV(32, PPCSTATE_SPR(SPR_LR), Imm32(nextPC + 4));
 
     const u32 destination = js.op[1].branchTo;
-    if (IsDebuggingEnabled())
-    {
-      // ABI_PARAM1 is safe to use after a GPR flush for an optimization in this function.
-      WriteBranchWatch<true>(nextPC, destination, next, ABI_PARAM1, RSCRATCH, {});
-    }
+    WriteBranchWatch<true>(nextPC, destination, next, {});
     WriteIdleExit(destination);
   }
   else if (next.OPCD == 16)  // bcx
@@ -400,11 +396,7 @@ void Jit64::DoMergedBranch()
       MOV(32, PPCSTATE_SPR(SPR_LR), Imm32(nextPC + 4));
 
     const u32 destination = js.op[1].branchTo;
-    if (IsDebuggingEnabled())
-    {
-      // ABI_PARAM1 is safe to use after a GPR flush for an optimization in this function.
-      WriteBranchWatch<true>(nextPC, destination, next, ABI_PARAM1, RSCRATCH, {});
-    }
+    WriteBranchWatch<true>(nextPC, destination, next, {});
     WriteExit(destination, next.LK, nextPC + 4);
   }
   else if ((next.OPCD == 19) && (next.SUBOP10 == 528))  // bcctrx
@@ -413,11 +405,7 @@ void Jit64::DoMergedBranch()
       MOV(32, PPCSTATE_SPR(SPR_LR), Imm32(nextPC + 4));
     MOV(32, R(RSCRATCH), PPCSTATE_SPR(SPR_CTR));
     AND(32, R(RSCRATCH), Imm32(0xFFFFFFFC));
-    if (IsDebuggingEnabled())
-    {
-      // ABI_PARAM1 is safe to use after a GPR flush for an optimization in this function.
-      WriteBranchWatchDestInRSCRATCH(nextPC, next, ABI_PARAM1, RSCRATCH2, BitSet32{RSCRATCH});
-    }
+    WriteBranchWatchDestInRSCRATCH(nextPC, next, BitSet32{RSCRATCH});
     WriteExitDestInRSCRATCH(next.LK, nextPC + 4);
   }
   else if ((next.OPCD == 19) && (next.SUBOP10 == 16))  // bclrx
@@ -427,11 +415,7 @@ void Jit64::DoMergedBranch()
       AND(32, R(RSCRATCH), Imm32(0xFFFFFFFC));
     if (next.LK)
       MOV(32, PPCSTATE_SPR(SPR_LR), Imm32(nextPC + 4));
-    if (IsDebuggingEnabled())
-    {
-      // ABI_PARAM1 is safe to use after a GPR flush for an optimization in this function.
-      WriteBranchWatchDestInRSCRATCH(nextPC, next, ABI_PARAM1, RSCRATCH2, BitSet32{RSCRATCH});
-    }
+    WriteBranchWatchDestInRSCRATCH(nextPC, next, BitSet32{RSCRATCH});
     WriteBLRExit();
   }
   else
@@ -488,17 +472,12 @@ void Jit64::DoMergedBranchCondition()
   {
     gpr.Flush();
     fpr.Flush();
-    if (IsDebuggingEnabled())
-    {
-      // ABI_PARAM1 is safe to use after a GPR flush for an optimization in this function.
-      WriteBranchWatch<false>(nextPC, nextPC + 4, next, ABI_PARAM1, RSCRATCH, {});
-    }
+    WriteBranchWatch<false>(nextPC, nextPC + 4, next, {});
     WriteExit(nextPC + 4);
   }
-  else if (IsDebuggingEnabled())
+  else
   {
-    WriteBranchWatch<false>(nextPC, nextPC + 4, next, RSCRATCH, RSCRATCH2,
-                            CallerSavedRegistersInUse());
+    WriteBranchWatch<false>(nextPC, nextPC + 4, next, CallerSavedRegistersInUse());
   }
 }
 
@@ -540,17 +519,12 @@ void Jit64::DoMergedBranchImmediate(s64 val)
   {
     gpr.Flush();
     fpr.Flush();
-    if (IsDebuggingEnabled())
-    {
-      // ABI_PARAM1 is safe to use after a GPR flush for an optimization in this function.
-      WriteBranchWatch<false>(nextPC, nextPC + 4, next, ABI_PARAM1, RSCRATCH, {});
-    }
+    WriteBranchWatch<false>(nextPC, nextPC + 4, next, {});
     WriteExit(nextPC + 4);
   }
-  else if (IsDebuggingEnabled())
+  else
   {
-    WriteBranchWatch<false>(nextPC, nextPC + 4, next, RSCRATCH, RSCRATCH2,
-                            CallerSavedRegistersInUse());
+    WriteBranchWatch<false>(nextPC, nextPC + 4, next, CallerSavedRegistersInUse());
   }
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -1296,16 +1296,13 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 
     if (op.skip)
     {
-      if (IsDebuggingEnabled())
+      if (IsBranchWatchEnabled())
       {
         // The only thing that currently sets op.skip is the BLR following optimization.
         // If any non-branch instruction starts setting that too, this will need to be changed.
         ASSERT(op.inst.hex == 0x4e800020);
-        const auto bw_reg_a = gpr.GetScopedReg(), bw_reg_b = gpr.GetScopedReg();
-        const BitSet32 gpr_caller_save =
-            gpr.GetCallerSavedUsed() & ~BitSet32{DecodeReg(bw_reg_a), DecodeReg(bw_reg_b)};
-        WriteBranchWatch<true>(op.address, op.branchTo, op.inst, bw_reg_a, bw_reg_b,
-                               gpr_caller_save, fpr.GetCallerSavedUsed());
+        WriteBranchWatch<true>(op.address, op.branchTo, op.inst, gpr.GetCallerSavedUsed(),
+                               fpr.GetCallerSavedUsed());
       }
     }
     else

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -334,11 +334,9 @@ protected:
   // Branch Watch
   template <bool condition>
   void WriteBranchWatch(u32 origin, u32 destination, UGeckoInstruction inst,
-                        Arm64Gen::ARM64Reg reg_a, Arm64Gen::ARM64Reg reg_b,
                         BitSet32 gpr_caller_save, BitSet32 fpr_caller_save);
   void WriteBranchWatchDestInRegister(u32 origin, Arm64Gen::ARM64Reg destination,
-                                      UGeckoInstruction inst, Arm64Gen::ARM64Reg reg_a,
-                                      Arm64Gen::ARM64Reg reg_b, BitSet32 gpr_caller_save,
+                                      UGeckoInstruction inst, BitSet32 gpr_caller_save,
                                       BitSet32 fpr_caller_save);
 
   // Exits

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -23,6 +23,7 @@
 #include "Core/PowerPC/JitCommon/JitAsmCommon.h"
 #include "Core/PowerPC/JitCommon/JitCache.h"
 #include "Core/PowerPC/PPCAnalyst.h"
+#include "Core/PowerPC/PowerPC.h"
 
 namespace Core
 {
@@ -200,6 +201,11 @@ public:
 
   bool IsProfilingEnabled() const { return m_enable_profiling && m_enable_debugging; }
   bool IsDebuggingEnabled() const { return m_enable_debugging; }
+  bool IsBranchWatchEnabled() const
+  {
+    auto& branch_watch = m_system.GetPowerPC().GetBranchWatch();
+    return branch_watch.GetRecordingActive();
+  }
 
   static const u8* Dispatch(JitBase& jit);
   virtual JitBaseBlockCache* GetBlockCache() = 0;


### PR DESCRIPTION
JIT code related to Branch Watch was emitted if the debugging UI was active: the emitted code would dynamically check whether Branch Watch is active.
However, this causes two problems:
1. It decreases performance by just having the debugging UI enabled*
2. It clutters the host assembly in the JIT tab, making it harder to read (unaware readers will wonder what these instructions are for)

With this PR, code related to Branch Watch is emitted only if Branch Watch itself is active, fixing the issues above.
The JIT cache will now be wiped whenever the feature is toggled, causing a slight stutter. However, this isn't the kind of feature that is toggled over and over, so IMO it is an acceptable trade-off.

ARM64 is untested.

#### A note about the debugging UI

So, you might wonder what the asterisk is about. It's not that the PR doesn't improve performance with the debug UI on, because it does.
The problem is that the performance is still worse than with the debugging UI disabled. I'm not sure why.[^1]
Even though this performance decrease is intended, *this downside isn't communicated anywhere in Dolphin*, and it's very possible for someone to unawarely leave the option enabled. (Hi.)
So... that should be communicated, but where? Only the tooltip of the option, or even in the option title itself `(disables optimizations)`? (Plus the help text in the command line for the `-d` argument.)

I'll leave the discussion for this and on whether to merge the PR (IMO, still worthy due to point 2) to the jury.

[^1]: I already tested that "reverting" [the disabled BLR optimization](https://github.com/dolphin-emu/dolphin/blob/70bd0943a7a271606367ac129eb39cbdcd659e42/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp#L153-L154) or [the extra checks in the main loop meant for the memory breakpoints](https://github.com/dolphin-emu/dolphin/blob/70bd0943a7a271606367ac129eb39cbdcd659e42/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp#L99-L104) changes basically nothing.