### PR TITLE
Common/MemArena: make shared memory name unique per DLL instance

### DIFF
--- a/Source/Core/Common/MemArenaWin.cpp
+++ b/Source/Core/Common/MemArenaWin.cpp
@@ -120,7 +120,9 @@ static DWORD GetLowDWORD(u64 value)
 
 void MemArena::GrabSHMSegment(size_t size, std::string_view base_name)
 {
-  const std::string name = fmt::format("{}.{}", base_name, GetCurrentProcessId());
+  // Each DLL copy is mapped at a different base address, making &s_dll_id unique per instance.
+  static const uintptr_t s_dll_id = reinterpret_cast<uintptr_t>(&s_dll_id);
+  const std::string name = fmt::format("{}.{}.{:x}", base_name, GetCurrentProcessId(), s_dll_id);
   m_memory_handle =
       CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, GetHighDWORD(size),
                         GetLowDWORD(size), UTF8ToTStr(name).c_str());

--- a/Source/Core/Common/MemArenaWin.cpp
+++ b/Source/Core/Common/MemArenaWin.cpp
@@ -120,10 +120,40 @@ static DWORD GetLowDWORD(u64 value)
 
 void MemArena::GrabSHMSegment(size_t size, std::string_view base_name)
 {
-  const std::string name = fmt::format("{}.{}", base_name, GetCurrentProcessId());
-  m_memory_handle =
-      CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, GetHighDWORD(size),
-                        GetLowDWORD(size), UTF8ToTStr(name).c_str());
+  // If a mapping of the given name already exists, CreateFileMapping() does not fail. It hands back
+  // a handle to that existing mapping instead, using its size rather than the requested one.
+  // Silently sharing another arena's memory is never what we want, so keep appending a counter
+  // until we get a mapping we actually created. MemArenaUnix gets this for free via O_EXCL.
+  //
+  // The name only distinguishes processes, so a collision happens whenever two arenas coexist
+  // within one process, which is the case if multiple copies of this code are loaded as a library.
+  constexpr u32 MAX_ATTEMPTS = 256;
+  for (u32 counter = 0; counter < MAX_ATTEMPTS; ++counter)
+  {
+    std::string name = fmt::format("{}.{}", base_name, GetCurrentProcessId());
+    if (counter != 0)
+      name += fmt::format(".{}", counter);
+
+    m_memory_handle =
+        CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, GetHighDWORD(size),
+                          GetLowDWORD(size), UTF8ToTStr(name).c_str());
+    const DWORD error = GetLastError();
+
+    if (!m_memory_handle)
+    {
+      ERROR_LOG_FMT(MEMMAP, "CreateFileMapping() failed: {}", GetWin32ErrorString(error));
+      return;
+    }
+
+    if (error != ERROR_ALREADY_EXISTS)
+      return;
+
+    CloseHandle(m_memory_handle);
+    m_memory_handle = nullptr;
+  }
+
+  ERROR_LOG_FMT(MEMMAP, "Found no unused name for the shared memory segment after {} attempts.",
+                MAX_ATTEMPTS);
 }
 
 void MemArena::ReleaseSHMSegment()


### PR DESCRIPTION
## Problem

When multiple copies of the same DLL are loaded into the same process (e.g. for libretro multi-instance support), all copies share the same PID. Using only the PID as the name suffix in `GrabSHMSegment` caused `CreateFileMapping` to return the existing named kernel object rather than creating a new one — so both instances silently mapped the **same** 4 GB+ GameCube/Wii RAM region and instantly corrupted each other.

## Fix

Embed the address of a static-local variable (`s_dll_id`) in the name in addition to the PID. Because each DLL copy is loaded at a different base address in the process, `s_dll_id` lives at a unique virtual address in every copy, so its value acts as a stable, zero-cost, per-instance discriminator with no extra synchronisation needed.

```cpp
static const uintptr_t s_dll_id = reinterpret_cast<uintptr_t>(&s_dll_id);
const std::string name = fmt::format("{}.{}.{:x}", base_name, GetCurrentProcessId(), s_dll_id);
```

Only `MemArenaWin.cpp` is affected; the other platform implementations do not use persistent kernel-namespace names.
