### PR TITLE
GameSettings: Force EFBToTextureEnable off in Metroid Prime 2: Dark Echoes (Wii)

### DIFF
--- a/Data/Sys/GameSettings/R32.ini
+++ b/Data/Sys/GameSettings/R32.ini
@@ -1,2 +1,3 @@
 [Video_Hacks]
 EFBToTextureEnable = False
+

--- a/Data/Sys/GameSettings/R32.ini
+++ b/Data/Sys/GameSettings/R32.ini
@@ -2,3 +2,7 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
+
+[Video_Settings]
+#Improves performance on the map screen
+CPUCull = True

--- a/Data/Sys/GameSettings/R32.ini
+++ b/Data/Sys/GameSettings/R32.ini
@@ -1,3 +1,4 @@
+# R32J01 - Metroid Prime 2: Dark Echoes (Wii)
+
 [Video_Hacks]
 EFBToTextureEnable = False
-

--- a/Data/Sys/GameSettings/R32.ini
+++ b/Data/Sys/GameSettings/R32.ini
@@ -1,8 +1,9 @@
 # R32J01 - Metroid Prime 2: Dark Echoes (Wii)
 
 [Video_Hacks]
+# Required for the Scan Visor to work.
 EFBToTextureEnable = False
 
 [Video_Settings]
-#Improves performance on the map screen
+# Improves performance on the map screen.
 CPUCull = True

--- a/Data/Sys/GameSettings/R32J01.ini
+++ b/Data/Sys/GameSettings/R32J01.ini
@@ -1,0 +1,2 @@
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
In the Japanese New Play Control version of Metroid Prime 2, the Scan Visor only works when you disable "Submit EFB Copies to Texture Only", otherwise you can't scan anything (nothing happens when pressing the Z button while aiming at a scannable object with Scan Visor equipped).