### PR TITLE
mingw: use reinterpret_cast for function→void* conversion to satisfy …

### DIFF
--- a/Source/Core/Common/GL/GLInterface/WGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/WGL.cpp
@@ -223,7 +223,7 @@ void* GLContextWGL::GetFuncAddress(const std::string& name)
     func = GetProcAddress(opengl_module, name.c_str());
   }
 
-  return func;
+  return reinterpret_cast<void*>(func);
 }
 
 // Create rendering window.


### PR DESCRIPTION
…C++ standard