### PR TITLE
Bugfix: Cheat codes:  Make newly added codes start disabled.

### DIFF
--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -279,7 +279,7 @@ void ARCodeWidget::AddCode(ActionReplay::ARCode code)
 void ARCodeWidget::OnCodeAddClicked()
 {
   ActionReplay::ARCode ar;
-  ar.enabled = true;
+  ar.enabled = false;
 
   m_cheat_code_editor->SetARCode(&ar);
   if (m_cheat_code_editor->exec() == QDialog::Rejected)

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -218,7 +218,7 @@ void GeckoCodeWidget::OnItemChanged(QListWidgetItem* item)
 void GeckoCodeWidget::AddCode()
 {
   Gecko::GeckoCode code;
-  code.enabled = true;
+  code.enabled = false;
 
   m_cheat_code_editor->SetGeckoCode(&code);
   if (m_cheat_code_editor->exec() == QDialog::Rejected)


### PR DESCRIPTION
When adding a new code while a game is in progress, it will be marked as enabled while not actually being enabled. Users have to toggle the code off and on again to get it to work.  This corrects that by marking them as disabled.  Also,, I don't think automatically enabling new codes is a good practice, because most codes can't be undone without a restart/savestate.