### PR TITLE
EXI: Show on-screen error when USB Gecko fails to bind

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -66,11 +66,10 @@ void GeckoSockServer::GeckoConnectionWaiter()
 
   if (!server_running.IsSet())
   {
-    ERROR_LOG_FMT(EXPANSIONINTERFACE, "USBGecko: Failed to bind to any port in range {}-{}",
-                  initial_port, initial_port + port_retries);
-    Core::DisplayMessage(fmt::format("USBGecko: Failed to listen on any port ({}-{})", initial_port,
-                                     initial_port + port_retries),
-                         5000);
+    const std::string message = fmt::format("USBGecko: Failed to bind to any port in range {}-{}",
+                                            initial_port, initial_port + port_retries);
+    ERROR_LOG_FMT(EXPANSIONINTERFACE, "{}", message);
+    Core::DisplayMessage(message, 5000);
     return;
   }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -55,7 +55,8 @@ void GeckoSockServer::GeckoConnectionWaiter()
   Common::SetCurrentThreadName("Gecko Connection Waiter");
 
   sf::TcpListener server;
-  initial_port = 0xd6ec;  // "dolphin gecko"
+  constexpr u16 initial_port = 0xd6ec;  // "dolphin gecko"
+  constexpr int port_retries = 10;
   server_port = initial_port;
   for (int bind_tries = 0; bind_tries <= port_retries && !server_running.IsSet(); bind_tries++)
   {

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -21,7 +21,6 @@ namespace ExpansionInterface
 {
 u16 GeckoSockServer::initial_port;
 u16 GeckoSockServer::server_port;
-int GeckoSockServer::port_retries;
 int GeckoSockServer::client_count;
 std::thread GeckoSockServer::connectionThread;
 Common::Flag GeckoSockServer::server_running;
@@ -57,7 +56,6 @@ void GeckoSockServer::GeckoConnectionWaiter()
 
   sf::TcpListener server;
   initial_port = 0xd6ec;  // "dolphin gecko"
-  port_retries = 10;
   server_port = initial_port;
   for (int bind_tries = 0; bind_tries <= port_retries && !server_running.IsSet(); bind_tries++)
   {

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -63,7 +63,12 @@ void GeckoSockServer::GeckoConnectionWaiter()
   }
 
   if (!server_running.IsSet())
+  {
+    ERROR_LOG_FMT(EXPANSIONINTERFACE, "USBGecko: Failed to bind to any port in range {}-{}", 0xd6ec,
+                  0xd6ec + 10);
+    Core::DisplayMessage("USBGecko: Failed to listen on any port (55020-55030)", 5000);
     return;
+  }
 
   Core::DisplayMessage(fmt::format("USBGecko: Listening on TCP port {}", server_port), 5000);
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -19,7 +19,9 @@
 
 namespace ExpansionInterface
 {
+u16 GeckoSockServer::initial_port;
 u16 GeckoSockServer::server_port;
+int GeckoSockServer::port_retries;
 int GeckoSockServer::client_count;
 std::thread GeckoSockServer::connectionThread;
 Common::Flag GeckoSockServer::server_running;
@@ -54,8 +56,10 @@ void GeckoSockServer::GeckoConnectionWaiter()
   Common::SetCurrentThreadName("Gecko Connection Waiter");
 
   sf::TcpListener server;
-  server_port = 0xd6ec;  // "dolphin gecko"
-  for (int bind_tries = 0; bind_tries <= 10 && !server_running.IsSet(); bind_tries++)
+  initial_port = 0xd6ec;  // "dolphin gecko"
+  port_retries = 10;
+  server_port = initial_port;
+  for (int bind_tries = 0; bind_tries <= port_retries && !server_running.IsSet(); bind_tries++)
   {
     server_running.Set(server.listen(server_port) == sf::Socket::Status::Done);
     if (!server_running.IsSet())
@@ -64,9 +68,11 @@ void GeckoSockServer::GeckoConnectionWaiter()
 
   if (!server_running.IsSet())
   {
-    ERROR_LOG_FMT(EXPANSIONINTERFACE, "USBGecko: Failed to bind to any port in range {}-{}", 0xd6ec,
-                  0xd6ec + 10);
-    Core::DisplayMessage("USBGecko: Failed to listen on any port (55020-55030)", 5000);
+    ERROR_LOG_FMT(EXPANSIONINTERFACE, "USBGecko: Failed to bind to any port in range {}-{}",
+                  initial_port, initial_port + port_retries);
+    Core::DisplayMessage(fmt::format("USBGecko: Failed to listen on any port ({}-{})", initial_port,
+                                     initial_port + port_retries),
+                         5000);
     return;
   }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.h
@@ -41,7 +41,7 @@ private:
 
   static u16 initial_port;
   static u16 server_port;
-  static int port_retries;
+  static constexpr int port_retries = 10;
   static Common::Flag server_running;
   static std::thread connectionThread;
   static std::mutex connection_lock;

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.h
@@ -39,7 +39,9 @@ private:
   // Only ever one server thread
   static void GeckoConnectionWaiter();
 
+  static u16 initial_port;
   static u16 server_port;
+  static int port_retries;
   static Common::Flag server_running;
   static std::thread connectionThread;
   static std::mutex connection_lock;


### PR DESCRIPTION
Previously, if the USB Gecko server failed to bind to any port in the 55020-55030 range, it silently returned with no indication to the user. This simple change now displays an on-screen message and logs an error. I found this "bug" while testing a homebrew project and WSL had silently reserved a conflicting port range causing a debugging nightmare since Gecko was enabled but not communicating.

AI Disclosure: Claude was used for assistance.

Edit: I fixed the whitespace issue that triggered a lint failure.

Edit 2: I've updated the messages to be build dynamically based on the stated port rather than hard-coding it to match.