### PR TITLE
GameINI: Add codes to Sonic Storybook games

### DIFF
--- a/Data/Sys/GameSettings/RENE8P.ini
+++ b/Data/Sys/GameSettings/RENE8P.ini
@@ -1,0 +1,5 @@
+# RENE8P - Sonic and the Black Knight
+
+[Gecko]
+$60FPS [Nick Reynolds]
+040887D8 3800003C

--- a/Data/Sys/GameSettings/RSR.ini
+++ b/Data/Sys/GameSettings/RSR.ini
@@ -1,4 +1,4 @@
-# RSRP8P, RSRE8P, RSRJ8P - Sonic and the Secret Rings
+# RSRE8P, RSRJ8P, RSRP8P - Sonic and the Secret Rings
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/RSRE8P.ini
+++ b/Data/Sys/GameSettings/RSRE8P.ini
@@ -1,0 +1,5 @@
+# RSRE8P - Sonic and the Secret Rings
+
+[Gecko]
+$60FPS [Nick Reynolds]
+040B6878 3800003C


### PR DESCRIPTION
This PR provides 60 FPS code additions to Sonic and the Secret Rings & Sonic and the Black Knight.

All regions:
* Formatting fixes.

NTSC-U:
* Added 60 FPS code, coming from the Dolphin wiki.
* Followed my code naming convention for Sega games.