### PR TITLE
JitArm64: Add analysis for m_ppc_state LDP/STP

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1227,7 +1227,11 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       gpr.Commit();
       fpr.Commit();
 
-      // If we have a register that will never be used again, discard or flush it.
+      // If a register won't be used again in this block, or its value will never be needed again,
+      // flush or discard it respectively.
+      //
+      // To improve JIT-time performance, we use some extra bitwise math to skip trying to flush
+      // registers that can't have changed state during the current PPC instruction.
       if (!bJITRegisterCacheOff)
       {
         gpr.Discard(op.gprDiscardable);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -1207,6 +1207,13 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
     IntializeSpeculativeConstants();
   }
 
+  BitSet32 previous_op_gpr_will_be_written = code_block.m_gpr_outputs;
+  BitSet32 previous_op_gpr_will_be_used = code_block.m_gpr_inputs | previous_op_gpr_will_be_written;
+  BitSet32 previous_op_fpr_will_be_written = code_block.m_fpr_outputs;
+  BitSet32 previous_op_fpr_will_be_used = code_block.m_fpr_inputs | previous_op_fpr_will_be_written;
+  BitSet8 previous_op_cr_will_be_written = code_block.m_cr_outputs;
+  BitSet8 previous_op_cr_will_be_used = code_block.m_cr_inputs | previous_op_cr_will_be_written;
+
   // Translate instructions
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {
@@ -1414,22 +1421,34 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       //
       // To improve JIT-time performance, we use some extra bitwise math to skip trying to flush
       // registers that can't have changed state during the current PPC instruction.
+
       if (!bJITRegisterCacheOff)
       {
         gpr.DiscardRegisters(op.gprDiscardable);
         fpr.DiscardRegisters(op.fprDiscardable);
         gpr.DiscardCRRegisters(op.crDiscardable);
       }
-      gpr.FlushRegisters(~(op.gprWillBeRead | op.gprWillBeWritten) & (op.regsIn | op.regsOut),
-                         FlushMode::Full);
-      fpr.FlushRegisters(~(op.fprWillBeRead | op.fprWillBeWritten) &
-                             (op.fregsIn | op.GetFregsOut()),
-                         FlushMode::Full);
-      gpr.FlushCRRegisters(~(op.crWillBeRead | op.crWillBeWritten) & (op.crIn | op.crOut),
-                           FlushMode::Full);
-      gpr.FlushRegisters(~op.gprWillBeWritten & op.regsOut, FlushMode::Undirty);
-      fpr.FlushRegisters(~op.fprWillBeWritten & op.GetFregsOut(), FlushMode::Undirty);
-      gpr.FlushCRRegisters(~op.crWillBeWritten & op.crOut, FlushMode::Undirty);
+
+      const BitSet32 gpr_will_be_used = op.gprWillBeRead | op.gprWillBeWritten;
+      const BitSet32 fpr_will_be_used = op.fprWillBeRead | op.fprWillBeWritten;
+      const BitSet8 cr_will_be_used = op.crWillBeRead | op.crWillBeWritten;
+
+      gpr.FlushRegisters(~op.gprWillBeWritten & previous_op_gpr_will_be_written,
+                         FlushMode::Undirty);
+      fpr.FlushRegisters(~op.fprWillBeWritten & previous_op_fpr_will_be_written,
+                         FlushMode::Undirty);
+      gpr.FlushCRRegisters(~op.crWillBeWritten & previous_op_cr_will_be_written,
+                           FlushMode::Undirty);
+      gpr.FlushRegisters(~gpr_will_be_used & previous_op_gpr_will_be_used, FlushMode::Full);
+      fpr.FlushRegisters(~fpr_will_be_used & previous_op_fpr_will_be_used, FlushMode::Full);
+      gpr.FlushCRRegisters(~cr_will_be_used & previous_op_cr_will_be_used, FlushMode::Full);
+
+      previous_op_gpr_will_be_written = op.gprWillBeWritten;
+      previous_op_gpr_will_be_used = gpr_will_be_used;
+      previous_op_fpr_will_be_written = op.fprWillBeWritten;
+      previous_op_fpr_will_be_used = fpr_will_be_used;
+      previous_op_cr_will_be_written = op.crWillBeWritten;
+      previous_op_cr_will_be_used = cr_will_be_used;
 
       if (opinfo->flags & FL_LOADSTORE)
         ++js.numLoadStoreInst;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -1409,7 +1409,11 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       if (!CanMergeNextInstructions(1) || js.op[1].opinfo->type != ::OpType::Integer)
         FlushCarry();
 
-      // If we have a register that will never be used again, discard or flush it.
+      // If a register won't be used again in this block, or its value will never be needed again,
+      // flush or discard it respectively.
+      //
+      // To improve JIT-time performance, we use some extra bitwise math to skip trying to flush
+      // registers that can't have changed state during the current PPC instruction.
       if (!bJITRegisterCacheOff)
       {
         gpr.DiscardRegisters(op.gprDiscardable);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -140,8 +140,9 @@ Arm64GPRCache::Arm64GPRCache() : Arm64RegCache(GUEST_GPR_COUNT + GUEST_CR_COUNT)
 {
 }
 
-void Arm64GPRCache::Start(PPCAnalyst::BlockRegStats& stats)
+void Arm64GPRCache::Start(const PPCAnalyst::BlockRegStats& stats)
 {
+  m_reg_stats = &stats;
 }
 
 // Returns if a register is set as an immediate. Only valid for guest GPRs.
@@ -519,6 +520,11 @@ constexpr size_t GUEST_FPR_COUNT = 32;
 
 Arm64FPRCache::Arm64FPRCache() : Arm64RegCache(GUEST_FPR_COUNT)
 {
+}
+
+void Arm64FPRCache::Start(const PPCAnalyst::BlockRegStats& stats)
+{
+  m_reg_stats = &stats;
 }
 
 void Arm64FPRCache::Flush(FlushMode mode, ARM64Reg tmp_reg,

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -380,6 +380,53 @@ ARM64Reg Arm64GPRCache::BindForRead(size_t index)
     ARM64Reg host_reg = bitsize != 64 ? GetReg() : EncodeRegTo64(GetReg());
     reg.Load(host_reg);
     reg.SetDirty(false);
+
+    // Load two registers at once if we have an opportunity to
+    if (index >= GUEST_GPR_OFFSET && index < GUEST_GPR_OFFSET + GUEST_GPR_COUNT &&
+        GetUnlockedRegisterCount() > 0)
+    {
+      const size_t gpr_index = index - GUEST_GPR_OFFSET;
+      const BitSet32 gpr_will_be_read = m_jit->js.op->gprWillBeRead | m_jit->js.op->regsIn;
+
+      if (gpr_index != 0 && m_reg_stats->load_pairs[gpr_index - 1] &&
+          gpr_will_be_read[gpr_index - 1])
+      {
+        const GuestRegInfo& guest_reg_2 = GetGuestGPR(gpr_index - 1);
+        OpArg& reg_2 = guest_reg_2.reg;
+        DEBUG_ASSERT(guest_reg_2.bitsize == bitsize);
+
+        if (!reg_2.IsInHostRegister() && reg_2.IsInPPCState() && guest_reg_2.ppc_offset <= 252)
+        {
+          ARM64Reg host_reg_2 = bitsize != 64 ? GetReg() : EncodeRegTo64(GetReg());
+          reg_2.Load(host_reg_2);
+          reg_2.SetDirty(false);
+
+          m_emit->LDP(IndexType::Signed, host_reg_2, host_reg, PPC_REG,
+                      u32(guest_reg_2.ppc_offset));
+          return host_reg;
+        }
+      }
+
+      if (gpr_index + 1 < GUEST_GPR_COUNT && m_reg_stats->load_pairs[gpr_index] &&
+          gpr_will_be_read[gpr_index + 1] && guest_reg.ppc_offset <= 252)
+      {
+        const GuestRegInfo& guest_reg_2 = GetGuestGPR(gpr_index + 1);
+        OpArg& reg_2 = guest_reg_2.reg;
+        DEBUG_ASSERT(guest_reg_2.bitsize == bitsize);
+
+        if (!reg_2.IsInHostRegister() && reg_2.IsInPPCState())
+        {
+          ARM64Reg host_reg_2 = bitsize != 64 ? GetReg() : EncodeRegTo64(GetReg());
+          reg_2.Load(host_reg_2);
+          reg_2.SetDirty(false);
+
+          m_emit->LDP(IndexType::Signed, host_reg, host_reg_2, PPC_REG, u32(guest_reg.ppc_offset));
+          return host_reg;
+        }
+      }
+    }
+
+    // Otherwise, just load this register
     m_emit->LDR(IndexType::Unsigned, host_reg, PPC_REG, u32(guest_reg.ppc_offset));
     return host_reg;
   }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -407,28 +407,15 @@ void Arm64GPRCache::BindForWrite(size_t index, bool will_read, bool will_write)
 
   if (!reg.IsInHostRegister())
   {
-    if (is_gpr && IsImm(index - GUEST_GPR_OFFSET))
-    {
-      const ARM64Reg host_reg = bitsize != 64 ? GetReg() : EncodeRegTo64(GetReg());
-      if (will_read || !will_write)
-      {
-        // TODO: Emitting this instruction when (!will_read && !will_write) would be unnecessary if
-        // we had some way to indicate to Flush that the immediate value should be written to
-        // ppcState even though there is a host register allocated
-        m_emit->MOVI2R(host_reg, GetImm(index - GUEST_GPR_OFFSET));
-      }
-      reg.Load(host_reg);
-    }
+    // TODO: This special case would be unnecessary if we had some way to indicate to Flush that
+    // an immediate value should be written to m_ppc_state even though a host register is allocated
+    const bool is_imm = is_gpr && IsImm(index - GUEST_GPR_OFFSET);
+    const bool special_case = is_imm && !will_write;
+
+    if (will_read || special_case)
+      BindForRead(index);
     else
-    {
-      ASSERT_MSG(DYNA_REC, !will_read || reg.IsInPPCState(), "Attempted to load a discarded value");
-      const ARM64Reg host_reg = bitsize != 64 ? GetReg() : EncodeRegTo64(GetReg());
-      reg.Load(host_reg);
-      reg.SetDirty(will_write);
-      if (will_read)
-        m_emit->LDR(IndexType::Unsigned, host_reg, PPC_REG, u32(guest_reg.ppc_offset));
-      return;
-    }
+      reg.Load(bitsize != 64 ? GetReg() : EncodeRegTo64(GetReg()));
   }
 
   if (will_write)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -164,7 +164,7 @@ public:
 
   void Init(JitArm64* jit);
 
-  virtual void Start(PPCAnalyst::BlockRegStats& stats) {}
+  virtual void Start(const PPCAnalyst::BlockRegStats& stats) {}
   void DiscardRegisters(BitSet32 regs);
   void ResetRegisters(BitSet32 regs);
   // Flushes the register cache in different ways depending on the mode.
@@ -304,7 +304,7 @@ protected:
   std::vector<OpArg> m_guest_registers;
 
   // Register stats for the current block
-  PPCAnalyst::BlockRegStats* m_reg_stats = nullptr;
+  const PPCAnalyst::BlockRegStats* m_reg_stats = nullptr;
 };
 
 class Arm64GPRCache : public Arm64RegCache
@@ -312,7 +312,7 @@ class Arm64GPRCache : public Arm64RegCache
 public:
   Arm64GPRCache();
 
-  void Start(PPCAnalyst::BlockRegStats& stats) override;
+  void Start(const PPCAnalyst::BlockRegStats& stats) override;
 
   // Flushes the register cache in different ways depending on the mode.
   // A temporary register must be supplied when flushing GPRs with FlushMode::MaintainState,
@@ -448,6 +448,8 @@ class Arm64FPRCache : public Arm64RegCache
 {
 public:
   Arm64FPRCache();
+
+  void Start(const PPCAnalyst::BlockRegStats& stats) override;
 
   // Flushes the register cache in different ways depending on the mode.
   // The temporary register can be set to ARM64Reg::INVALID_REG when convenient for the caller.

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -1190,6 +1190,12 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
     }
 
 #ifdef _M_ARM_64
+    // Make JitArm64 wait with storing one half of a pair until the other half is ready to be stored
+    op.gprWillBeWritten |= (op.gprWillBeWritten & block->m_gpa->store_pairs) << 1 |
+                           ((op.gprWillBeWritten >> 1) & block->m_gpa->store_pairs);
+    // Equivalent calculations for fprWillBeWritten and crWillBeWritten are left out because
+    // JitArm64 isn't able to use STP when flushing those
+
     // As a tie-break for odd-length runs of registers to assign load pairs for, if an instruction
     // that's early in a block has two adjacent registers as inputs, prefer putting those registers
     // in the same load pair. This is intended to let the host CPU start doing useful work as soon
@@ -1212,6 +1218,11 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
   block->m_gqr_used = gqrUsed;
   block->m_gqr_modified = gqrModified;
   block->m_gpr_inputs = gprWillBeRead;
+  block->m_gpr_outputs = gprWillBeWritten;
+  block->m_fpr_inputs = fprWillBeRead;
+  block->m_fpr_outputs = fprWillBeWritten;
+  block->m_cr_inputs = crWillBeRead;
+  block->m_cr_outputs = crWillBeWritten;
 
 #ifdef _M_ARM_64
   OddLengthRunsToEvenLengthRuns(&fpr_load_pair_candidates);

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -4,6 +4,7 @@
 #include "Core/PowerPC/PPCAnalyst.h"
 
 #include <algorithm>
+#include <bit>
 #include <map>
 #include <string>
 #include <vector>
@@ -812,6 +813,12 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
   // Clear register stats
   block->m_gpa->any = true;
   block->m_fpa->any = false;
+#ifdef _M_ARM_64
+  block->m_gpa->load_pairs = {};
+  block->m_gpa->store_pairs = {};
+  block->m_fpa->load_pairs = {};
+  block->m_fpa->store_pairs = {};
+#endif
 
   // Set the blocks start address
   block->m_address = address;
@@ -1072,6 +1079,24 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
     }
   }
 
+#ifdef _M_ARM_64
+  BitSet32 gpr_load_pair_candidates = gprWillBeRead;
+  FindRegisterPairs(&gpr_load_pair_candidates, &block->m_gpa->load_pairs);
+
+  BitSet32 fpr_load_pair_candidates = fprWillBeRead;
+  FindRegisterPairs(&fpr_load_pair_candidates, &block->m_fpa->load_pairs);
+
+  BitSet32 gpr_store_pair_candidates = gprWillBeWritten;
+  FindRegisterPairs(&gpr_store_pair_candidates, &block->m_gpa->store_pairs);
+  OddLengthRunsToEvenLengthRuns(&gpr_store_pair_candidates);
+  FindRegisterPairs(&gpr_store_pair_candidates, &block->m_gpa->store_pairs);
+
+  BitSet32 fpr_store_pair_candidates = fprWillBeWritten;
+  FindRegisterPairs(&fpr_store_pair_candidates, &block->m_fpa->store_pairs);
+  OddLengthRunsToEvenLengthRuns(&fpr_store_pair_candidates);
+  FindRegisterPairs(&fpr_store_pair_candidates, &block->m_fpa->store_pairs);
+#endif
+
   // Forward scan, for flags that need the other direction for calculation.
   BitSet32 fprIsSingle, fprIsDuplicated, fprIsStoreSafe;
   BitSet8 gqrUsed, gqrModified;
@@ -1163,11 +1188,73 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer,
       if (gqr >= 0 && gqr <= 7)
         gqrModified[gqr] = true;
     }
+
+#ifdef _M_ARM_64
+    // As a tie-break for odd-length runs of registers to assign load pairs for, if an instruction
+    // that's early in a block has two adjacent registers as inputs, prefer putting those registers
+    // in the same load pair. This is intended to let the host CPU start doing useful work as soon
+    // as possible.
+    if (FindRegisterPairs(&gpr_load_pair_candidates, &block->m_gpa->load_pairs, op.regsIn) != 0)
+    {
+      // If the odd-length run was long, it will now have been split into two shorter runs, with a
+      // gap in between. One of the new runs is even-length, so let's run FindRegisterPairs again.
+      FindRegisterPairs(&gpr_load_pair_candidates, &block->m_gpa->load_pairs);
+    }
+    if (FindRegisterPairs(&fpr_load_pair_candidates, &block->m_fpa->load_pairs, op.fregsIn) != 0)
+    {
+      // If the odd-length run was long, it will now have been split into two shorter runs, with a
+      // gap in between. One of the new runs is even-length, so let's run FindRegisterPairs again.
+      FindRegisterPairs(&fpr_load_pair_candidates, &block->m_fpa->load_pairs);
+    }
+#endif
   }
+
   block->m_gqr_used = gqrUsed;
   block->m_gqr_modified = gqrModified;
   block->m_gpr_inputs = gprWillBeRead;
+
+#ifdef _M_ARM_64
+  OddLengthRunsToEvenLengthRuns(&fpr_load_pair_candidates);
+  FindRegisterPairs(&fpr_load_pair_candidates, &block->m_fpa->load_pairs);
+
+  OddLengthRunsToEvenLengthRuns(&fpr_load_pair_candidates);
+  FindRegisterPairs(&fpr_load_pair_candidates, &block->m_fpa->load_pairs);
+#endif
+
   return address;
+}
+
+size_t FindRegisterPairs(BitSet32* candidates, BitSet32* out, BitSet32 mask)
+{
+  u64 candidates_to_check = candidates->m_val & mask.m_val;
+  size_t shift = 32;
+  size_t registers_handled = 0;
+
+  while (candidates_to_check != 0)
+  {
+    const int zero_count = std::countl_zero(u32(candidates_to_check));
+    shift -= zero_count;
+    candidates_to_check <<= zero_count;
+
+    const int one_count = std::countl_one(u32(candidates_to_check));
+    shift -= one_count;
+    candidates_to_check <<= one_count;
+
+    if ((one_count & 1) == 0)
+    {
+      const u32 ones = static_cast<u32>(((1ULL << one_count) - 1));
+      *candidates &= ~BitSet32(ones << shift);
+      *out |= BitSet32((ones & 0x55555555) << shift);
+      registers_handled += ones;
+    }
+  }
+
+  return registers_handled;
+}
+
+void OddLengthRunsToEvenLengthRuns(BitSet32* candidates)
+{
+  *candidates &= *candidates >> 1;
 }
 
 }  // namespace PPCAnalyst

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -139,6 +139,21 @@ struct CodeBlock
   // Which GPRs this block reads from before writing to, if any.
   BitSet32 m_gpr_inputs;
 
+  // Which GPRs this block writes to, if any.
+  BitSet32 m_gpr_outputs;
+
+  // Which FPRs this block reads from before writing to, if any.
+  BitSet32 m_fpr_inputs;
+
+  // Which FPRs this block writes to, if any.
+  BitSet32 m_fpr_outputs;
+
+  // Which CRs this block reads from before writing to, if any.
+  BitSet8 m_cr_inputs;
+
+  // Which CRs this block writes to, if any.
+  BitSet8 m_cr_outputs;
+
   // Which memory locations are occupied by this block.
   Common::RangeSet<u32> m_physical_addresses;
 };

--- a/Source/UnitTests/Core/CMakeLists.txt
+++ b/Source/UnitTests/Core/CMakeLists.txt
@@ -25,6 +25,7 @@ if(_M_X86_64)
     PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
     PowerPC/Jit64Common/Fres.cpp
     PowerPC/Jit64Common/Frsqrte.cpp
+    PowerPC/PPCAnalystTest.cpp
   )
 elseif(_M_ARM_64)
   add_dolphin_test(PowerPCTest
@@ -35,11 +36,13 @@ elseif(_M_ARM_64)
     PowerPC/JitArm64/Fres.cpp
     PowerPC/JitArm64/Frsqrte.cpp
     PowerPC/JitArm64/MovI2R.cpp
+    PowerPC/PPCAnalystTest.cpp
   )
 else()
   add_dolphin_test(PowerPCTest
     PowerPC/DivUtilsTest.cpp
     PowerPC/PageTableHostMappingTest.cpp
+    PowerPC/PPCAnalystTest.cpp
   )
 endif()
 

--- a/Source/UnitTests/Core/PowerPC/PPCAnalystTest.cpp
+++ b/Source/UnitTests/Core/PowerPC/PPCAnalystTest.cpp
@@ -1,0 +1,57 @@
+// Copyright 2021 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "Common/BitSet.h"
+#include "Core/PowerPC/PPCAnalyst.h"
+
+TEST(PPCAnalyst, FindRegisterPairs)
+{
+  BitSet32 input{1, 3, 4, 6, 7, 8, 11, 12, 13, 14, 19, 20, 21, 22, 23};
+  BitSet32 output{15, 18, 30};
+  BitSet32 input_expected{1, 6, 7, 8, 19, 20, 21, 22, 23};
+  BitSet32 output_expected{3, 11, 13, 15, 18, 30};
+
+  PPCAnalyst::FindRegisterPairs(&input, &output);
+
+  ASSERT_EQ(input, input_expected);
+  ASSERT_EQ(output, output_expected);
+}
+
+TEST(PPCAnalyst, FindRegisterPairs_AllOnes)
+{
+  BitSet32 input(0xFFFFFFFF);
+  BitSet32 output(0x0);
+  BitSet32 input_expected(0x0);
+  BitSet32 output_expected(0x55555555);
+
+  PPCAnalyst::FindRegisterPairs(&input, &output);
+
+  ASSERT_EQ(input, input_expected);
+  ASSERT_EQ(output, output_expected);
+}
+
+TEST(PPCAnalyst, FindRegisterPairs_Masked)
+{
+  BitSet32 input{1, 3, 4, 6, 7, 8, 11, 12, 13, 14, 19, 20, 21, 22, 23};
+  BitSet32 output{15, 18, 30};
+  BitSet32 mask{1, 8, 9, 21, 22};
+  BitSet32 input_expected{1, 3, 4, 6, 7, 8, 11, 12, 13, 14, 19, 20, 23};
+  BitSet32 output_expected{15, 18, 21, 30};
+
+  PPCAnalyst::FindRegisterPairs(&input, &output, mask);
+
+  ASSERT_EQ(input, input_expected);
+  ASSERT_EQ(output, output_expected);
+}
+
+TEST(PPCAnalyst, OddLengthRunsToEvenLengthRuns)
+{
+  BitSet32 input{1, 3, 4, 6, 7, 8, 11, 12, 13, 14, 19, 20, 21, 22, 23};
+  BitSet32 expected{3, 6, 7, 11, 12, 13, 19, 20, 21, 22};
+
+  PPCAnalyst::OddLengthRunsToEvenLengthRuns(&input);
+
+  ASSERT_EQ(input, expected);
+}


### PR DESCRIPTION
Using LDP/STP when accessing m_ppc_state lets us load/store two registers at once. We previously opportunistically used STP, but this new analysis lets us move loads earlier and move stores later to make use of LDP/STP in more situations. This reduces code size and time spent on m_ppc_state accesses, possibly with exceptions when under heavy register pressure.