### PR TITLE
DolphinQt: Custom style for `QGroupBox` in Fusion.

### DIFF
--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -159,15 +159,13 @@ void Settings::ApplyStyle()
 {
   const StyleType style_type = GetStyleType();
 
-  {
-    const bool use_fusion{style_type == StyleType::FusionLight ||
-                          style_type == StyleType::FusionDarkGray ||
-                          style_type == StyleType::FusionDark};
-    static const QString s_initial_style_name{QApplication::style()->name()};
-    const QString style_name{use_fusion ? QStringLiteral("fusion") : s_initial_style_name};
-    if (QApplication::style()->name() != style_name)
-      QApplication::setStyle(style_name);
-  }
+  const bool use_fusion{style_type == StyleType::FusionLight ||
+                        style_type == StyleType::FusionDarkGray ||
+                        style_type == StyleType::FusionDark};
+  static const QString s_initial_style_name{QApplication::style()->name()};
+  const QString style_name{use_fusion ? QStringLiteral("fusion") : s_initial_style_name};
+  if (QApplication::style()->name() != style_name)
+    QApplication::setStyle(style_name);
 
   const QString stylesheet_name = GetUserStyleName();
   QString stylesheet_contents;
@@ -384,6 +382,26 @@ void Settings::ApplyStyle()
             .arg(padding)
             .arg(border_color.rgba(), 0, 16);
     stylesheet_contents.append(QStringLiteral("%1").arg(tooltip_stylesheet));
+  }
+
+  // For Fusion, define group box style if not already defined.
+  if (style_name.compare(QStringLiteral("fusion"), Qt::CaseInsensitive) == 0 &&
+      !stylesheet_contents.contains(QStringLiteral("QGroupBox")))
+  {
+    stylesheet_contents.append(QStringLiteral("QGroupBox {"
+                                              " margin-top: 0.6em;"
+                                              " padding-top: 0.5em;"
+                                              " padding-bottom: 0;"
+                                              " padding-left: 1px;"
+                                              " padding-right: 1px;"
+                                              "} "
+                                              "QGroupBox::title {"
+                                              " subcontrol-origin: margin;"
+                                              " subcontrol-position: top left;"
+                                              " left: 0.7em;"
+                                              " padding-top: 1px;"
+                                              " min-width: 0;"
+                                              "}"));
   }
 
   qApp->setStyleSheet(stylesheet_contents);


### PR DESCRIPTION
Fusion is the fallback style that Qt provides in systems that do not offer a OS-specific style. Basically, anything that is not Windows, macOS, or KDE (NOTE: Since #13919, users on these systems can opt in to Fusion too).

Its default style for `QGroupBox` is not very conventional, and has been customized to align with more popular designs.

| Before | After |
| --- | --- |
| ![Default QGroupBox style in Fusion](https://github.com/user-attachments/assets/b9f63e21-4282-4a61-a93c-93806ee589a4) | ![Custom QGroupBox style in Fusion](https://github.com/user-attachments/assets/1c8f7f1e-11a2-4712-b1b2-c5e5045b120e) |