### PR TITLE
Loading custom textures using combination of elf/dol game ids and iso game ids.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -4,6 +4,7 @@
 #include "Core/ConfigManager.h"
 
 #include <algorithm>
+#include <fmt/format.h>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -12,8 +13,6 @@
 #include <variant>
 
 #include <Core/Core.h>
-
-#include <fmt/format.h>
 
 #include "AudioCommon/AudioCommon.h"
 
@@ -130,6 +129,27 @@ const std::string SConfig::GetGameTDBID() const
   return m_gametdb_id;
 }
 
+const std::string SConfig::GetGameIDElfDol() const
+{
+  std::lock_guard<std::recursive_mutex> lock(m_metadata_lock);
+  return m_game_id_elf_dol;
+}
+
+const std::string SConfig::GetGameIDForTextures() const
+{
+  return GetGameIDsForTextures().front();
+}
+
+const std::vector<std::string> SConfig::GetGameIDsForTextures() const
+{
+  std::lock_guard<std::recursive_mutex> lock(m_metadata_lock);
+
+  if (m_game_id_elf_dol.empty())
+    return {m_game_id};
+
+  return {fmt::format("{}-{}", m_game_id_elf_dol, m_game_id), m_game_id};
+}
+
 const std::string SConfig::GetTitleName() const
 {
   std::lock_guard<std::recursive_mutex> lock(m_metadata_lock);
@@ -164,6 +184,7 @@ void SConfig::ResetRunningGameMetadata()
 {
   std::lock_guard<std::recursive_mutex> lock(m_metadata_lock);
   SetRunningGameMetadata("00000000", "", 0, 0, DiscIO::Region::Unknown, 0);
+  SetElfDolID("");
 }
 
 void SConfig::SetRunningGameMetadata(const DiscIO::Volume& volume,
@@ -269,6 +290,12 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
     DolphinAnalytics::Instance().ReportGameStart();
 }
 
+void SConfig::SetElfDolID(const std::string& game_id)
+{
+  std::lock_guard<std::recursive_mutex> lock(m_metadata_lock);
+  m_game_id_elf_dol = game_id;
+}
+
 void SConfig::OnESTitleChanged()
 {
   auto& system = Core::System::GetInstance();
@@ -368,7 +395,9 @@ struct SetGameMetadata
     constexpr char BACKSLASH = '\\';
     constexpr char FORWARDSLASH = '/';
     std::ranges::replace(executable_path, BACKSLASH, FORWARDSLASH);
-    config->SetRunningGameMetadata(SConfig::MakeGameID(PathToFileName(executable_path)));
+    const std::string made_game_id = SConfig::MakeGameID(PathToFileName(executable_path));
+    config->SetRunningGameMetadata(made_game_id);
+    config->SetElfDolID(made_game_id);
 
     Host_TitleChanged();
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 
@@ -61,6 +62,16 @@ struct SConfig
 
   const std::string GetGameID() const;
   const std::string GetGameTDBID() const;
+  const std::string GetGameIDElfDol() const;
+
+  // Returns a preference ordered list of ids to try for texture loading.
+  // If launched via elf/dol, returns {elfdolid-gameid, gameid}. Otherwise returns {gameid}.
+  const std::vector<std::string> GetGameIDsForTextures() const;
+
+  // Returns the single most-preferred id from GetGameIDsForTextures(); see that function for
+  // the full priority order.
+  const std::string GetGameIDForTextures() const;
+
   const std::string GetTitleName() const;
   const std::string GetTitleDescription() const;
   u64 GetTitleID() const;
@@ -70,6 +81,8 @@ struct SConfig
   void SetRunningGameMetadata(const DiscIO::Volume& volume, const DiscIO::Partition& partition);
   void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd, DiscIO::Platform platform);
   void SetRunningGameMetadata(const std::string& game_id);
+
+  void SetElfDolID(const std::string& game_id);
 
   // Triggered when Dolphin loads a title directly
   // Reloads title-specific map files, patches, etc.
@@ -127,6 +140,7 @@ private:
   mutable std::recursive_mutex m_metadata_lock;
 
   std::string m_game_id;
+  std::string m_game_id_elf_dol;
   std::string m_gametdb_id;
   std::string m_title_name;
   std::string m_title_description;

--- a/Source/Core/InputCommon/DynamicInputTextureManager.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextureManager.cpp
@@ -23,10 +23,9 @@ DynamicInputTextureManager::~DynamicInputTextureManager() = default;
 void DynamicInputTextureManager::Load()
 {
   m_configuration.clear();
-
-  const std::string& game_id = SConfig::GetInstance().GetGameID();
   const std::set<std::string> dynamic_input_directories =
-      GetTextureDirectoriesWithGameId(File::GetUserPath(D_DYNAMICINPUT_IDX), game_id);
+      GetTextureDirectoriesForFirstMatchingGameId(File::GetUserPath(D_DYNAMICINPUT_IDX),
+                                                  SConfig::GetInstance().GetGameIDsForTextures());
 
   for (const auto& dynamic_input_directory : dynamic_input_directories)
   {
@@ -46,8 +45,8 @@ void DynamicInputTextureManager::GenerateTextures(const Common::IniFile& file,
   {
     configuration.GenerateTextures(file, controller_names, &output);
   }
-
-  const std::string& game_id = SConfig::GetInstance().GetGameID();
+  // write to highest preference gameid for textures
+  const std::string& game_id_for_textures = SConfig::GetInstance().GetGameIDForTextures();
   for (const auto& [generated_folder_name, images] : output)
   {
     const auto hi_res_folder = File::GetUserPath(D_HIRESTEXTURES_IDX) + generated_folder_name;
@@ -63,7 +62,7 @@ void DynamicInputTextureManager::GenerateTextures(const Common::IniFile& file,
       File::CreateDir(game_id_folder);
     }
 
-    File::CreateEmptyFile(game_id_folder + DIR_SEP + game_id + ".txt");
+    File::CreateEmptyFile(game_id_folder + DIR_SEP + game_id_for_textures + ".txt");
 
     for (const auto& [image_name, image] : images)
     {

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -3,14 +3,13 @@
 
 #include "VideoCommon/HiresTextures.h"
 
+#include <fmt/format.h>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <xxhash.h>
-
-#include <fmt/format.h>
 
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
@@ -84,9 +83,9 @@ void HiresTexture::Update()
     return;
   }
 
-  const std::string& game_id = SConfig::GetInstance().GetGameID();
-  const std::set<std::string> texture_directories =
-      GetTextureDirectoriesWithGameId(File::GetUserPath(D_HIRESTEXTURES_IDX), game_id);
+  const std::set<std::string> texture_directories = GetTextureDirectoriesForFirstMatchingGameId(
+      File::GetUserPath(D_HIRESTEXTURES_IDX), SConfig::GetInstance().GetGameIDsForTextures());
+
   constexpr auto extensions = std::to_array<std::string_view>({".png", ".dds"});
 
   for (const auto& texture_directory : texture_directories)
@@ -141,16 +140,14 @@ void HiresTexture::Update()
     }
   }
 
-  if (g_ActiveConfig.bCacheHiresTextures)
-  {
-    OSD::AddMessage(fmt::format("Loading '{}' custom textures", s_hires_texture_cache.size()),
-                    10000);
-  }
-  else
-  {
-    OSD::AddMessage(
-        fmt::format("Found '{}' custom textures", s_hires_texture_id_to_arbmipmap.size()), 10000);
-  }
+  const std::vector<std::string> game_ids_for_textures =
+      SConfig::GetInstance().GetGameIDsForTextures();
+  const std::string game_id_display = fmt::format("{}", fmt::join(game_ids_for_textures, "' or '"));
+
+  const auto message = fmt::format("{} '{}' custom textures for '{}'",
+                                   g_ActiveConfig.bCacheHiresTextures ? "Preloading" : "Found",
+                                   s_hires_texture_cache.size(), game_id_display);
+  OSD::AddMessage(message, 10000);
 }
 
 void HiresTexture::Clear()
@@ -237,4 +234,17 @@ std::set<std::string> GetTextureDirectoriesWithGameId(const std::string& root_di
   }
 
   return result;
+}
+
+std::set<std::string>
+GetTextureDirectoriesForFirstMatchingGameId(const std::string& root_directory,
+                                            const std::vector<std::string>& game_ids)
+{
+  for (const auto& game_id : game_ids)
+  {
+    auto directories = GetTextureDirectoriesWithGameId(root_directory, game_id);
+    if (!directories.empty())
+      return directories;
+  }
+  return {};
 }

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <fmt/ranges.h>
 #include <memory>
 #include <set>
 #include <string>
@@ -19,6 +20,12 @@ enum class TextureFormat;
 
 std::set<std::string> GetTextureDirectoriesWithGameId(const std::string& root_directory,
                                                       const std::string& game_id);
+
+// Tries each id in priority order, returning the directories for the first id that matches
+// anything. Returns an empty set if none of the ids match.
+std::set<std::string>
+GetTextureDirectoriesForFirstMatchingGameId(const std::string& root_directory,
+                                            const std::vector<std::string>& game_ids);
 
 class HiresTexture
 {


### PR DESCRIPTION
An earlier PR https://github.com/dolphin-emu/dolphin/pull/9461 added "fake" game ids for elf/dol files so that they could have custom textures applied. At some point, this behavior was broken and Dolphin would only load textures for the game id corresponding to the iso that was launched, not the dol/elf that launched it. This PR addresses that issue and also adds the possibility for more sophisticated texture lookup in the future on the basis of some combination of elf/dol id and iso game id.

See https://discord.com/channels/521709831132807179/521711075721478145/1478439952508518450 and ensuing discussion.