### PR TITLE
DeleteDirRecursively: Don't report error for absent directory

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -528,9 +528,9 @@ bool DeleteDirRecursively(const std::string& directory)
 
   std::error_code error;
   const std::uintmax_t num_removed = std::filesystem::remove_all(StringToPath(directory), error);
-  const bool success = num_removed != 0 && !error;
+  const bool success = num_removed != static_cast<std::uintmax_t>(-1) && !error;
   if (!success)
-    ERROR_LOG_FMT(COMMON, "{}: {} failed {}", __func__, directory, error.message());
+    ERROR_LOG_FMT(COMMON, "{}: {} failed. {}", __func__, directory, error.message());
   return success;
 }
 


### PR DESCRIPTION
Check if the return value of `std::filesystem::remove_all` is -1 rather than 0; the former is the [specified return value](https://en.cppreference.com/w/cpp/filesystem/remove.html) if there's an error while 0 just means the directory already didn't exist (which is the end result we want).

Previously error messages such as the following were possible: `E[COMMON]: DeleteDirRecursively: [path]/User/RedirectSession/ failed The operation completed successfully.`

Also adds a period in the error string to make it look nicer.