### PR TITLE
JitArm64: Minor subfzex optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1326,6 +1326,15 @@ void JitArm64::subfzex(UGeckoInstruction inst)
     gpr.SetImmediate(d, imm + carry);
     ComputeCarry(Interpreter::Helper_Carry(imm, carry));
   }
+  else if (gpr.IsImm(a, 0) && js.carryFlag == CarryFlag::InHostCarry)
+  {
+    gpr.BindToRegister(d, false);
+    // RD = ~0 + carry = -1 + carry = carry ? 0 : -1
+    // Note that CSETM sets the destination to -1 if the condition is true,
+    // and 0 otherwise. Hence, the condition must be carry clear.
+    CSETM(gpr.R(d), CC_CC);
+    // Carry remains unchanged.
+  }
   else
   {
     gpr.BindToRegister(d, d == a);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1335,6 +1335,13 @@ void JitArm64::subfzex(UGeckoInstruction inst)
     CSETM(gpr.R(d), CC_CC);
     // Carry remains unchanged.
   }
+  else if (gpr.IsImm(a, 0xFFFFFFFF) && js.carryFlag == CarryFlag::InHostCarry)
+  {
+    gpr.BindToRegister(d, false);
+    // RD = ~(-1) + carry = 0 + carry = carry ? 1 : 0
+    CSET(gpr.R(d), CC_CS);
+    ComputeCarry(false);
+  }
   else
   {
     gpr.BindToRegister(d, d == a);


### PR DESCRIPTION
Some optimizations that were missed in #13251 for this instruction.

<details><summary>Optimize a == 0 with in-host carry</summary>
Before:

```
0x52800019   mov    w25, #0x0                 ; =0
0x7a1903f9   ngcs   w25, w25
0x1a9f37f5   cset   w21, hs
0x390bd3b5   strb   w21, [x29, #0x2f4]
```

After:
```
0x5a9f23f9   csetm  w25, lo
```
</details>

<details><summary>Optimize a == -1 with in-host carry</summary>
Before:

```
0x12800019   mov    w25, #-0x1                ; =-1
0x7a1903fa   ngcs   w26, w25
0x1a9f37f8   cset   w24, hs
0x390bd3b8   strb   w24, [x29, #0x2f4]
```

After:
```
0x1a9f37fa   cset   w26, hs
```
</details>