### PR TITLE
fmt: Remove unnecessary locale specifications

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -157,8 +157,7 @@ std::string MovieManager::GetRTCDisplay() const
   const time_t current_time = CEXIIPL::GetEmulatedTime(m_system, CEXIIPL::UNIX_EPOCH);
   const tm gm_time = fmt::gmtime(current_time);
 
-  // Use current locale for formatting time, as fmt is locale-agnostic by default.
-  return fmt::format(std::locale{""}, "Date/Time: {:%c}", gm_time);
+  return fmt::format("Date/Time: {:%c}", gm_time);
 }
 
 // NOTE: GPU Thread

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -299,8 +299,7 @@ static std::string SystemTimeAsDoubleToString(double time)
   if (!local_time)
     return "";
 
-  // fmt is locale agnostic by default, so explicitly use current locale.
-  return fmt::format(std::locale{""}, "{:%x %X}", *local_time);
+  return fmt::format("{:%x %X}", *local_time);
 }
 
 static std::string MakeStateFilename(u32 number)

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -330,7 +330,7 @@ void PostProcessingConfiguration::SaveOptionsConfiguration()
     case ConfigurationOption::OptionType::Float:
     {
       std::ostringstream value;
-      value.imbue(std::locale("C"));
+      value.imbue(std::locale::classic());
 
       for (size_t i = 0; i < it.second.m_float_values.size(); ++i)
       {


### PR DESCRIPTION
As far as I can tell the comments are wrong, in my testing the string representation changes with the locale without using `std::locale{""}`. Moreso, using `std::locale{""}` throws `std::runtime_error` if LC_ALL points to an invalid locale, leading to a crash.