### PR TITLE
GameSettings: Add patch to limit the internal frame rate in UK release of Rabbids Go Home

### DIFF
--- a/Data/Sys/GameSettings/RGWP41.ini
+++ b/Data/Sys/GameSettings/RGWP41.ini
@@ -1,0 +1,8 @@
+# RGWP41 - Rabbids Go Home
+
+[OnFrame]
+$Limit internal frame rate (speed hack)
+0x80231138:dword:0x48148D38
+
+[OnFrame_Enabled]
+$Limit internal frame rate (speed hack)


### PR DESCRIPTION
Followed Billiard's instructions in the Discord server; this patch makes Rabbids Go Home performance in the UK release very good (~30 FPS --> full speed on my system).