### PR TITLE
CCache: Set as opt-in by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence, show the current gam
 option(USE_MGBA "Enables GBA controllers emulation using libmgba" ON)
 option(ENABLE_AUTOUPDATE "Enables support for automatic updates" ON)
 option(USE_RETRO_ACHIEVEMENTS "Enables integration with retroachievements.org" ON)
+option(ENABLE_CCACHE "Enables CCache compiler cache" OFF)
 
 # Maintainers: if you consider blanket disabling this for your users, please
 # consider the following points:
@@ -207,8 +208,12 @@ if (WIN32)
   endif()
 endif()
 
-# setup CCache
-include(CCache)
+if(ENABLE_CCACHE)
+  include(CCache)
+  if(NOT CCACHE_BIN)
+    message(WARNING "Ccache was enabled but not found. This build will not use Ccache.")
+  endif()
+endif()
 
 # Architecture detection and arch specific settings
 message(STATUS "Detected architecture: ${CMAKE_SYSTEM_PROCESSOR}")


### PR DESCRIPTION
I'm not sure if we want to set it to OFF by default, like most projects do. ~~I've set it to ON and show no warning if it's missing to match the current behavior~~, but feedback would be appreciated.

Ccache is now opt-in, showing a warning to the user if they're trying to use Ccache without having it installed on their system.