### PR TITLE
mingw: lower case windows includes

### DIFF
--- a/Source/Core/AudioCommon/CubebStream.cpp
+++ b/Source/Core/AudioCommon/CubebStream.cpp
@@ -12,7 +12,7 @@
 #include "Core/System.h"
 
 #ifdef _WIN32
-#include <Objbase.h>
+#include <objbase.h>
 #endif
 
 // ~10 ms - needs to be at least 240 for surround

--- a/Source/Core/AudioCommon/CubebUtils.cpp
+++ b/Source/Core/AudioCommon/CubebUtils.cpp
@@ -14,7 +14,7 @@
 #include <cubeb/cubeb.h>
 
 #ifdef _WIN32
-#include <Objbase.h>
+#include <objbase.h>
 #endif
 
 static void LogCallback(const char* format, ...)

--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -7,7 +7,7 @@
 
 // clang-format off
 #include <initguid.h>
-#include <Audioclient.h>
+#include <audioclient.h>
 #include <mmdeviceapi.h>
 #include <functiondiscoverykeys_devpkey.h>
 #include <wil/resource.h>

--- a/Source/Core/AudioCommon/WASAPIStream.h
+++ b/Source/Core/AudioCommon/WASAPIStream.h
@@ -6,7 +6,7 @@
 #ifdef _WIN32
 
 // clang-format off
-#include <Windows.h>
+#include <windows.h>
 #include <mmreg.h>
 #include <objbase.h>
 #include <wil/resource.h>

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -21,7 +21,7 @@
 #include "Common/SmallVector.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 #ifdef __APPLE__
 #include <libkern/OSCacheControl.h>

--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -12,7 +12,7 @@
 #ifdef __APPLE__
 #include <sys/sysctl.h>
 #elif defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #include <arm64intr.h>
 #include "Common/WindowsRegistry.h"
 #elif defined(__linux__)

--- a/Source/Core/Common/CommonFuncs.cpp
+++ b/Source/Core/Common/CommonFuncs.cpp
@@ -9,7 +9,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#include <SetupAPI.h>
+#include <setupapi.h>
 
 #define strerror_r(err, buf, len) strerror_s(buf, len, err)
 

--- a/Source/Core/Common/CompatPatches.cpp
+++ b/Source/Core/Common/CompatPatches.cpp
@@ -1,7 +1,7 @@
 // Copyright 2008 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <Windows.h>
+#include <windows.h>
 #include <functional>
 #include <optional>
 #include <string>

--- a/Source/Core/Common/DynamicLibrary.cpp
+++ b/Source/Core/Common/DynamicLibrary.cpp
@@ -8,7 +8,7 @@
 #include <fmt/format.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <dlfcn.h>
 #endif

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -11,8 +11,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
-#ifdef _MSC_VER
-#include <Windows.h>
+#ifdef _WIN32
+#include <windows.h>
 #elifdef ANDROID
 #include "jni/AndroidCommon/AndroidCommon.h"
 #endif

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -29,13 +29,13 @@
 #include "Common/StringUtil.h"
 
 #ifdef _WIN32
-#include <Windows.h>
-#include <Shlwapi.h>
+#include <windows.h>
 #include <commdlg.h>  // for GetSaveFileName
 #include <direct.h>   // getcwd
 #include <io.h>
 #include <objbase.h>  // guid stuff
 #include <shellapi.h>
+#include <shlwapi.h>
 #else
 #include <libgen.h>
 #include <stdlib.h>

--- a/Source/Core/Common/LdrWatcher.cpp
+++ b/Source/Core/Common/LdrWatcher.cpp
@@ -3,9 +3,9 @@
 
 #include "Common/LdrWatcher.h"
 
-#include <Windows.h>
-#include <TlHelp32.h>
+#include <windows.h>
 #include <string>
+#include <tlhelp32.h>
 #include <winternl.h>
 
 typedef struct _LDR_DLL_LOADED_NOTIFICATION_DATA

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -13,7 +13,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #else
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif
 
 #include <fmt/format.h>

--- a/Source/Core/Common/SocketContext.h
+++ b/Source/Core/Common/SocketContext.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #ifdef _WIN32
-#include <WinSock2.h>
 #include <mutex>
+#include <winsock2.h>
 #endif
 
 namespace Common

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -25,7 +25,7 @@
 #include "Common/Logging/Log.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <shellapi.h>
 constexpr u32 CODEPAGE_SHIFT_JIS = 932;
 constexpr u32 CODEPAGE_WINDOWS_1252 = 1252;

--- a/Source/Core/Common/Thread.cpp
+++ b/Source/Core/Common/Thread.cpp
@@ -4,7 +4,7 @@
 #include "Common/Thread.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <processthreadsapi.h>
 #else
 #include <pthread.h>

--- a/Source/Core/Common/Timer.cpp
+++ b/Source/Core/Common/Timer.cpp
@@ -8,7 +8,7 @@
 #include "Common/CommonFuncs.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <timeapi.h>
 #endif
 

--- a/Source/Core/Common/WindowsDevice.cpp
+++ b/Source/Core/Common/WindowsDevice.cpp
@@ -7,7 +7,7 @@
 
 #include <string>
 
-#include "Hidclass.h"
+#include "hidclass.h"
 
 #include "Common/CommonFuncs.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Common/WindowsDevice.h
+++ b/Source/Core/Common/WindowsDevice.h
@@ -16,11 +16,10 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
-
-#include <SetupAPI.h>
+#include <windows.h>
 #include <cfgmgr32.h>
 #include <devpropdef.h>
+#include <setupapi.h>
 
 #include "Common/Functional.h"
 

--- a/Source/Core/Common/WindowsRegistry.cpp
+++ b/Source/Core/Common/WindowsRegistry.cpp
@@ -1,6 +1,6 @@
 #include "Common/WindowsRegistry.h"
 
-#include <Windows.h>
+#include <windows.h>
 #include <string>
 #include <type_traits>
 #include "Common/StringUtil.h"

--- a/Source/Core/Common/WindowsRegistry.h
+++ b/Source/Core/Common/WindowsRegistry.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 #include <string>
 
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/Config/DefaultLocale.cpp
+++ b/Source/Core/Core/Config/DefaultLocale.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "Common/Assert.h"

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -13,7 +13,7 @@
 #include <fmt/format.h>
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #include "Common/WindowsRegistry.h"
 #endif
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -4,7 +4,7 @@
 #include "Core/HW/DSPHLE/UCodes/ROM.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "Common/ChunkFile.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "Common/ChunkFile.h"

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 using socklen_t = int;
 #else
 #include <netinet/in.h>

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -11,7 +11,7 @@
 #include "SFML/Network/IpAddress.hpp"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <SFML/Network.hpp>

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -20,7 +20,7 @@
 #include "Core/System.h"
 
 #ifdef _WIN32
-#include <Objbase.h>
+#include <objbase.h>
 #endif
 
 namespace ExpansionInterface

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -9,11 +9,11 @@
 #include <optional>
 #include <vector>
 
-#include <Windows.h>
-#include <BluetoothAPIs.h>
-#include <Cfgmgr32.h>
-#include <Hidclass.h>
-#include <Hidsdi.h>
+#include <windows.h>
+#include <bluetoothapis.h>
+#include <cfgmgr32.h>
+#include <hidclass.h>
+#include <hidsdi.h>
 #include <initguid.h>
 #include <wtypes.h>
 // initguid.h must be included before devpkey.h

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -12,7 +12,7 @@
 
 #ifdef _WIN32
 // TODO: Horrible hack, remove ASAP!
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/IOS/Network/ICMP.h
+++ b/Source/Core/Core/IOS/Network/ICMP.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #else
 #include <netinet/in.h>
 #endif

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #ifdef _WIN32
-#include <WinSock2.h>
 #include <iphlpapi.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 
 typedef pollfd pollfd_t;

--- a/Source/Core/Core/IOS/USB/Emulated/Microphone.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Microphone.cpp
@@ -21,7 +21,7 @@
 #include "Core/System.h"
 
 #ifdef _WIN32
-#include <Objbase.h>
+#include <objbase.h>
 #endif
 
 #ifdef ANDROID

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -9,7 +9,7 @@
 #include <mutex>
 
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 using socklen_t = int;
 #else
 #include <netinet/in.h>

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -9,8 +9,8 @@
 #include <optional>
 #include <string.h>
 #ifdef _WIN32
-#include <WinSock2.h>
 #include <iphlpapi.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 typedef SSIZE_T ssize_t;
 #define SHUT_RDWR SD_BOTH

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -12,7 +12,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "Common/ScopeGuard.h"

--- a/Source/Core/DolphinNoGUI/PlatformWin32.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformWin32.cpp
@@ -8,7 +8,7 @@
 #include "Core/Core.h"
 #include "Core/System.h"
 
-#include <Windows.h>
+#include <windows.h>
 #include <climits>
 #include <dwmapi.h>
 

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #ifdef __linux__

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -32,7 +32,7 @@
 #include "VideoCommon/Present.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <dwmapi.h>
 #endif
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.cpp
@@ -7,8 +7,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <Windows.h>
-#include <SetupAPI.h>
+#include <windows.h>
+#include <setupapi.h>
 
 namespace ciface::DInput
 {

--- a/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 #include <unordered_set>
 
 namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <thread>
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "Common/Event.h"
 #include "Common/Flag.h"

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <SDL3/SDL.h>

--- a/Source/Core/InputCommon/ControllerInterface/Win32/Win32.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Win32/Win32.cpp
@@ -3,7 +3,7 @@
 
 #include "InputCommon/ControllerInterface/Win32/Win32.h"
 
-#include <Windows.h>
+#include <windows.h>
 #include <cfgmgr32.h>
 // must be before hidclass
 #include <initguid.h>

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <windows.h>
-#include <XInput.h>
+#include <xinput.h>
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -18,7 +18,7 @@
 #include "Common/Version.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <unistd.h>
 #endif

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -32,7 +32,7 @@
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <filesystem>
 #endif
 

--- a/Source/Core/WinUpdater/Platform.cpp
+++ b/Source/Core/WinUpdater/Platform.cpp
@@ -1,4 +1,4 @@
-#include <Windows.h>
+#include <windows.h>
 
 #include <filesystem>
 #include <map>

--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -7,11 +7,11 @@
 #include <string>
 #include <thread>
 
-#include <Windows.h>
-#include <CommCtrl.h>
-#include <ShObjIdl.h>
-#include <ShlObj.h>
+#include <windows.h>
+#include <commctrl.h>
 #include <shellapi.h>
+#include <shlobj.h>
+#include <shobjidl.h>
 #include <wrl/client.h>
 
 #include "Common/Event.h"

--- a/Source/PCH/pch.h
+++ b/Source/PCH/pch.h
@@ -94,7 +94,7 @@
 #include <vector>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "Common/Common.h"


### PR DESCRIPTION
Make all Windows includes lower case as ming on Linux only provides them in lower case and fails to compile otherwise