### PR TITLE
Config: Add Edit button to DSU server menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ CMakeLists.txt.user
 /.vscode/
 # Ignore flatpak-builder's cache dir
 .flatpak-builder
+
+# clangd cache for Neovim
+.cache/clangd

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -71,10 +71,12 @@ add_executable(dolphin-emu
   Config/ControllerInterface/ControllerInterfaceWindow.h
   Config/SDLHints/SDLHintsWindow.cpp
   Config/SDLHints/SDLHintsWindow.h
-  Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
-  Config/ControllerInterface/DualShockUDPClientAddServerDialog.h
+  Config/ControllerInterface/DualShockUDPClientEditServerDialog.cpp
+  Config/ControllerInterface/DualShockUDPClientEditServerDialog.h
   Config/ControllerInterface/DualShockUDPClientWidget.cpp
   Config/ControllerInterface/DualShockUDPClientWidget.h
+  Config/ControllerInterface/DualShockUDPSettings.cpp
+  Config/ControllerInterface/DualShockUDPSettings.h
   Config/ControllerInterface/ServerStringValidator.cpp
   Config/ControllerInterface/ServerStringValidator.h
   Config/ControllersPane.cpp

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientEditServerDialog.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientEditServerDialog.cpp
@@ -1,7 +1,7 @@
 // Copyright 2020 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.h"
+#include "DolphinQt/Config/ControllerInterface/DualShockUDPClientEditServerDialog.h"
 
 #include <fmt/format.h>
 
@@ -15,20 +15,21 @@
 #include <QString>
 #include <QWidget>
 
-#include "Common/Config/Config.h"
+#include "DolphinQt/Config/ControllerInterface/DualShockUDPSettings.h"
 #include "DolphinQt/Config/ControllerInterface/ServerStringValidator.h"
 #include "InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h"
 
-DualShockUDPClientAddServerDialog::DualShockUDPClientAddServerDialog(QWidget* parent)
-    : QDialog(parent)
+DualShockUDPClientEditServerDialog::DualShockUDPClientEditServerDialog(
+    QWidget* parent, std::optional<size_t> existing_index)
+    : QDialog(parent), m_existing_index(std::move(existing_index))
 {
   CreateWidgets();
   setLayout(m_main_layout);
 }
 
-void DualShockUDPClientAddServerDialog::CreateWidgets()
+void DualShockUDPClientEditServerDialog::CreateWidgets()
 {
-  setWindowTitle(tr("Add New DSU Server"));
+  setWindowTitle(tr(m_existing_index.has_value() ? "Edit DSU Server" : "Add New DSU Server"));
 
   m_main_layout = new QGridLayout;
 
@@ -44,6 +45,14 @@ void DualShockUDPClientAddServerDialog::CreateWidgets()
   m_server_port->setMaximum(65535);
   m_server_port->setValue(ciface::DualShockUDPClient::DEFAULT_SERVER_PORT);
 
+  if (m_existing_index.has_value())
+  {
+    const auto server = DualShockUDPSettings::GetServers()[*m_existing_index];
+    m_description->setText(QString::fromStdString(server.description));
+    m_server_address->setText(QString::fromStdString(server.server_address));
+    m_server_port->setValue(server.server_port);
+  }
+
   m_main_layout->addWidget(new QLabel(tr("Description")), 1, 0);
   m_main_layout->addWidget(m_description, 1, 1);
   m_main_layout->addWidget(new QLabel(tr("Server IP Address")), 2, 0);
@@ -52,25 +61,30 @@ void DualShockUDPClientAddServerDialog::CreateWidgets()
   m_main_layout->addWidget(m_server_port, 3, 1);
 
   m_buttonbox = new QDialogButtonBox();
-  auto* add_button = new QPushButton(tr("Add"));
+  auto* finish_button = new QPushButton(tr(m_existing_index ? "Apply" : "Add"));
   auto* cancel_button = new QPushButton(tr("Cancel"));
-  m_buttonbox->addButton(add_button, QDialogButtonBox::AcceptRole);
+  m_buttonbox->addButton(finish_button, QDialogButtonBox::AcceptRole);
   m_buttonbox->addButton(cancel_button, QDialogButtonBox::RejectRole);
-  connect(add_button, &QPushButton::clicked, this,
-          &DualShockUDPClientAddServerDialog::OnServerAdded);
-  connect(cancel_button, &QPushButton::clicked, this, &DualShockUDPClientAddServerDialog::reject);
-  add_button->setDefault(true);
+  connect(finish_button, &QPushButton::clicked, this,
+          &DualShockUDPClientEditServerDialog::OnServerFinished);
+  connect(cancel_button, &QPushButton::clicked, this, &DualShockUDPClientEditServerDialog::reject);
+  finish_button->setDefault(true);
 
   m_main_layout->addWidget(m_buttonbox, 4, 0, 1, 2);
 }
 
-void DualShockUDPClientAddServerDialog::OnServerAdded()
+void DualShockUDPClientEditServerDialog::OnServerFinished()
 {
-  const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
-  Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS,
-                           servers_setting + fmt::format("{}:{}:{};",
-                                                         m_description->text().toStdString(),
-                                                         m_server_address->text().toStdString(),
-                                                         m_server_port->value()));
+  const auto server =
+      DualShockUDPServer(m_description->text().toStdString(),
+                         m_server_address->text().toStdString(), m_server_port->value());
+  if (m_existing_index.has_value())
+  {
+    DualShockUDPSettings::ReplaceServer(*m_existing_index, server);
+  }
+  else
+  {
+    DualShockUDPSettings::AddServer(server);
+  }
   accept();
 }

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientEditServerDialog.h
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientEditServerDialog.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QDialog>
 
 class QDialogButtonBox;
@@ -10,16 +12,18 @@ class QGridLayout;
 class QLineEdit;
 class QSpinBox;
 
-class DualShockUDPClientAddServerDialog final : public QDialog
+class DualShockUDPClientEditServerDialog final : public QDialog
 {
   Q_OBJECT
 public:
-  explicit DualShockUDPClientAddServerDialog(QWidget* parent);
+  explicit DualShockUDPClientEditServerDialog(QWidget* parent,
+                                              std::optional<size_t> existing_index);
 
 private:
   void CreateWidgets();
-  void OnServerAdded();
+  void OnServerFinished();
 
+  std::optional<size_t> m_existing_index;
   QDialogButtonBox* m_buttonbox;
   QGridLayout* m_main_layout;
   QLineEdit* m_description;

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
@@ -11,10 +11,9 @@
 #include <QListWidget>
 #include <QPushButton>
 
-#include "Common/Config/Config.h"
-#include "DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.h"
+#include "DolphinQt/Config/ControllerInterface/DualShockUDPClientEditServerDialog.h"
+#include "DolphinQt/Config/ControllerInterface/DualShockUDPSettings.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
-#include "InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h"
 
 DualShockUDPClientWidget::DualShockUDPClientWidget()
 {
@@ -27,27 +26,26 @@ void DualShockUDPClientWidget::CreateWidgets()
   auto* main_layout = new QVBoxLayout;
 
   m_servers_enabled = new QCheckBox(tr("Enable"));
-  m_servers_enabled->setChecked(Config::Get(ciface::DualShockUDPClient::Settings::SERVERS_ENABLED));
+  m_servers_enabled->setChecked(DualShockUDPSettings::IsEnabled());
   main_layout->addWidget(m_servers_enabled, 0, {});
 
   m_server_list = new QListWidget();
   main_layout->addWidget(m_server_list);
 
   m_add_server = new NonDefaultQPushButton(tr("Add..."));
-  m_add_server->setEnabled(m_servers_enabled->isChecked());
-
+  m_edit_server = new NonDefaultQPushButton(tr("Edit"));
   m_remove_server = new NonDefaultQPushButton(tr("Remove"));
-  m_remove_server->setEnabled(m_servers_enabled->isChecked());
 
   QHBoxLayout* hlayout = new QHBoxLayout;
   hlayout->addStretch();
   hlayout->addWidget(m_add_server);
+  hlayout->addWidget(m_edit_server);
   hlayout->addWidget(m_remove_server);
 
   main_layout->addItem(hlayout);
 
   auto* description =
-      new QLabel(tr("DSU protocol enables the use of input and motion data from compatible "
+      new QLabel(tr("The DSU protocol enables the use of input and motion data from compatible "
                     "sources, like PlayStation, Nintendo Switch and Steam controllers.<br><br>"
                     "For setup instructions, "
                     "<a href=\"https://wiki.dolphin-emu.org/index.php?title=DSU_Client\">"
@@ -65,82 +63,69 @@ void DualShockUDPClientWidget::CreateWidgets()
 
 void DualShockUDPClientWidget::ConnectWidgets()
 {
+  connect(m_add_server, &QPushButton::clicked, this, &DualShockUDPClientWidget::OnServerAdded);
+  connect(m_edit_server, &QPushButton::clicked, this, &DualShockUDPClientWidget::OnServerEdited);
+  connect(m_remove_server, &QPushButton::clicked, this, &DualShockUDPClientWidget::OnServerRemoved);
+  connect(m_server_list, &QListWidget::currentRowChanged, this,
+          &DualShockUDPClientWidget::OnServerSelection);
   connect(m_servers_enabled, &QCheckBox::clicked, this,
           &DualShockUDPClientWidget::OnServersToggled);
-  connect(m_add_server, &QPushButton::clicked, this, &DualShockUDPClientWidget::OnServerAdded);
-  connect(m_remove_server, &QPushButton::clicked, this, &DualShockUDPClientWidget::OnServerRemoved);
+}
+
+void DualShockUDPClientWidget::SetButtonEnableStates()
+{
+  const bool has_selection = m_server_list->currentRow() != -1;
+  m_edit_server->setEnabled(has_selection);
+  m_remove_server->setEnabled(has_selection);
 }
 
 void DualShockUDPClientWidget::RefreshServerList()
 {
   m_server_list->clear();
 
-  const auto server_address_setting =
-      Config::Get(ciface::DualShockUDPClient::Settings::SERVER_ADDRESS);
-  const auto server_port_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVER_PORT);
-
-  // Update our servers setting if the user is using old configuration
-  if (!server_address_setting.empty() && server_port_setting != 0)
+  for (const auto& server : DualShockUDPSettings::GetServers())
   {
-    const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
-    Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS,
-                             servers_setting + fmt::format("{}:{}:{};", "DS4",
-                                                           server_address_setting,
-                                                           server_port_setting));
-    Config::SetBase(ciface::DualShockUDPClient::Settings::SERVER_ADDRESS, "");
-    Config::SetBase(ciface::DualShockUDPClient::Settings::SERVER_PORT, 0);
-  }
-
-  const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
-  const auto server_details = SplitString(servers_setting, ';');
-  for (const std::string& server_detail : server_details)
-  {
-    const auto server_info = SplitString(server_detail, ':');
-    if (server_info.size() < 3)
-      continue;
-
     QListWidgetItem* list_item = new QListWidgetItem(QString::fromStdString(
-        fmt::format("{}:{} - {}", server_info[1], server_info[2], server_info[0])));
+        fmt::format("{}:{} - {}", server.description, server.server_address, server.server_port)));
     m_server_list->addItem(list_item);
   }
+
+  SetButtonEnableStates();
+
   emit ConfigChanged();
 }
 
 void DualShockUDPClientWidget::OnServerAdded()
 {
-  DualShockUDPClientAddServerDialog add_server_dialog(this);
-  connect(&add_server_dialog, &DualShockUDPClientAddServerDialog::accepted, this,
+  DualShockUDPClientEditServerDialog add_server_dialog(this, std::nullopt);
+  connect(&add_server_dialog, &DualShockUDPClientEditServerDialog::accepted, this,
           &DualShockUDPClientWidget::RefreshServerList);
   add_server_dialog.exec();
+}
+
+void DualShockUDPClientWidget::OnServerEdited()
+{
+  DualShockUDPClientEditServerDialog edit_server_dialog(this, m_server_list->currentRow());
+  connect(&edit_server_dialog, &DualShockUDPClientEditServerDialog::accepted, this,
+          &DualShockUDPClientWidget::RefreshServerList);
+  edit_server_dialog.exec();
 }
 
 void DualShockUDPClientWidget::OnServerRemoved()
 {
   const int row_to_remove = m_server_list->currentRow();
 
-  const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
-  const auto server_details = SplitString(servers_setting, ';');
-
-  std::string new_server_setting;
-  for (int i = 0; i < m_server_list->count(); i++)
-  {
-    if (i == row_to_remove)
-    {
-      continue;
-    }
-
-    new_server_setting += server_details[i] + ';';
-  }
-
-  Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS, new_server_setting);
+  DualShockUDPSettings::RemoveServer(row_to_remove);
 
   RefreshServerList();
 }
 
+void DualShockUDPClientWidget::OnServerSelection()
+{
+  SetButtonEnableStates();
+}
+
 void DualShockUDPClientWidget::OnServersToggled()
 {
-  bool checked = m_servers_enabled->isChecked();
-  Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS_ENABLED, checked);
-  m_add_server->setEnabled(checked);
-  m_remove_server->setEnabled(checked);
+  DualShockUDPSettings::SetEnabled(m_servers_enabled->isChecked());
 }

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.h
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.h
@@ -24,14 +24,18 @@ private:
   void CreateWidgets();
   void ConnectWidgets();
 
+  void SetButtonEnableStates();
   void RefreshServerList();
 
   void OnServerAdded();
+  void OnServerEdited();
   void OnServerRemoved();
+  void OnServerSelection();
   void OnServersToggled();
 
   QCheckBox* m_servers_enabled;
   QListWidget* m_server_list;
   QPushButton* m_add_server;
+  QPushButton* m_edit_server;
   QPushButton* m_remove_server;
 };

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPSettings.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPSettings.cpp
@@ -1,0 +1,129 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DualShockUDPSettings.h"
+
+#include <fmt/format.h>
+
+#include "Common/Config/Config.h"
+#include "Common/StringUtil.h"
+#include "InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h"
+
+namespace
+{
+std::string SerializeServer(DualShockUDPServer server)
+{
+  return fmt::format("{}{}{}{}{}{}", server.description, DualShockUDPSettings::FIELD_SEPARATOR,
+                     server.server_address, DualShockUDPSettings::FIELD_SEPARATOR,
+                     server.server_port, DualShockUDPSettings::SERVER_SEPARATOR);
+}
+
+void MigrateIfNeeded()
+{
+  const auto server_address_setting =
+      Config::Get(ciface::DualShockUDPClient::Settings::SERVER_ADDRESS);
+  const auto server_port_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVER_PORT);
+
+  // Update our servers setting if the user is using old configuration
+  if (!server_address_setting.empty() && server_port_setting != 0)
+  {
+    const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
+    Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS,
+                             servers_setting +
+                                 SerializeServer(DualShockUDPServer("DS4", server_address_setting,
+                                                                    server_port_setting)));
+    Config::SetBase(ciface::DualShockUDPClient::Settings::SERVER_ADDRESS, "");
+    Config::SetBase(ciface::DualShockUDPClient::Settings::SERVER_PORT, 0);
+  }
+}
+}  // Anonymous namespace
+
+namespace DualShockUDPSettings
+{
+std::vector<DualShockUDPServer> GetServers()
+{
+  MigrateIfNeeded();
+
+  const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
+  const auto server_details = SplitString(servers_setting, SERVER_SEPARATOR);
+
+  std::vector<DualShockUDPServer> result;
+  for (const std::string& server_detail : server_details)
+  {
+    const auto server_info = SplitString(server_detail, FIELD_SEPARATOR);
+    if (server_info.size() < 3)
+      continue;
+
+    int port;
+    if (TryParse(server_info[2], &port))
+    {
+      result.push_back(DualShockUDPServer(server_info[0], server_info[1], port));
+    }
+  }
+
+  return result;
+}
+
+void AddServer(DualShockUDPServer server)
+{
+  MigrateIfNeeded();
+
+  const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
+  Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS,
+                           servers_setting + SerializeServer(server));
+}
+
+void ReplaceServer(size_t index, DualShockUDPServer server)
+{
+  MigrateIfNeeded();
+
+  const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
+  const auto server_details = SplitString(servers_setting, SERVER_SEPARATOR);
+
+  std::string new_servers_setting;
+  for (size_t i = 0; i < server_details.size(); i++)
+  {
+    if (i == index)
+    {
+      new_servers_setting += SerializeServer(server);
+    }
+    else
+    {
+      new_servers_setting += server_details[i] + SERVER_SEPARATOR;
+    }
+  }
+
+  Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS, new_servers_setting);
+}
+
+void RemoveServer(size_t index)
+{
+  MigrateIfNeeded();
+
+  const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
+  const auto server_details = SplitString(servers_setting, SERVER_SEPARATOR);
+
+  std::string new_servers_setting;
+  for (size_t i = 0; i < server_details.size(); i++)
+  {
+    if (i == index)
+    {
+      continue;
+    }
+
+    new_servers_setting += server_details[i] + SERVER_SEPARATOR;
+  }
+
+  Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS, new_servers_setting);
+}
+
+bool IsEnabled()
+{
+  return Config::Get(ciface::DualShockUDPClient::Settings::SERVERS_ENABLED);
+}
+
+void SetEnabled(bool enabled)
+{
+  Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS_ENABLED, enabled);
+}
+}  // namespace DualShockUDPSettings

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPSettings.h
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPSettings.h
@@ -1,0 +1,32 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct DualShockUDPServer
+{
+  std::string description;
+  std::string server_address;
+  int server_port;
+};
+
+namespace DualShockUDPSettings
+{
+constexpr char FIELD_SEPARATOR = ':';
+constexpr char SERVER_SEPARATOR = ';';
+
+std::vector<DualShockUDPServer> GetServers();
+
+void AddServer(DualShockUDPServer server);
+
+void ReplaceServer(size_t index, DualShockUDPServer server);
+
+void RemoveServer(size_t index);
+
+bool IsEnabled();
+
+void SetEnabled(bool enabled);
+}  // namespace DualShockUDPSettings

--- a/Source/Core/DolphinQt/Config/ControllerInterface/ServerStringValidator.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/ServerStringValidator.cpp
@@ -3,6 +3,10 @@
 
 #include "DolphinQt/Config/ControllerInterface/ServerStringValidator.h"
 
+#include <string>
+
+#include "DolphinQt/Config/ControllerInterface/DualShockUDPSettings.h"
+
 ServerStringValidator::ServerStringValidator(QObject* parent) : QValidator(parent)
 {
 }
@@ -12,10 +16,10 @@ QValidator::State ServerStringValidator::validate(QString& input, int& pos) cons
   if (input.isEmpty())
     return Invalid;
 
-  if (input.contains(QStringLiteral(":")))
+  if (input.contains(QString::fromStdString(std::string{DualShockUDPSettings::FIELD_SEPARATOR})))
     return Invalid;
 
-  if (input.contains(QStringLiteral(";")))
+  if (input.contains(QString::fromStdString(std::string{DualShockUDPSettings::SERVER_SEPARATOR})))
     return Invalid;
 
   return Acceptable;

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -68,8 +68,9 @@
     <ClCompile Include="Config\ConfigControls\ConfigUserPath.cpp" />
     <ClCompile Include="Config\ControllerInterface\ControllerInterfaceWindow.cpp" />
     <ClCompile Include="Config\SDLHints\SDLHintsWindow.cpp" />
-    <ClCompile Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.cpp" />
+    <ClCompile Include="Config\ControllerInterface\DualShockUDPClientEditServerDialog.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientWidget.cpp" />
+    <ClCompile Include="Config\ControllerInterface\DualShockUDPSettings.cpp" />
     <ClCompile Include="Config\ControllerInterface\ServerStringValidator.cpp" />
     <ClCompile Include="Config\ControllersPane.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
@@ -305,8 +306,9 @@
     <QtMoc Include="Config\ConfigControls\ConfigUserPath.h" />
     <QtMoc Include="Config\ControllerInterface\ControllerInterfaceWindow.h" />
     <QtMoc Include="Config\SDLHints\SDLHintsWindow.h" />
-    <QtMoc Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.h" />
+    <QtMoc Include="Config\ControllerInterface\DualShockUDPClientEditServerDialog.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientWidget.h" />
+    <QtMoc Include="Config\ControllerInterface\DualShockUDPSettings.h" />
     <QtMoc Include="Config\ControllerInterface\ServerStringValidator.h" />
     <QtMoc Include="Config\ControllersPane.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />


### PR DESCRIPTION
This PR adds an Edit button to the DSU server selection menu.
- I added an Edit button (obviously)
- Renamed `DualShockUDPClientAddServerDialog` to `DualShockUDPClientEditServerDialog` and made it be able to handle either adding or updating
- I moved all DSU config handling code under a `DualShockUDPSettings` namespace to avoid redundant string handling across multiple files
- Edit/Remove buttons are grayed out when there are no servers

This is my first PR to this project, so I tried to keep, for instance, the naming scheme almost identical. In general I tried to come up with the minimal code diff. Let me know if this is a stylistic issue. Using `clang-format version 19.1.7`, `TOOLS/lints.sh` did not report anything.

<img width="852" height="988" alt="Screenshot 2026-02-12 at 11 27 18 PM" src="https://github.com/user-attachments/assets/f61597e3-5830-4fd4-94e4-7ec96909a5c6" />
<img width="394" height="300" alt="Screenshot 2026-02-12 at 11 27 22 PM" src="https://github.com/user-attachments/assets/b20e2d11-e3e1-436b-9e00-94d57f78edbd" />