### PR TITLE
AutoUpdateChecker: Fix Edge Cases

### DIFF
--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -3,6 +3,7 @@
 
 #include "UICommon/AutoUpdate.h"
 
+#include <atomic>
 #include <cstdlib>
 #include <string>
 
@@ -12,6 +13,7 @@
 #include "Common/HttpRequest.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+#include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
 #include "Common/Version.h"
 
@@ -36,6 +38,7 @@
 
 namespace
 {
+std::atomic_bool s_check_in_progress = false;
 bool s_update_triggered = false;
 
 #ifdef __APPLE__
@@ -188,6 +191,20 @@ static u32 GetOwnProcessId()
 void AutoUpdateChecker::CheckForUpdate(std::string_view update_track,
                                        std::string_view hash_override, const CheckType check_type)
 {
+  bool expected_check_in_progress = false;
+  if (!s_check_in_progress.compare_exchange_strong(expected_check_in_progress, true))
+    return;
+
+  Common::ScopeGuard guard([]() { s_check_in_progress.store(false); });
+
+  if (s_update_triggered)
+  {
+    if (check_type == CheckType::Manual)
+      SuccessAlertFmtT("A Dolphin update is already scheduled for the next time it closes.");
+
+    return;
+  }
+
   // Don't bother checking if updates are not supported or not enabled.
   if (!SystemSupportsAutoUpdates() || update_track.empty())
     return;

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -278,7 +278,6 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
     return;
   }
 
-  s_update_triggered = true;
 #ifdef OS_SUPPORTS_UPDATER
   std::map<std::string, std::string> updater_flags;
   updater_flags["this-manifest-url"] = info.this_manifest_url;
@@ -319,6 +318,7 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
   {
     CloseHandle(pinfo.hThread);
     CloseHandle(pinfo.hProcess);
+    s_update_triggered = true;
   }
   else
   {
@@ -330,6 +330,10 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
   {
     const std::string error = Common::LastStrerrorString();
     CriticalAlertFmtT("Could not start updater process: {0}", error);
+  }
+  else
+  {
+    s_update_triggered = true;
   }
 #endif
 


### PR DESCRIPTION
Fix some edge cases in the update checking logic:

Prevent multiple update checks from happening at the same time. If a user started a check right after starting Dolphin they could end up with one `Update available` window from the manual check and a second window at the same time from the startup check.

If the user checks for an update when one is already pending, show a message explaining that.

Don't set the `s_update_triggered` flag if the updater process fails to start. This allows users in this situation to try again later without having to restart Dolphin first.