### PR TITLE
Add page table fastmem to Debug/JIT settings

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -14,6 +14,7 @@ enum class BooleanSetting(
     MAIN_SKIP_IPL(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "SkipIPL", true),
     MAIN_DSP_HLE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "DSPHLE", true),
     MAIN_FASTMEM(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "Fastmem", true),
+    MAIN_PAGE_TABLE_FASTMEM(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "PageTableFastmem", true),
     MAIN_FASTMEM_ARENA(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "FastmemArena", true),
     MAIN_LARGE_ENTRY_POINTS_MAP(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "LargeEntryPointsMap", true),
     MAIN_CPU_THREAD(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "CPUThread", true),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -2218,6 +2218,14 @@ class SettingsFragmentPresenter(
         sl.add(
             InvertedSwitchSetting(
                 context,
+                BooleanSetting.MAIN_PAGE_TABLE_FASTMEM,
+                R.string.debug_page_table_fastmem,
+                0
+            )
+        )
+        sl.add(
+            InvertedSwitchSetting(
+                context,
                 BooleanSetting.MAIN_FASTMEM_ARENA,
                 R.string.debug_fastmem_arena,
                 0

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -424,6 +424,7 @@
     <string name="debug_submenu">Debug</string>
     <string name="debug_warning">Warning: Debug settings will slow emulation</string>
     <string name="debug_fastmem">Disable Fastmem</string>
+    <string name="debug_page_table_fastmem">Disable Page Table Fastmem</string>
     <string name="debug_fastmem_arena">Disable Fastmem Arena</string>
     <string name="debug_large_entry_points_map">Disable Large Entry Points Map</string>
     <string name="debug_jit_profiling_header">Jit Profiling</string>

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -926,6 +926,13 @@ void MenuBar::AddJITMenu()
   connect(m_jit_disable_fastmem, &QAction::toggled,
           [](bool enabled) { Config::SetBaseOrCurrent(Config::MAIN_FASTMEM, !enabled); });
 
+  m_jit_disable_page_table_fastmem = m_jit->addAction(tr("Disable Page Table Fastmem"));
+  m_jit_disable_page_table_fastmem->setCheckable(true);
+  m_jit_disable_page_table_fastmem->setChecked(!Config::Get(Config::MAIN_PAGE_TABLE_FASTMEM));
+  connect(m_jit_disable_page_table_fastmem, &QAction::toggled, [](bool enabled) {
+    Config::SetBaseOrCurrent(Config::MAIN_PAGE_TABLE_FASTMEM, !enabled);
+  });
+
   m_jit_disable_fastmem_arena = m_jit->addAction(tr("Disable Fastmem Arena"));
   m_jit_disable_fastmem_arena->setCheckable(true);
   m_jit_disable_fastmem_arena->setChecked(!Config::Get(Config::MAIN_FASTMEM_ARENA));

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -288,6 +288,7 @@ private:
   QAction* m_jit_block_linking;
   QAction* m_jit_disable_cache;
   QAction* m_jit_disable_fastmem;
+  QAction* m_jit_disable_page_table_fastmem;
   QAction* m_jit_disable_fastmem_arena;
   QAction* m_jit_disable_large_entry_points_map;
   QAction* m_jit_clear_cache;


### PR DESCRIPTION
This can be useful for experimenting with how a game behaves with and without page table fastmem. I didn't add this in PR #14480 when I added the setting itself because we were under a string freeze for Dolphin 2603a at the time.