### PR TITLE
mingw: replace usages of SendMessage due to clash with existing function

### DIFF
--- a/Source/Core/VideoCommon/NetPlayChatUI.cpp
+++ b/Source/Core/VideoCommon/NetPlayChatUI.cpp
@@ -59,7 +59,7 @@ void NetPlayChatUI::Display()
   if (ImGui::InputText("##NetplayMessageBuffer", m_message_buf, IM_ARRAYSIZE(m_message_buf),
                        ImGuiInputTextFlags_EnterReturnsTrue))
   {
-    SendMessage();
+    SendChatMessage();
   }
 
   if (m_activate)
@@ -73,7 +73,7 @@ void NetPlayChatUI::Display()
   ImGui::SameLine();
 
   if (ImGui::Button("Send"))
-    SendMessage();
+    SendChatMessage();
 
   ImGui::End();
 }
@@ -90,7 +90,7 @@ void NetPlayChatUI::AppendChat(std::string message, Color color)
     m_scroll_to_bottom = true;
 }
 
-void NetPlayChatUI::SendMessage()
+void NetPlayChatUI::SendChatMessage()
 {
   // Check whether the input field is empty
   if (m_message_buf[0] != '\0')

--- a/Source/Core/VideoCommon/NetPlayChatUI.h
+++ b/Source/Core/VideoCommon/NetPlayChatUI.h
@@ -20,7 +20,7 @@ public:
 
   void Display();
   void AppendChat(std::string message, Color color);
-  void SendMessage();
+  void SendChatMessage();
   void Activate();
 
 private:


### PR DESCRIPTION
SendMessage is an existing function being pulled in causing a compiler failure