### PR TITLE
GameINI: Add codes to Sonic Unleashed

### DIFF
--- a/Data/Sys/GameSettings/RSVE8P.ini
+++ b/Data/Sys/GameSettings/RSVE8P.ini
@@ -1,0 +1,27 @@
+# RSVE8P - Sonic Unleashed
+
+[Gecko]
+$Toggleable 60FPS (Gamecube controller) [yorkiesandskittles, dreamsyntax]
+28760BF7 00000008
+04868794 3F800000
+04792460 0000003C
+0419D33C 4E800020
+E0000000 80008000
+28760BF7 00000004
+04868794 40000000
+04792460 0000001E
+0419D33C 806304C4
+E0000000 80008000
+*Causes many problems during gameplay. Use D-pad Up to toggle to 60 FPS, and D-pad Down to toggle to 30 FPS, as necessary.
+$Toggleable 60FPS (Wii controller) [yorkiesandskittles, dreamsyntax]
+288144aa 00000008
+04868794 3f800000
+04792460 0000003c
+0419d33c 4e800020
+e0000000 80008000
+288144aa 00000004
+04868794 40000000
+04792460 0000001e
+0419d33c 806304c4
+e0000000 80008000
+*Causes many problems during gameplay. Use D-pad Up to toggle to 60 FPS, and D-pad Down to toggle to 30 FPS, as necessary.


### PR DESCRIPTION
This PR provides 60 FPS code additions to Sonic Unleashed.

NTSC-U:
* Added 60 FPS code, coming from the Dolphin wiki.
* Followed my code naming convention for Sega games.