### PR TITLE
Jit64: In `bcx`, use DEC to reduce CTR

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -974,6 +974,34 @@ void XEmitter::NOT(int bits, const OpArg& src)
   WriteMulDivType(bits, src, 2);
 }
 
+void XEmitter::WriteIncDecType(int bits, OpArg src, int opReg)
+{
+  ASSERT_MSG(DYNA_REC, !src.IsImm(), "WriteIncDecType - Imm argument");
+  CheckFlags();
+  if (bits == 16)
+    Write8(0x66);
+  src.WriteREX(this, bits, bits, 0);
+  if (bits == 8)
+  {
+    Write8(0xFE);
+  }
+  else
+  {
+    Write8(0xFF);
+  }
+  src.WriteRest(this, 0, (X64Reg)opReg);
+}
+
+void XEmitter::INC(int bits, const OpArg& src)
+{
+  WriteIncDecType(bits, src, 0);
+}
+
+void XEmitter::DEC(int bits, const OpArg& src)
+{
+  WriteIncDecType(bits, src, 1);
+}
+
 void XEmitter::WriteBitSearchType(int bits, X64Reg dest, OpArg src, u8 byte2, bool rep)
 {
   ASSERT_MSG(DYNA_REC, !src.IsImm(), "WriteBitSearchType - Imm argument");

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -348,6 +348,7 @@ private:
   void WriteSimple1Byte(int bits, u8 byte, X64Reg reg);
   void WriteSimple2Byte(int bits, u8 byte1, u8 byte2, X64Reg reg);
   void WriteMulDivType(int bits, OpArg src, int ext);
+  void WriteIncDecType(int bits, OpArg src, int opReg);
   void WriteBitSearchType(int bits, X64Reg dest, OpArg src, u8 byte2, bool rep = false);
   void WriteShift(int bits, OpArg dest, const OpArg& shift, int ext);
   void WriteBitTest(int bits, const OpArg& dest, const OpArg& index, int ext);
@@ -500,6 +501,10 @@ public:
   void IMUL(int bits, X64Reg regOp, const OpArg& src, const OpArg& imm);
   void DIV(int bits, const OpArg& src);
   void IDIV(int bits, const OpArg& src);
+
+  // Inc / Dec
+  void INC(int bits, const OpArg& src);
+  void DEC(int bits, const OpArg& src);
 
   // Shift
   void ROL(int bits, const OpArg& dest, const OpArg& shift);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -194,7 +194,7 @@ void Jit64::bcx(UGeckoInstruction inst)
   FixupBranch pCTRDontBranch;
   if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
   {
-    SUB(32, PPCSTATE_CTR, Imm8(1));
+    DEC(32, PPCSTATE_CTR);
     if (inst.BO & BO_BRANCH_IF_CTR_0)
       pCTRDontBranch = J_CC(CC_NZ, Jump::Near);
     else
@@ -363,7 +363,7 @@ void Jit64::bclrx(UGeckoInstruction inst)
   FixupBranch pCTRDontBranch;
   if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
   {
-    SUB(32, PPCSTATE_CTR, Imm8(1));
+    DEC(32, PPCSTATE_CTR);
     if (inst.BO & BO_BRANCH_IF_CTR_0)
       pCTRDontBranch = J_CC(CC_NZ, Jump::Near);
     else


### PR DESCRIPTION
DEC uses one less byte than SUB.
The only difference is that it doesn't affect the carry flag, which doesn't matter since it's the zero flag that is checked.

Tested in the disassembler that DEC is indeed used (and uses 6 bytes instead of 7), and tested that some games work.

I guess that INC and DEC could be used for PPC's add and sub too if the second argument is the immediate 1... but maybe Dolphin has some optimizations I don't know about that involve merging it with a conditional jump that uses the carry flag somewhere. I'm not risking it.