### PR TITLE
GameINI: Add codes to NiGHTS Journey of Dreams

### DIFF
--- a/Data/Sys/GameSettings/R7E.ini
+++ b/Data/Sys/GameSettings/R7E.ini
@@ -12,3 +12,7 @@
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 
+[Gecko]
+$60FPS [Nick Reynolds]
+045524c8 00000001
+*During Will's final stage towards the cutscene with Helen, fly towards the bottom of the level to avoid softlocking.


### PR DESCRIPTION
This PR provides 60 FPS code additions to NiGHTS: Journey of Dreams.

NTSC-U/PAL/NTSC-J:
* Added 60 FPS code, coming from the Dolphin wiki.
* Followed my code naming convention for Sega games.
* The wiki says that the code is for NTSC-U but it's actually region free. It's been confirmed via testing.
* The wiki also says that a certain part in the final level softlocks, but that's actually not true and can be bypassed. An explanation has been included with the code.