### PR TITLE
AutoUpdateChecker: Use separate thread for manual checks

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -283,11 +283,12 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    if (!Settings::Instance().IsBatchModeEnabled())
+    if (!Settings::Instance().IsBatchModeEnabled() &&
+        AutoUpdateChecker::SystemSupportsAutoUpdates())
     {
-      auto* updater = new Updater(&win, Config::Get(Config::MAIN_AUTOUPDATE_UPDATE_TRACK),
-                                  Config::Get(Config::MAIN_AUTOUPDATE_HASH_OVERRIDE));
-      updater->start();
+      new Updater(&win, Config::Get(Config::MAIN_AUTOUPDATE_UPDATE_TRACK),
+                  Config::Get(Config::MAIN_AUTOUPDATE_HASH_OVERRIDE),
+                  AutoUpdateChecker::CheckType::Automatic);
     }
 
     retval = app.exec();

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -660,10 +660,9 @@ void MenuBar::InstallUpdateManually()
 {
   const std::string autoupdate_track = Config::Get(Config::MAIN_AUTOUPDATE_UPDATE_TRACK);
   const std::string manual_track = autoupdate_track.empty() ? "dev" : autoupdate_track;
-  auto* const updater = new Updater(this->parentWidget(), manual_track,
-                                    Config::Get(Config::MAIN_AUTOUPDATE_HASH_OVERRIDE));
-
-  updater->CheckForUpdate();
+  new Updater(this->parentWidget(), manual_track,
+              Config::Get(Config::MAIN_AUTOUPDATE_HASH_OVERRIDE),
+              AutoUpdateChecker::CheckType::Manual);
 }
 
 void MenuBar::AddHelpMenu()

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -21,23 +21,18 @@
 
 // Refer to docs/autoupdate_overview.md for a detailed overview of the autoupdate process
 
-Updater::Updater(QWidget* parent, std::string update_track, std::string hash_override)
+Updater::Updater(QWidget* parent, std::string update_track, std::string hash_override,
+                 const CheckType check_type)
     : m_parent(parent), m_update_track(std::move(update_track)),
-      m_hash_override(std::move(hash_override))
+      m_hash_override(std::move(hash_override)), m_check_type(check_type)
 {
   connect(this, &QThread::finished, this, &QObject::deleteLater);
+  start();
 }
 
 void Updater::run()
 {
-  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override,
-                                    AutoUpdateChecker::CheckType::Automatic);
-}
-
-void Updater::CheckForUpdate()
-{
-  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override,
-                                    AutoUpdateChecker::CheckType::Manual);
+  AutoUpdateChecker::CheckForUpdate(m_update_track, m_hash_override, m_check_type);
 }
 
 void Updater::OnUpdateAvailable(const NewVersionInformation& info)

--- a/Source/Core/DolphinQt/Updater.h
+++ b/Source/Core/DolphinQt/Updater.h
@@ -17,14 +17,15 @@ class Updater : public QThread, public AutoUpdateChecker
 {
   Q_OBJECT
 public:
-  explicit Updater(QWidget* parent, std::string update_track, std::string hash_override);
+  explicit Updater(QWidget* parent, std::string update_track, std::string hash_override,
+                   CheckType check_type);
 
   void run() override;
   void OnUpdateAvailable(const NewVersionInformation& info) override;
-  void CheckForUpdate();
 
 private:
   QWidget* m_parent;
   std::string m_update_track;
   std::string m_hash_override;
+  CheckType m_check_type;
 };


### PR DESCRIPTION
Run manual update checks on a separate thread to avoid blocking the UI, like the automatic check already does.