### PR TITLE
Refactor the GameCube microphone code

### DIFF
--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(audiocommon
   AudioCommon.h
   CubebStream.h
   Enums.h
+  Microphone.cpp
+  Microphone.h
   Mixer.cpp
   Mixer.h
   SurroundDecoder.cpp

--- a/Source/Core/AudioCommon/Microphone.cpp
+++ b/Source/Core/AudioCommon/Microphone.cpp
@@ -1,7 +1,7 @@
 // Copyright 2025 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "Core/IOS/USB/Emulated/Microphone.h"
+#include "AudioCommon/Microphone.h"
 
 #include <algorithm>
 #include <cmath>
@@ -28,7 +28,7 @@
 #include "jni/AndroidCommon/IDCache.h"
 #endif
 
-namespace IOS::HLE::USB
+namespace AudioCommon
 {
 #ifdef HAVE_CUBEB
 Microphone::Microphone(const MicrophoneState& sampler, const std::string& worker_name)
@@ -385,4 +385,4 @@ void Microphone::Loudness::LogStats()
                samples_count, SAMPLES_NEEDED, peak_min, peak_max, amplitude, amplitude_db, rms,
                rms_db, abs_mean, abs_mean_db, crest_factor, crest_factor_db);
 }
-}  // namespace IOS::HLE::USB
+}  // namespace AudioCommon

--- a/Source/Core/AudioCommon/Microphone.h
+++ b/Source/Core/AudioCommon/Microphone.h
@@ -18,7 +18,7 @@ struct cubeb;
 struct cubeb_stream;
 #endif
 
-namespace IOS::HLE::USB
+namespace AudioCommon
 {
 class MicrophoneState
 {
@@ -123,4 +123,4 @@ private:
   CubebUtils::CoInitSyncWorker m_worker;
 #endif
 };
-}  // namespace IOS::HLE::USB
+}  // namespace AudioCommon

--- a/Source/Core/AudioCommon/Microphone.h
+++ b/Source/Core/AudioCommon/Microphone.h
@@ -49,6 +49,7 @@ public:
 
 protected:
   static constexpr u32 BUFF_SIZE_SAMPLES = 32;
+  u32 m_samples_avail = 0;
 
 private:
 #ifdef HAVE_CUBEB
@@ -58,6 +59,7 @@ private:
   virtual std::string GetCubebStreamName() const = 0;
   virtual s16 GetVolumeModifier() const = 0;
   virtual bool AreSamplesByteSwapped() const = 0;
+  virtual void OnOverflow();
 #endif
 
   long DataCallback(const SampleType* input_buffer, long nframes);
@@ -73,7 +75,6 @@ private:
   std::vector<SampleType> m_stream_buffer{};
   u32 m_stream_wpos = 0;
   u32 m_stream_rpos = 0;
-  u32 m_samples_avail = 0;
 
   // TODO: Find how this level is calculated on real hardware
   std::atomic<u16> m_loudness_level = 0;

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -429,8 +429,6 @@ add_library(core
   IOS/USB/Common.h
   IOS/USB/Emulated/Infinity.cpp
   IOS/USB/Emulated/Infinity.h
-  IOS/USB/Emulated/Microphone.cpp
-  IOS/USB/Emulated/Microphone.h
   IOS/USB/Emulated/Skylanders/Skylander.cpp
   IOS/USB/Emulated/Skylanders/Skylander.h
   IOS/USB/Emulated/Skylanders/SkylanderCrypto.cpp

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -3,18 +3,7 @@
 
 #include "Core/HW/EXI/EXI_DeviceMic.h"
 
-#include <algorithm>
-#include <cstring>
-#include <mutex>
-
-#include <cubeb/cubeb.h>
-
-#include "AudioCommon/CubebUtils.h"
-#include "Common/Common.h"
-#include "Common/CommonTypes.h"
-#include "Common/Event.h"
 #include "Common/Logging/Log.h"
-#include "Common/ScopeGuard.h"
 
 #include "Core/CoreTiming.h"
 #include "Core/HW/EXI/EXI.h"
@@ -22,158 +11,61 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/System.h"
 
-#ifdef _WIN32
-#include <Objbase.h>
-#endif
-
 namespace ExpansionInterface
 {
-void CEXIMic::StreamInit()
+bool GameCubeMicState::IsSampleOn() const
 {
-  stream_buffer = nullptr;
-  samples_avail = stream_wpos = stream_rpos = 0;
-
-#ifdef _WIN32
-  if (!m_coinit_success)
-    return;
-  m_work_queue.PushBlocking([this] {
-#endif
-    m_cubeb_ctx = CubebUtils::GetContext();
-#ifdef _WIN32
-  });
-#endif
+  return status.is_active;
 }
 
-void CEXIMic::StreamTerminate()
+bool GameCubeMicState::IsMuted() const
 {
-  StreamStop();
+  return false;  // Not applicable
+}
 
-  if (m_cubeb_ctx)
+u32 GameCubeMicState::GetDefaultSamplingRate() const
+{
+  return DEFAULT_SAMPLING_RATE;
+}
+
+namespace
+{
+class MicrophoneGameCube : public AudioCommon::Microphone
+{
+public:
+  explicit MicrophoneGameCube(const GameCubeMicState& sampler)
+      : Microphone(sampler, "GameCube Microphone"), m_sampler(sampler)
   {
-#ifdef _WIN32
-    if (!m_coinit_success)
-      return;
-    m_work_queue.PushBlocking([this] {
-#endif
-      m_cubeb_ctx.reset();
-#ifdef _WIN32
-    });
-#endif
-  }
-}
-
-static void state_callback(cubeb_stream* stream, void* user_data, cubeb_state state)
-{
-}
-
-long CEXIMic::DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
-                           void* /*output_buffer*/, long nframes)
-{
-  CEXIMic* mic = static_cast<CEXIMic*>(user_data);
-
-  std::lock_guard lk(mic->ring_lock);
-
-  const s16* buff_in = static_cast<const s16*>(input_buffer);
-  for (long i = 0; i < nframes; i++)
-  {
-    mic->stream_buffer[mic->stream_wpos] = buff_in[i];
-    mic->stream_wpos = (mic->stream_wpos + 1) % mic->stream_size;
   }
 
-  mic->samples_avail += nframes;
-  if (mic->samples_avail > mic->stream_size)
+  bool GetOverflowBit()
   {
-    mic->samples_avail = 0;
-    mic->status.buff_ovrflw = 1;
+    const bool result = m_overflow_bit_set;
+    m_overflow_bit_set = false;
+    return result;
   }
 
-  return nframes;
-}
-
-void CEXIMic::StreamStart()
-{
-  if (!m_cubeb_ctx)
-    return;
-
-#ifdef _WIN32
-  if (!m_coinit_success)
-    return;
-  m_work_queue.PushBlocking([this] {
+private:
+#ifdef HAVE_CUBEB
+  std::string GetInputDeviceId() const override { return {}; }
+  std::string GetCubebStreamName() const override { return "Dolphin Emulated GameCube Microphone"; }
+  s16 GetVolumeModifier() const override { return 0; }
+  bool AreSamplesByteSwapped() const override { return true; }
 #endif
-    // Open stream with current parameters
-    stream_size = buff_size_samples * 500;
-    stream_buffer = new s16[stream_size];
 
-    cubeb_stream_params params{};
-    params.format = CUBEB_SAMPLE_S16LE;
-    params.rate = sample_rate;
-    params.channels = 1;
-    params.layout = CUBEB_LAYOUT_MONO;
-
-    u32 minimum_latency;
-    if (cubeb_get_min_latency(m_cubeb_ctx.get(), &params, &minimum_latency) != CUBEB_OK)
-    {
-      WARN_LOG_FMT(EXPANSIONINTERFACE, "Error getting minimum latency");
-    }
-
-    if (cubeb_stream_init(m_cubeb_ctx.get(), &m_cubeb_stream,
-                          "Dolphin Emulated GameCube Microphone", nullptr, &params, nullptr,
-                          nullptr, std::max<u32>(buff_size_samples, minimum_latency), DataCallback,
-                          state_callback, this) != CUBEB_OK)
-    {
-      ERROR_LOG_FMT(EXPANSIONINTERFACE, "Error initializing cubeb stream");
-      return;
-    }
-
-    if (cubeb_stream_start(m_cubeb_stream) != CUBEB_OK)
-    {
-      ERROR_LOG_FMT(EXPANSIONINTERFACE, "Error starting cubeb stream");
-      return;
-    }
-
-    INFO_LOG_FMT(EXPANSIONINTERFACE, "started cubeb stream");
-#ifdef _WIN32
-  });
-#endif
-}
-
-void CEXIMic::StreamStop()
-{
-  if (m_cubeb_stream)
+  void OnOverflow() override
   {
-#ifdef _WIN32
-    m_work_queue.PushBlocking([this] {
-#endif
-      if (cubeb_stream_stop(m_cubeb_stream) != CUBEB_OK)
-        ERROR_LOG_FMT(EXPANSIONINTERFACE, "Error stopping cubeb stream");
-      cubeb_stream_destroy(m_cubeb_stream);
-      m_cubeb_stream = nullptr;
-#ifdef _WIN32
-    });
-#endif
+    m_samples_avail = 0;
+    m_overflow_bit_set = true;
   }
 
-  samples_avail = stream_wpos = stream_rpos = 0;
+  bool IsMicrophoneMuted() const override { return false; }
+  u32 GetStreamSize() const override { return BUFF_SIZE_SAMPLES * 500; }
 
-  delete[] stream_buffer;
-  stream_buffer = nullptr;
-}
-
-void CEXIMic::StreamReadOne()
-{
-  std::lock_guard lk(ring_lock);
-
-  if (samples_avail >= buff_size_samples)
-  {
-    s16* last_buffer = &stream_buffer[stream_rpos];
-    std::memcpy(ring_buffer, last_buffer, buff_size);
-
-    samples_avail -= buff_size_samples;
-
-    stream_rpos += buff_size_samples;
-    stream_rpos %= stream_size;
-  }
-}
+  const GameCubeMicState& m_sampler;
+  bool m_overflow_bit_set = false;
+};
+}  // namespace
 
 // EXI Mic Device
 // This works by opening and starting an input stream when the is_active
@@ -182,53 +74,10 @@ void CEXIMic::StreamReadOne()
 // cmdGetBuffer, which is when we actually read data from a buffer filled
 // in the background.
 
-u8 const CEXIMic::exi_id[] = {0, 0x0a, 0, 0, 0};
-
-CEXIMic::CEXIMic(Core::System& system, int index)
-    : IEXIDevice(system), slot(index)
-#ifdef _WIN32
-      ,
-      m_work_queue("Mic Worker")
-#endif
+CEXIMic::CEXIMic(Core::System& system, int index) : IEXIDevice(system), m_slot(index)
 {
-  m_position = 0;
-  command = 0;
-  status.U16 = 0;
-
-  sample_rate = rate_base;
-  buff_size = ring_base;
-  buff_size_samples = buff_size / sample_size;
-
-  ring_pos = 0;
-  std::memset(ring_buffer, 0, sizeof(ring_buffer));
-
-  next_int_ticks = 0;
-
-#ifdef _WIN32
-  m_work_queue.PushBlocking([this] {
-    auto result = ::CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
-    m_coinit_success = result == S_OK;
-    m_should_couninit = result == S_OK || result == S_FALSE;
-  });
-#endif
-
-  StreamInit();
-}
-
-CEXIMic::~CEXIMic()
-{
-  StreamTerminate();
-
-#ifdef _WIN32
-  if (m_should_couninit)
-  {
-    m_work_queue.PushBlocking([this] {
-      m_should_couninit = false;
-      CoUninitialize();
-    });
-  }
-  m_coinit_success = false;
-#endif
+  m_microphone = std::make_unique<MicrophoneGameCube>(m_sampler);
+  m_microphone->Initialize();
 }
 
 bool CEXIMic::IsPresent() const
@@ -246,91 +95,126 @@ void CEXIMic::SetCS(int cs)
 
 void CEXIMic::UpdateNextInterruptTicks()
 {
-  int diff = (m_system.GetSystemTimers().GetTicksPerSecond() / sample_rate) * buff_size_samples;
-  next_int_ticks = m_system.GetCoreTiming().GetTicks() + diff;
+  const int diff =
+      (m_system.GetSystemTimers().GetTicksPerSecond() / m_sample_rate) * m_buff_size_samples;
+  m_next_int_ticks = m_system.GetCoreTiming().GetTicks() + diff;
   m_system.GetExpansionInterface().ScheduleUpdateInterrupts(CoreTiming::FromThread::CPU, diff);
 }
 
 bool CEXIMic::IsInterruptSet()
 {
-  if (next_int_ticks && m_system.GetCoreTiming().GetTicks() >= next_int_ticks)
-  {
-    if (status.is_active)
-      UpdateNextInterruptTicks();
-    else
-      next_int_ticks = 0;
-
-    return true;
-  }
-  else
-  {
+  if (m_next_int_ticks == 0 || m_system.GetCoreTiming().GetTicks() < m_next_int_ticks)
     return false;
-  }
+
+  if (m_sampler.IsSampleOn())
+    UpdateNextInterruptTicks();
+  else
+    m_next_int_ticks = 0;
+
+  return true;
 }
 
 void CEXIMic::TransferByte(u8& byte)
 {
   if (m_position == 0)
   {
-    command = byte;  // first byte is command
-    byte = 0xFF;     // would be tristate, but we don't care.
+    m_command = byte;  // first byte is command
+    byte = 0xFF;       // would be tristate, but we don't care.
     m_position++;
     return;
   }
 
-  int pos = m_position - 1;
+  const int pos = m_position - 1;
 
-  switch (command)
+  switch (m_command)
   {
   case cmdID:
-    byte = exi_id[pos];
+    byte = EXI_ID[pos];
     break;
 
   case cmdGetStatus:
-    if (pos == 0)
-      status.button = Pad::GetMicButton(slot);
+  {
+    if (pos >= 2)
+      ERROR_LOG_FMT(EXPANSIONINTERFACE, "GetStatus will overflow, pos={}", pos);
+    if (static_cast<MicrophoneGameCube*>(m_microphone.get())->GetOverflowBit())
+    {
+      m_sampler.status.buff_ovrflw = 1;
+    }
 
-    byte = status.U8[pos ^ 1];
+    if (pos == 0)
+      m_sampler.status.button = Pad::GetMicButton(m_slot);
+
+    const u8* ptr = reinterpret_cast<u8*>(&m_sampler.status);
+    ptr += pos ^ 1;  // byteswap
+    byte = *ptr;
 
     if (pos == 1)
-      status.buff_ovrflw = 0;
-    break;
+      m_sampler.status.buff_ovrflw = 0;
+  }
+  break;
 
   case cmdSetStatus:
   {
-    bool wasactive = status.is_active;
-    status.U8[pos ^ 1] = byte;
+    if (pos >= 2)
+      ERROR_LOG_FMT(EXPANSIONINTERFACE, "SetStatus will overflow, pos={}", pos);
+    const bool was_active = m_sampler.IsSampleOn();
+
+    u8* ptr = reinterpret_cast<u8*>(&m_sampler.status);
+    ptr += pos ^ 1;  // byteswap
+    *ptr = byte;
 
     // safe to do since these can only be entered if both bytes of status have been written
-    if (!wasactive && status.is_active)
+    if (!was_active && m_sampler.IsSampleOn())
     {
-      sample_rate = rate_base << status.sample_rate;
-      buff_size = ring_base << status.buff_size;
-      buff_size_samples = buff_size / sample_size;
+      m_sample_rate = RATE_BASE << m_sampler.status.sample_rate;
+      m_buff_size = RING_BASE << m_sampler.status.buff_size;
+      m_buff_size_samples = m_buff_size / SAMPLE_SIZE;
 
       UpdateNextInterruptTicks();
 
-      StreamStart();
+      INFO_LOG_FMT(EXPANSIONINTERFACE, "Microphone sampling on (rate={}, samples={})",
+                   m_sample_rate, m_buff_size_samples);
+      m_microphone->SetSamplingRate(m_sample_rate);
     }
-    else if (wasactive && !status.is_active)
+    else if (was_active && !m_sampler.IsSampleOn())
     {
-      StreamStop();
+      // If IsSampleOn() is false the DataCallback will skip frames.
+      //
+      // TODO: Is it worth to stop and destroy the stream each time?
+      //
+      // StreamStop();
     }
   }
   break;
 
   case cmdGetBuffer:
   {
-    if (ring_pos == 0)
-      StreamReadOne();
+    if (m_ring_pos == 0)
+    {
+      const u32 buff_size = static_cast<u32>(m_ring_buffer.size());
+      if (m_buff_size > buff_size)
+      {
+        ERROR_LOG_FMT(EXPANSIONINTERFACE, "size={} larger than the ring_buffer's={}", m_buff_size,
+                      buff_size);
+      }
+      m_ring_size = m_microphone->ReadIntoBuffer(m_ring_buffer.data(), buff_size);
+    }
 
-    byte = ring_buffer[ring_pos ^ 1];
-    ring_pos = (ring_pos + 1) % buff_size;
+    if (m_ring_size == 0)
+    {
+      WARN_LOG_FMT(EXPANSIONINTERFACE, "Microphone buffer was empty");
+      byte = 0;
+    }
+    else
+    {
+      byte = m_ring_buffer[m_ring_pos];
+      m_ring_pos = (m_ring_pos + 1) % m_ring_size;
+    }
   }
   break;
 
   default:
-    ERROR_LOG_FMT(EXPANSIONINTERFACE, "EXI MIC: unknown command byte {:02x}", command);
+    ERROR_LOG_FMT(EXPANSIONINTERFACE, "EXI MIC: unknown command byte {:02x}", m_command);
     break;
   }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -3,31 +3,52 @@
 
 #pragma once
 
-#include <mutex>
+#include <memory>
 
+#include "AudioCommon/Microphone.h"
 #include "Common/CommonTypes.h"
-#include "Common/WorkQueueThread.h"
 #include "Core/HW/EXI/EXI_Device.h"
-
-struct cubeb;
-struct cubeb_stream;
 
 namespace ExpansionInterface
 {
+class GameCubeMicState final : public AudioCommon::MicrophoneState
+{
+public:
+  static constexpr u32 DEFAULT_SAMPLING_RATE = 11025;
+
+  bool IsSampleOn() const override;
+  bool IsMuted() const override;
+  u32 GetDefaultSamplingRate() const override;
+
+  struct Status
+  {
+    u16 out : 4;          // MICSet/GetOut...???
+    u16 id : 1;           // Used for MICGetDeviceID (always 0)
+    u16 button_unk : 3;   // Button bits which appear unused
+    u16 button : 1;       // The actual button on the mic
+    u16 buff_ovrflw : 1;  // Ring buffer wrote over bytes which weren't read by console
+    u16 gain : 1;         // Gain: 0dB or 15dB
+    u16 sample_rate : 2;  // Sample rate, 00-11025, 01-22050, 10-44100, 11-??
+    u16 buff_size : 2;    // Ring buffer size in bytes, 00-32, 01-64, 10-128, 11-???
+    u16 is_active : 1;    // If we are sampling or not
+  };
+
+  Status status{};
+};
+
 class CEXIMic : public IEXIDevice
 {
 public:
   CEXIMic(Core::System& system, const int index);
-  ~CEXIMic() override;
   void SetCS(int cs) override;
   bool IsInterruptSet() override;
   bool IsPresent() const override;
 
 private:
-  static u8 const exi_id[];
-  static int const sample_size = sizeof(s16);
-  static int const rate_base = 11025;
-  static int const ring_base = 32;
+  static constexpr u8 EXI_ID[] = {0, 0x0a, 0, 0, 0};
+  static constexpr int SAMPLE_SIZE = sizeof(s16);
+  static constexpr int RATE_BASE = 11025;
+  static constexpr int RING_BASE = 32;
 
   enum
   {
@@ -38,73 +59,31 @@ private:
     cmdReset = 0xFF,
   };
 
-  int slot;
+  int m_slot;
 
-  u32 m_position;
-  int command;
-  union UStatus
-  {
-    u16 U16;
-    u8 U8[2];
-    struct
-    {
-      u16 out : 4;          // MICSet/GetOut...???
-      u16 id : 1;           // Used for MICGetDeviceID (always 0)
-      u16 button_unk : 3;   // Button bits which appear unused
-      u16 button : 1;       // The actual button on the mic
-      u16 buff_ovrflw : 1;  // Ring buffer wrote over bytes which weren't read by console
-      u16 gain : 1;         // Gain: 0dB or 15dB
-      u16 sample_rate : 2;  // Sample rate, 00-11025, 01-22050, 10-44100, 11-??
-      u16 buff_size : 2;    // Ring buffer size in bytes, 00-32, 01-64, 10-128, 11-???
-      u16 is_active : 1;    // If we are sampling or not
-    };
-  };
-
-  static long DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
-                           void* output_buffer, long nframes);
+  u32 m_position = 0;
+  int m_command = 0;
 
   void TransferByte(u8& byte) override;
 
-  void StreamInit();
-  void StreamTerminate();
-  void StreamStart();
-  void StreamStop();
-  void StreamReadOne();
-
-  // 64 is the max size, can be 16 or 32 as well
-  int ring_pos;
-  u8 ring_buffer[64 * sample_size];
-
   // 0 to disable interrupts, else it will be checked against current CPU ticks
   // to determine if interrupt should be raised
-  u64 next_int_ticks;
+  u64 m_next_int_ticks = 0;
   void UpdateNextInterruptTicks();
 
-  // Streaming input interface
-  std::shared_ptr<cubeb> m_cubeb_ctx = nullptr;
-  cubeb_stream* m_cubeb_stream = nullptr;
-
-  UStatus status;
-
-  std::mutex ring_lock;
-
   // status bits converted to nice numbers
-  int sample_rate;
-  int buff_size;
-  int buff_size_samples;
+  u32 m_sample_rate = RATE_BASE;
+  u32 m_buff_size = RING_BASE;
+  u32 m_buff_size_samples = m_buff_size / SAMPLE_SIZE;
 
   // Arbitrarily small ringbuffer used by audio input backend in order to
   // keep delay tolerable
-  s16* stream_buffer;
-  int stream_size;
-  int stream_wpos;
-  int stream_rpos;
-  int samples_avail;
+  std::unique_ptr<AudioCommon::Microphone> m_microphone{};
+  GameCubeMicState m_sampler{};
 
-#ifdef _WIN32
-  Common::AsyncWorkThread m_work_queue;
-  bool m_coinit_success = false;
-  bool m_should_couninit = false;
-#endif
+  // 64 is the max size, can be 16 or 32 as well
+  std::array<u8, 64 * SAMPLE_SIZE> m_ring_buffer{};
+  std::size_t m_ring_pos = 0;
+  std::size_t m_ring_size = m_ring_buffer.size();
 };
 }  // namespace ExpansionInterface

--- a/Source/Core/Core/IOS/USB/Emulated/LogitechMic.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/LogitechMic.cpp
@@ -63,7 +63,7 @@ u32 LogitechMicState::GetDefaultSamplingRate() const
 
 namespace
 {
-class MicrophoneLogitech final : public Microphone
+class MicrophoneLogitech final : public AudioCommon::Microphone
 {
 public:
   explicit MicrophoneLogitech(const LogitechMicState& sampler, u8 index)

--- a/Source/Core/Core/IOS/USB/Emulated/LogitechMic.h
+++ b/Source/Core/Core/IOS/USB/Emulated/LogitechMic.h
@@ -7,14 +7,14 @@
 #include <memory>
 #include <vector>
 
+#include "AudioCommon/Microphone.h"
 #include "Common/CommonTypes.h"
 #include "Core/IOS/USB/Common.h"
-#include "Core/IOS/USB/Emulated/Microphone.h"
 
 namespace IOS::HLE::USB
 {
 
-class LogitechMicState final : public MicrophoneState
+class LogitechMicState final : public AudioCommon::MicrophoneState
 {
 public:
   // Use atomic for members concurrently used by the data callback
@@ -61,6 +61,6 @@ private:
   u8 m_index = 0;
   u8 m_active_interface = 0;
   bool m_device_attached = false;
-  std::unique_ptr<Microphone> m_microphone{};
+  std::unique_ptr<AudioCommon::Microphone> m_microphone{};
 };
 }  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/Emulated/WiiSpeak.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/WiiSpeak.cpp
@@ -28,7 +28,7 @@ u32 WiiSpeakState::GetDefaultSamplingRate() const
 
 namespace
 {
-class MicrophoneWiiSpeak final : public Microphone
+class MicrophoneWiiSpeak final : public AudioCommon::Microphone
 {
 public:
   explicit MicrophoneWiiSpeak(const WiiSpeakState& sampler)

--- a/Source/Core/Core/IOS/USB/Emulated/WiiSpeak.h
+++ b/Source/Core/Core/IOS/USB/Emulated/WiiSpeak.h
@@ -7,13 +7,13 @@
 #include <memory>
 #include <vector>
 
+#include "AudioCommon/Microphone.h"
 #include "Common/CommonTypes.h"
 #include "Core/IOS/USB/Common.h"
-#include "Core/IOS/USB/Emulated/Microphone.h"
 
 namespace IOS::HLE::USB
 {
-class WiiSpeakState final : public MicrophoneState
+class WiiSpeakState final : public AudioCommon::MicrophoneState
 {
 public:
   // Use atomic for members concurrently used by the data callback
@@ -89,7 +89,7 @@ private:
   u8 m_active_interface = 0;
   bool m_device_attached = false;
   bool init = false;
-  std::unique_ptr<Microphone> m_microphone{};
+  std::unique_ptr<AudioCommon::Microphone> m_microphone{};
   const DeviceDescriptor m_device_descriptor{0x12,  0x1,    0x200,  0,   0,   0,   0x10,
                                              0x57E, 0x0308, 0x0214, 0x1, 0x2, 0x0, 0x1};
   const std::vector<ConfigDescriptor> m_config_descriptor{

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ClInclude Include="AudioCommon\AudioCommon.h" />
     <ClInclude Include="AudioCommon\Enums.h" />
+    <ClInclude Include="AudioCommon\Microphone.h" />
     <ClInclude Include="AudioCommon\Mixer.h" />
     <ClInclude Include="AudioCommon\NullSoundStream.h" />
     <ClInclude Include="AudioCommon\OpenALStream.h" />
@@ -415,7 +416,6 @@
     <ClInclude Include="Core\IOS\USB\Common.h" />
     <ClInclude Include="Core\IOS\USB\Emulated\Infinity.h" />
     <ClInclude Include="Core\IOS\USB\Emulated\LogitechMic.h" />
-    <ClInclude Include="Core\IOS\USB\Emulated\Microphone.h" />
     <ClInclude Include="Core\IOS\USB\Emulated\Skylanders\Skylander.h" />
     <ClInclude Include="Core\IOS\USB\Emulated\Skylanders\SkylanderCrypto.h" />
     <ClInclude Include="Core\IOS\USB\Emulated\Skylanders\SkylanderFigure.h" />
@@ -798,6 +798,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AudioCommon\AudioCommon.cpp" />
+    <ClCompile Include="AudioCommon\Microphone.cpp" />
     <ClCompile Include="AudioCommon\Mixer.cpp" />
     <ClCompile Include="AudioCommon\NullSoundStream.cpp" />
     <ClCompile Include="AudioCommon\OpenALStream.cpp" />
@@ -1098,7 +1099,6 @@
     <ClCompile Include="Core\IOS\USB\Common.cpp" />
     <ClCompile Include="Core\IOS\USB\Emulated\Infinity.cpp" />
     <ClCompile Include="Core\IOS\USB\Emulated\LogitechMic.cpp" />
-    <ClCompile Include="Core\IOS\USB\Emulated\Microphone.cpp" />
     <ClCompile Include="Core\IOS\USB\Emulated\Skylanders\Skylander.cpp" />
     <ClCompile Include="Core\IOS\USB\Emulated\Skylanders\SkylanderCrypto.cpp" />
     <ClCompile Include="Core\IOS\USB\Emulated\Skylanders\SkylanderFigure.cpp" />


### PR DESCRIPTION
This PR deduplicates the code between the Logitech USB, Wii Speak and GameCube microphones. I'll put it as a draft for now, as I'd like to implement some more features.

TODO:
 - [x] Move the code to AudioCommon
 - [x] Refactor the GC microphone code
 - [ ] Check the GC microphone code for regressions/improvements
   * Investigate this regression, the sound is louder and can saturate, compared to master
 - [ ] Allow to configure the GC microphone device (like WiiSpeak/Logitech USB)
 - [ ] Ensure 2 GC microphones can work simultaneously

I'm able to test the following games:
 - [ ] Mario Party 6
 - [ ] Mario Party 7
 - [ ] Karaoke Revolution Party _(you can hear your voice back on this one)_
