### PR TITLE
Improve usage of std::move and const references parameters

### DIFF
--- a/Source/Core/AudioCommon/CubebUtils.cpp
+++ b/Source/Core/AudioCommon/CubebUtils.cpp
@@ -211,7 +211,7 @@ bool CoInitSyncWorker::Execute(FunctionType f)
   if (!m_coinit_success)
     return false;
 
-  m_work_queue.PushBlocking(f);
+  m_work_queue.PushBlocking(std::move(f));
 #else
   f();
 #endif

--- a/Source/Core/Common/Assembler/GekkoIRGen.cpp
+++ b/Source/Core/Common/Assembler/GekkoIRGen.cpp
@@ -538,7 +538,7 @@ void GekkoIRPlugin::AddSymbolResolve(std::string_view sym, bool absolute)
   };
 
   m_fixup_stack.emplace(
-      [this, sym, absolute, source_address, err_on_fail = std::move(err_on_fail)] {
+      [this, sym, absolute, source_address, err_on_fail = std::move(err_on_fail)] mutable {
         auto label_it = m_labels.find(sym);
         if (label_it != m_labels.end())
         {
@@ -575,7 +575,7 @@ void GekkoIRPlugin::AddNumLabelSymResolve(std::string_view sym, u32 num)
   // Searching forward only
   size_t search_start_idx = static_cast<size_t>(m_numlabs.size());
   m_fixup_stack.emplace(
-      [this, num, source_address, search_start_idx, err_on_fail = std::move(err_on_fail)] {
+      [this, num, source_address, search_start_idx, err_on_fail = std::move(err_on_fail)] mutable {
         for (size_t i = search_start_idx; i < m_numlabs.size(); i++)
         {
           if (num == m_numlabs[i].first)

--- a/Source/Core/Common/Crypto/ec.cpp
+++ b/Source/Core/Common/Crypto/ec.cpp
@@ -133,7 +133,7 @@ static Elt operator/(const Elt& dividend, const Elt& divisor)
 struct Point
 {
   Point() = default;
-  constexpr explicit Point(Elt x, Elt y) : m_data{{std::move(x), std::move(y)}} {}
+  constexpr explicit Point(Elt x, Elt y) : m_data{{x, y}} {}
   explicit Point(const u8* data) { std::copy_n(data, sizeof(m_data), Data()); }
 
   bool IsZero() const { return X().IsZero() && Y().IsZero(); }

--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -598,7 +598,7 @@ bool SyncSDFolderToSDImage(const std::function<bool()>& cancelled, bool determin
   return true;
 }
 
-static bool Unpack(const std::function<bool()>& cancelled, const std::string path,
+static bool Unpack(const std::function<bool()>& cancelled, const std::string& path,
                    bool is_directory, const char* name, std::vector<u8>& tmp_buffer)
 {
   if (cancelled())

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -71,13 +71,13 @@ std::vector<std::string> DoFileSearch(std::span<const std::string_view> director
       std::error_code error;
       if (recursive)
       {
-        for (auto it = fs::recursive_directory_iterator(std::move(directory_path), error);
+        for (auto it = fs::recursive_directory_iterator(directory_path, error);
              it != fs::recursive_directory_iterator(); it.increment(error))
           add_filtered(*it);
       }
       else
       {
-        for (auto it = fs::directory_iterator(std::move(directory_path), error);
+        for (auto it = fs::directory_iterator(directory_path, error);
              it != fs::directory_iterator(); it.increment(error))
           add_filtered(*it);
       }

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -425,7 +425,7 @@ static FSTEntry ScanDirectoryTreeAndroidContent(std::string directory, bool recu
 #endif
 
 // Recursive or non-recursive list of files and directories under directory.
-FSTEntry ScanDirectoryTree(std::string directory, bool recursive)
+FSTEntry ScanDirectoryTree(const std::string& directory, bool recursive)
 {
   DEBUG_LOG_FMT(COMMON, "{}: directory {}", __func__, directory);
 

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -193,7 +193,7 @@ bool CopyRegularFile(std::string_view source_path, std::string_view destination_
 bool CreateEmptyFile(const std::string& filename);
 
 // Recursive or non-recursive list of files and directories under directory.
-FSTEntry ScanDirectoryTree(std::string directory, bool recursive);
+FSTEntry ScanDirectoryTree(const std::string& directory, bool recursive);
 
 // deletes the given directory and anything under it. Returns true on success.
 bool DeleteDirRecursively(const std::string& directory);

--- a/Source/Core/Common/Profiler.cpp
+++ b/Source/Core/Common/Profiler.cpp
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <ios>
 #include <sstream>
+#include <utility>
 
 #include "Common/Timer.h"
 
@@ -26,8 +27,9 @@ u64 Profiler::s_usecs_frame;
 std::string Profiler::s_lazy_result;
 int Profiler::s_lazy_delay = 0;
 
-Profiler::Profiler(const std::string& name)
-    : m_name(name), m_usecs(0), m_usecs_min(UINT64_MAX), m_usecs_max(0), m_usecs_quad(0), m_calls(0)
+Profiler::Profiler(std::string name)
+    : m_name(std::move(name)), m_usecs(0), m_usecs_min(UINT64_MAX), m_usecs_max(0), m_usecs_quad(0),
+      m_calls(0)
 {
   s_max_length = std::max<u32>(s_max_length, u32(m_name.length()));
 

--- a/Source/Core/Common/Profiler.h
+++ b/Source/Core/Common/Profiler.h
@@ -14,7 +14,7 @@ namespace Common
 class Profiler
 {
 public:
-  Profiler(const std::string& name);
+  Profiler(std::string name);
   ~Profiler();
 
   static std::string ToString();

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstring>
 #include <string>
+#include <utility>
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -14,9 +15,9 @@
 
 namespace Common
 {
-TraversalClient::TraversalClient(ENetHost* netHost, const std::string& server, const u16 port,
+TraversalClient::TraversalClient(ENetHost* netHost, std::string server, const u16 port,
                                  const u16 port_alt)
-    : m_NetHost(netHost), m_Server(server), m_port(port), m_portAlt(port_alt)
+    : m_NetHost(netHost), m_Server(std::move(server)), m_port(port), m_portAlt(port_alt)
 {
   netHost->intercept = TraversalClient::InterceptCallback;
 

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -43,8 +43,7 @@ public:
     SocketSendError,
     ResendTimeout,
   };
-  TraversalClient(ENetHost* netHost, const std::string& server, const u16 port,
-                  const u16 port_alt = 0);
+  TraversalClient(ENetHost* netHost, std::string server, const u16 port, const u16 port_alt = 0);
   ~TraversalClient();
 
   TraversalHostId GetHostID() const;

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -1360,7 +1360,7 @@ u32 AchievementManager::MemoryPeeker(u32 address, u8* buffer, u32 num_bytes, rc_
 }
 
 void AchievementManager::FetchBadge(AchievementManager::Badge* badge, u32 badge_type,
-                                    const AchievementManager::BadgeNameFunction function,
+                                    AchievementManager::BadgeNameFunction function,
                                     UpdatedItems callback_data)
 {
   if (!m_client || !HasAPIToken())

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -243,8 +243,8 @@ private:
   static void Request(const rc_api_request_t* request, rc_client_server_callback_t callback,
                       void* callback_data, rc_client_t* client);
   static u32 MemoryPeeker(u32 address, u8* buffer, u32 num_bytes, rc_client_t* client);
-  void FetchBadge(Badge* badge, u32 badge_type, const BadgeNameFunction function,
-                  const UpdatedItems callback_data);
+  void FetchBadge(Badge* badge, u32 badge_type, BadgeNameFunction function,
+                  UpdatedItems callback_data);
   static void EventHandler(const rc_client_event_t* event, rc_client_t* client);
 
 #ifdef RC_CLIENT_SUPPORTS_RAINTEGRATION

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -270,7 +270,7 @@ std::unique_ptr<BootParameters> BootParameters::GenerateFromFile(std::vector<std
 
   if (extension == ".wad")
   {
-    std::unique_ptr<DiscIO::VolumeWAD> wad = DiscIO::CreateWAD(std::move(path));
+    std::unique_ptr<DiscIO::VolumeWAD> wad = DiscIO::CreateWAD(path);
     if (wad)
       return std::make_unique<BootParameters>(std::move(*wad), std::move(boot_session_data_));
   }
@@ -707,7 +707,7 @@ void StateFlags::UpdateChecksum()
   checksum = std::accumulate(flag_data.cbegin(), flag_data.cend(), 0U);
 }
 
-void UpdateStateFlags(std::function<void(StateFlags*)> update_function)
+void UpdateStateFlags(const std::function<void(StateFlags*)>& update_function)
 {
   CreateSystemMenuTitleDirs();
   const std::string file_path = Common::GetTitleDataPath(Titles::SYSTEM_MENU) + "/" WII_STATE;

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -222,7 +222,7 @@ struct StateFlags
 
 // Reads the state file from the NAND, then calls the passed update function to update the struct,
 // and finally writes the updated state file to the NAND.
-void UpdateStateFlags(std::function<void(StateFlags*)> update_function);
+void UpdateStateFlags(const std::function<void(StateFlags*)>& update_function);
 
 /// Create title directories for the system menu (if needed).
 ///

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -176,9 +176,9 @@ static SectionKey GetINILocationFromConfig(const Location& location)
 class INIGameConfigLayerLoader final : public Config::ConfigLayerLoader
 {
 public:
-  INIGameConfigLayerLoader(const std::string& id, u16 revision, bool global)
+  INIGameConfigLayerLoader(std::string id, u16 revision, bool global)
       : ConfigLayerLoader(global ? Config::LayerType::GlobalGame : Config::LayerType::LocalGame),
-        m_id(id), m_revision(revision)
+        m_id(std::move(id)), m_revision(revision)
   {
   }
 
@@ -229,7 +229,7 @@ private:
       std::string path = "Profiles/" + std::get<1>(use_data) + "/";
 
       const auto control_section = [&](std::string key) {
-        return Config::Location{std::get<2>(use_data), "Controls", key};
+        return Config::Location{std::get<2>(use_data), "Controls", std::move(key)};
       };
 
       for (const char num : nums)

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -4,6 +4,7 @@
 #include "Core/ConfigLoaders/NetPlayConfigLoader.h"
 
 #include <memory>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -23,8 +24,8 @@ namespace ConfigLoaders
 class NetPlayConfigLayerLoader final : public Config::ConfigLayerLoader
 {
 public:
-  explicit NetPlayConfigLayerLoader(const NetPlay::NetSettings& settings)
-      : ConfigLayerLoader(Config::LayerType::Netplay), m_settings(settings)
+  explicit NetPlayConfigLayerLoader(NetPlay::NetSettings settings)
+      : ConfigLayerLoader(Config::LayerType::Netplay), m_settings(std::move(settings))
   {
   }
 

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -363,7 +363,7 @@ void CoreTimingManager::Advance()
 
   while (!m_event_queue.empty() && m_event_queue.front().time <= m_globals.global_timer)
   {
-    Event evt = std::move(m_event_queue.front());
+    Event evt = m_event_queue.front();
     std::ranges::pop_heap(m_event_queue, std::ranges::greater{});
     m_event_queue.pop_back();
     evt.type->callback(m_system, evt.userdata, m_globals.global_timer - evt.time);

--- a/Source/Core/Core/Debugger/RSO.cpp
+++ b/Source/Core/Core/Debugger/RSO.cpp
@@ -183,7 +183,7 @@ void RSOSectionsView::Load(const Core::CPUThreadGuard& guard, u32 address, std::
     RSOSection section;
     section.offset = PowerPC::MMU::HostRead<u32>(guard, address);
     section.size = PowerPC::MMU::HostRead<u32>(guard, address + 4);
-    m_sections.emplace_back(std::move(section));
+    m_sections.emplace_back(section);
     address += sizeof(RSOSection);
   }
 }
@@ -212,7 +212,7 @@ void RSOImportsView::Load(const Core::CPUThreadGuard& guard, u32 address, std::s
     rso_import.name_offset = PowerPC::MMU::HostRead<u32>(guard, address);
     rso_import.code_offset = PowerPC::MMU::HostRead<u32>(guard, address + 4);
     rso_import.entry_offset = PowerPC::MMU::HostRead<u32>(guard, address + 8);
-    m_imports.emplace_back(std::move(rso_import));
+    m_imports.emplace_back(rso_import);
     address += sizeof(RSOImport);
   }
 }
@@ -242,7 +242,7 @@ void RSOExportsView::Load(const Core::CPUThreadGuard& guard, u32 address, std::s
     rso_export.code_offset = PowerPC::MMU::HostRead<u32>(guard, address + 4);
     rso_export.section_index = PowerPC::MMU::HostRead<u32>(guard, address + 8);
     rso_export.hash = PowerPC::MMU::HostRead<u32>(guard, address + 12);
-    m_exports.emplace_back(std::move(rso_export));
+    m_exports.emplace_back(rso_export);
     address += sizeof(RSOExport);
   }
 }
@@ -271,7 +271,7 @@ void RSOInternalsView::Load(const Core::CPUThreadGuard& guard, u32 address, std:
     entry.r_offset = PowerPC::MMU::HostRead<u32>(guard, address);
     entry.r_info = PowerPC::MMU::HostRead<u32>(guard, address + 4);
     entry.r_addend = PowerPC::MMU::HostRead<u32>(guard, address + 8);
-    m_entries.emplace_back(std::move(entry));
+    m_entries.emplace_back(entry);
     address += sizeof(RSOInternalsEntry);
   }
 }
@@ -300,7 +300,7 @@ void RSOExternalsView::Load(const Core::CPUThreadGuard& guard, u32 address, std:
     entry.r_offset = PowerPC::MMU::HostRead<u32>(guard, address);
     entry.r_info = PowerPC::MMU::HostRead<u32>(guard, address + 4);
     entry.r_addend = PowerPC::MMU::HostRead<u32>(guard, address + 8);
-    m_entries.emplace_back(std::move(entry));
+    m_entries.emplace_back(entry);
     address += sizeof(RSOExternalsEntry);
   }
 }

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -207,7 +207,7 @@ void DolphinAnalytics::ReportGameQuirk(GameQuirk quirk)
   Send(builder);
 }
 
-void DolphinAnalytics::ReportPerformanceInfo(PerformanceSample&& sample)
+void DolphinAnalytics::ReportPerformanceInfo(PerformanceSample sample)
 {
   if (ShouldStartPerformanceSampling())
   {
@@ -216,7 +216,7 @@ void DolphinAnalytics::ReportPerformanceInfo(PerformanceSample&& sample)
 
   if (m_sampling_performance_info)
   {
-    m_performance_samples.emplace_back(std::move(sample));
+    m_performance_samples.emplace_back(sample);
   }
 
   if (m_performance_samples.size() >= NUM_PERFORMANCE_SAMPLES_PER_REPORT)

--- a/Source/Core/Core/DolphinAnalytics.h
+++ b/Source/Core/Core/DolphinAnalytics.h
@@ -148,7 +148,7 @@ public:
   // calling it does not guarantee when a report will actually be sent.
   //
   // This method is NOT thread-safe.
-  void ReportPerformanceInfo(PerformanceSample&& sample);
+  void ReportPerformanceInfo(PerformanceSample sample);
 
   // Forward Send method calls to the reporter.
   template <typename T>

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <utility>
 
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -246,7 +247,7 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
   }
 
   m_RequestedRecordingEnd = false;
-  m_FinishedCb = finishedCb;
+  m_FinishedCb = std::move(finishedCb);
 
   m_end_of_frame_event =
       m_system.GetVideoEvents().after_frame_event.Register([this](const Core::System& system) {

--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -15,10 +15,10 @@
 
 namespace Gecko
 {
-std::expected<std::vector<GeckoCode>, int> DownloadCodes(std::string gametdb_id)
+std::expected<std::vector<GeckoCode>, int> DownloadCodes(std::string_view gametdb_id)
 {
   // codes.rc24.xyz is a mirror of the now defunct geckocodes.org.
-  std::string endpoint{"https://codes.rc24.xyz/txt.php?txt=" + gametdb_id};
+  std::string endpoint{"https://codes.rc24.xyz/txt.php?txt=" + std::string(gametdb_id)};
   Common::HttpRequest http;
 
   // The server always redirects once to the same location.

--- a/Source/Core/Core/GeckoCodeConfig.h
+++ b/Source/Core/Core/GeckoCodeConfig.h
@@ -19,7 +19,7 @@ class IniFile;
 namespace Gecko
 {
 std::vector<GeckoCode> LoadCodes(const Common::IniFile& globalIni, const Common::IniFile& localIni);
-std::expected<std::vector<GeckoCode>, int> DownloadCodes(std::string gametdb_id);
+std::expected<std::vector<GeckoCode>, int> DownloadCodes(std::string_view gametdb_id);
 void SaveCodes(Common::IniFile& inifile, std::span<const GeckoCode> gcodes);
 
 std::optional<GeckoCode::Code> DeserializeLine(const std::string& line);

--- a/Source/Core/Core/HW/EXI/BBA/TAPServerConnection.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAPServerConnection.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <optional>
+#include <utility>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -33,10 +34,11 @@ using ws_ssize_t = ssize_t;
 
 using Common::SEND_FLAGS;
 
-TAPServerConnection::TAPServerConnection(const std::string& destination,
+TAPServerConnection::TAPServerConnection(std::string destination,
                                          std::function<void(std::string&&)> recv_cb,
                                          std::size_t max_frame_size)
-    : m_destination(destination), m_recv_cb(recv_cb), m_max_frame_size(max_frame_size)
+    : m_destination(std::move(destination)), m_recv_cb(std::move(recv_cb)),
+      m_max_frame_size(max_frame_size)
 {
 }
 

--- a/Source/Core/Core/HW/EXI/BBA/TAPServerConnection.h
+++ b/Source/Core/Core/HW/EXI/BBA/TAPServerConnection.h
@@ -19,8 +19,7 @@ class TAPServerConnection
 public:
   using RecvCallback = std::function<void(std::string&&)>;
 
-  TAPServerConnection(const std::string& destination, RecvCallback recv_cb,
-                      std::size_t max_frame_size);
+  TAPServerConnection(std::string destination, RecvCallback recv_cb, std::size_t max_frame_size);
 
   bool Activate();
   void Deactivate();

--- a/Source/Core/Core/HW/EXI/EXI_DeviceDummy.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceDummy.cpp
@@ -4,14 +4,15 @@
 #include "Core/HW/EXI/EXI_DeviceDummy.h"
 
 #include <string>
+#include <utility>
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
 namespace ExpansionInterface
 {
-CEXIDummy::CEXIDummy(Core::System& system, const std::string& name)
-    : IEXIDevice(system), m_name{name}
+CEXIDummy::CEXIDummy(Core::System& system, std::string name)
+    : IEXIDevice(system), m_name{std::move(name)}
 {
 }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceDummy.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceDummy.h
@@ -16,7 +16,7 @@ namespace ExpansionInterface
 class CEXIDummy final : public IEXIDevice
 {
 public:
-  CEXIDummy(Core::System& system, const std::string& name);
+  CEXIDummy(Core::System& system, std::string name);
 
   void ImmWrite(u32 data, u32 size) override;
   u32 ImmRead(u32 size) override;

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -55,7 +55,7 @@ static Common::EnumMap<char, MAX_MEMCARD_SLOT> s_card_short_names{'A', 'B'};
 // Takes care of the nasty recovery of the 'this' pointer from card_slot,
 // stored in the userdata parameter of the CoreTiming event.
 void CEXIMemoryCard::EventCompleteFindInstance(Core::System& system, u64 userdata,
-                                               std::function<void(CEXIMemoryCard*)> callback)
+                                               const std::function<void(CEXIMemoryCard*)>& callback)
 {
   Slot card_slot = static_cast<Slot>(userdata);
   IEXIDevice* self = system.GetExpansionInterface().GetDevice(card_slot);

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.h
@@ -68,7 +68,7 @@ private:
   void SetupGciFolder(const Memcard::HeaderData& header_data);
   void SetupRawMemcard(u16 size_mb);
   static void EventCompleteFindInstance(Core::System& system, u64 userdata,
-                                        std::function<void(CEXIMemoryCard*)> callback);
+                                        const std::function<void(CEXIMemoryCard*)>& callback);
 
   // Scheduled when a command that required delayed end signaling is done.
   static void CmdDoneCallback(Core::System& system, u64 userdata, s64 cyclesLate);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -176,11 +177,11 @@ std::vector<std::string> GCMemcardDirectory::GetFileNamesForGameID(const std::st
   return filenames;
 }
 
-GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, ExpansionInterface::Slot slot,
+GCMemcardDirectory::GCMemcardDirectory(std::string directory, ExpansionInterface::Slot slot,
                                        const Memcard::HeaderData& header_data, u32 game_id)
     : MemoryCardBase(slot, header_data.m_size_mb), m_game_id(game_id), m_last_block(-1),
-      m_hdr(header_data), m_bat1(header_data.m_size_mb), m_saves(0), m_save_directory(directory),
-      m_exiting(false)
+      m_hdr(header_data), m_bat1(header_data.m_size_mb), m_saves(0),
+      m_save_directory(std::move(directory)), m_exiting(false)
 {
   // Use existing header data if available
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -22,7 +22,7 @@ void MigrateFromMemcardFile(const std::string& directory_name, ExpansionInterfac
 class GCMemcardDirectory : public MemoryCardBase
 {
 public:
-  GCMemcardDirectory(const std::string& directory, ExpansionInterface::Slot slot,
+  GCMemcardDirectory(std::string directory, ExpansionInterface::Slot slot,
                      const Memcard::HeaderData& header_data, u32 game_id);
   ~GCMemcardDirectory() override;
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -34,9 +35,8 @@
 #define SIZE_TO_Mb (1024 * 8 * 16)
 #define MC_HDR_SIZE 0xA000
 
-MemoryCard::MemoryCard(const std::string& filename, ExpansionInterface::Slot card_slot,
-                       u16 size_mbits)
-    : MemoryCardBase(card_slot, size_mbits), m_filename(filename)
+MemoryCard::MemoryCard(std::string filename, ExpansionInterface::Slot card_slot, u16 size_mbits)
+    : MemoryCardBase(card_slot, size_mbits), m_filename(std::move(filename))
 {
   File::IOFile file(m_filename, "rb");
   if (file)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.h
@@ -17,7 +17,7 @@ class PointerWrap;
 class MemoryCard : public MemoryCardBase
 {
 public:
-  MemoryCard(const std::string& filename, ExpansionInterface::Slot card_slot,
+  MemoryCard(std::string filename, ExpansionInterface::Slot card_slot,
              u16 size_mbits = Memcard::MBIT_SIZE_MEMORY_CARD_2043);
   ~MemoryCard() override;
   void FlushThread();

--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -4,6 +4,7 @@
 #include "Core/HW/MMIO.h"
 
 #include <functional>
+#include <utility>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
@@ -113,12 +114,12 @@ class ComplexHandlingMethod : public ReadHandlingMethod<T>, public WriteHandling
 {
 public:
   explicit ComplexHandlingMethod(std::function<T(Core::System&, u32)> read_lambda)
-      : read_lambda_(read_lambda), write_lambda_(InvalidWriteLambda())
+      : read_lambda_(std::move(read_lambda)), write_lambda_(InvalidWriteLambda())
   {
   }
 
   explicit ComplexHandlingMethod(std::function<void(Core::System&, u32, T)> write_lambda)
-      : read_lambda_(InvalidReadLambda()), write_lambda_(write_lambda)
+      : read_lambda_(InvalidReadLambda()), write_lambda_(std::move(write_lambda))
   {
   }
 
@@ -159,12 +160,12 @@ private:
 template <typename T>
 ReadHandlingMethod<T>* ComplexRead(std::function<T(Core::System&, u32)> lambda)
 {
-  return new ComplexHandlingMethod<T>(lambda);
+  return new ComplexHandlingMethod<T>(std::move(lambda));
 }
 template <typename T>
 WriteHandlingMethod<T>* ComplexWrite(std::function<void(Core::System&, u32, T)> lambda)
 {
-  return new ComplexHandlingMethod<T>(lambda);
+  return new ComplexHandlingMethod<T>(std::move(lambda));
 }
 
 // Invalid: specialization of the complex handling type with lambdas that

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -126,7 +126,7 @@ public:
 
     Md5 md5_calc;
     mbedtls_md5_ret(reinterpret_cast<const u8*>(&header), sizeof(Header), md5_calc.data());
-    header.md5 = std::move(md5_calc);
+    header.md5 = md5_calc;
     return header;
   }
 
@@ -541,7 +541,7 @@ CopyResult Copy(Storage* source, Storage* dest)
   return CopyResult::Success;
 }
 
-CopyResult Import(const std::string& data_bin_path, std::function<bool()> can_overwrite)
+CopyResult Import(const std::string& data_bin_path, const std::function<bool()>& can_overwrite)
 {
   IOS::HLE::Kernel ios;
   const auto data_bin = MakeDataBinStorage(&ios.GetIOSC(), data_bin_path, "rb");

--- a/Source/Core/Core/HW/WiiSave.h
+++ b/Source/Core/Core/HW/WiiSave.h
@@ -44,7 +44,7 @@ enum class CopyResult
 CopyResult Copy(Storage* source, Storage* destination);
 
 /// Import a save into the NAND from a .bin file.
-CopyResult Import(const std::string& data_bin_path, std::function<bool()> can_overwrite);
+CopyResult Import(const std::string& data_bin_path, const std::function<bool()>& can_overwrite);
 /// Export a save to a .bin file.
 CopyResult Export(u64 tid, std::string_view export_path);
 /// Export all saves that are in the NAND. Returns the number of exported saves.

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <map>
+#include <utility>
 
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
@@ -152,8 +153,8 @@ void IOCtlVRequest::DumpUnknown(Core::System& system, const std::string& descrip
   Dump(system, "Unknown IOCtlV - " + description, type, level);
 }
 
-Device::Device(Kernel& ios, const std::string& device_name, const DeviceType type)
-    : m_ios(ios), m_name(device_name), m_device_type(type)
+Device::Device(Kernel& ios, std::string device_name, const DeviceType type)
+    : m_ios(ios), m_name(std::move(device_name)), m_device_type(type)
 {
 }
 

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -186,7 +186,7 @@ public:
     OH0,     // OH0 child devices which are created dynamically.
   };
 
-  Device(Kernel& ios, const std::string& device_name, DeviceType type = DeviceType::Static);
+  Device(Kernel& ios, std::string device_name, DeviceType type = DeviceType::Static);
 
   virtual ~Device() = default;
   virtual void DoState(PointerWrap& p);

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -141,9 +142,8 @@ bool HostFileSystem::FstEntry::CheckPermission(Uid caller_uid, Gid caller_gid,
   return (u8(requested_mode) & u8(file_mode)) == u8(requested_mode);
 }
 
-HostFileSystem::HostFileSystem(const std::string& root_path,
-                               std::vector<NandRedirect> nand_redirects)
-    : m_root_path{root_path}, m_nand_redirects(std::move(nand_redirects))
+HostFileSystem::HostFileSystem(std::string root_path, std::vector<NandRedirect> nand_redirects)
+    : m_root_path{std::move(root_path)}, m_nand_redirects(std::move(nand_redirects))
 {
   while (m_root_path.ends_with('/'))
     m_root_path.pop_back();
@@ -279,7 +279,7 @@ HostFileSystem::FstEntry* HostFileSystem::GetFstEntryForPath(const std::string& 
   return entry;
 }
 
-void HostFileSystem::DoStateRead(PointerWrap& p, std::string start_directory_path)
+void HostFileSystem::DoStateRead(PointerWrap& p, const std::string& start_directory_path)
 {
   std::string path = BuildFilename(start_directory_path).host_path;
   File::DeleteDirRecursively(path);
@@ -324,7 +324,7 @@ void HostFileSystem::DoStateRead(PointerWrap& p, std::string start_directory_pat
   }
 }
 
-void HostFileSystem::DoStateWriteOrMeasure(PointerWrap& p, std::string start_directory_path)
+void HostFileSystem::DoStateWriteOrMeasure(PointerWrap& p, const std::string& start_directory_path)
 {
   std::string path = BuildFilename(start_directory_path).host_path;
   File::FSTEntry parent_entry = File::ScanDirectoryTree(path, true);

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.h
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.h
@@ -22,7 +22,7 @@ namespace IOS::HLE::FS
 class HostFileSystem final : public FileSystem
 {
 public:
-  HostFileSystem(const std::string& root_path, std::vector<NandRedirect> nand_redirects = {});
+  HostFileSystem(std::string root_path, std::vector<NandRedirect> nand_redirects = {});
   ~HostFileSystem() override;
 
   void DoState(PointerWrap& p) override;
@@ -60,8 +60,8 @@ public:
   void SetNandRedirects(std::vector<NandRedirect> nand_redirects) override;
 
 private:
-  void DoStateWriteOrMeasure(PointerWrap& p, std::string start_directory_path);
-  void DoStateRead(PointerWrap& p, std::string start_directory_path);
+  void DoStateWriteOrMeasure(PointerWrap& p, const std::string& start_directory_path);
+  void DoStateRead(PointerWrap& p, const std::string& start_directory_path);
 
   struct FstEntry
   {

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -69,7 +69,7 @@ enum SOResultCode : s32
 NetIPTopDevice::NetIPTopDevice(EmulationKernel& ios, const std::string& device_name)
     : EmulationDevice(ios, device_name)
 {
-  m_work_queue.Reset("Network Worker", [this](AsyncTask task) {
+  m_work_queue.Reset("Network Worker", [this](const AsyncTask& task) {
     const IPCReply reply = task.handler();
     {
       std::lock_guard lg(m_async_reply_lock);

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -159,7 +159,7 @@ NetKDRequestDevice::NetKDRequestDevice(EmulationKernel& ios, const std::string& 
   // Enable all NWC24 permissions
   m_scheduler_buffer[1] = Common::swap32(-1);
 
-  m_work_queue.Reset("WiiConnect24 Worker", [this](AsyncTask task) {
+  m_work_queue.Reset("WiiConnect24 Worker", [this](const AsyncTask& task) {
     const IPCReply reply = task.handler();
     {
       std::lock_guard lg(m_async_reply_lock);

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -850,14 +850,14 @@ void WiiSocket::ResetTimeout()
   timeout.reset();
 }
 
-void WiiSocket::DoSock(Request request, NET_IOCTL type)
+void WiiSocket::DoSock(const Request& request, NET_IOCTL type)
 {
   sockop so = {request, false};
   so.net_type = type;
   pending_sockops.push_back(so);
 }
 
-void WiiSocket::DoSock(Request request, SSL_IOCTL type)
+void WiiSocket::DoSock(const Request& request, SSL_IOCTL type)
 {
   sockop so = {request, true};
   so.ssl_type = type;

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -213,8 +213,8 @@ private:
   const Timeout& GetTimeout();
   void ResetTimeout();
 
-  void DoSock(Request request, NET_IOCTL type);
-  void DoSock(Request request, SSL_IOCTL type);
+  void DoSock(const Request& request, NET_IOCTL type);
+  void DoSock(const Request& request, SSL_IOCTL type);
   void Update(bool read, bool write, bool except);
   void UpdateConnectingState(s32 connect_rv);
   ConnectingState GetConnectingState() const;

--- a/Source/Core/Core/IOS/USB/Emulated/Microphone.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Microphone.cpp
@@ -31,13 +31,13 @@
 namespace IOS::HLE::USB
 {
 #ifdef HAVE_CUBEB
-Microphone::Microphone(const MicrophoneState& sampler, const std::string& worker_name)
-    : m_sampler(sampler), m_worker(worker_name)
+Microphone::Microphone(const MicrophoneState& sampler, std::string worker_name)
+    : m_sampler(sampler), m_worker(std::move(worker_name))
 {
 }
 #else
-Microphone::Microphone(const MicrophoneState& sampler, const std::string& worker_name)
-    : m_sampler(sampler)
+Microphone::Microphone(MicrophoneState sampler, std::string worker_name)
+    : m_sampler(std::move(sampler))
 {
 }
 #endif

--- a/Source/Core/Core/IOS/USB/Emulated/Microphone.h
+++ b/Source/Core/Core/IOS/USB/Emulated/Microphone.h
@@ -38,7 +38,7 @@ public:
   using SampleType = s16;
   using UnsignedSampleType = std::make_unsigned_t<SampleType>;
 
-  Microphone(const MicrophoneState& sampler, const std::string& worker_name);
+  Microphone(const MicrophoneState& sampler, std::string worker_name);
   virtual ~Microphone();
 
   void Initialize();

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -111,7 +111,7 @@ void USBHost::OnDevicesChangedInternal(const USBScanner::DeviceMap& new_devices)
                    device->GetPid());
 
       changes = true;
-      auto device_copy = std::move(device);
+      auto device_copy = device;
       it = m_devices.erase(it);
       OnDeviceChange(ChangeEvent::Removed, std::move(device_copy));
     }
@@ -138,8 +138,9 @@ void USBHost::OnDevicesChangedInternal(const USBScanner::DeviceMap& new_devices)
     OnDeviceChangeEnd();
 }
 
-std::optional<IPCReply> USBHost::HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
-                                                std::function<s32()> submit) const
+std::optional<IPCReply> USBHost::HandleTransfer(const std::shared_ptr<USB::Device>& device,
+                                                u32 request,
+                                                const std::function<s32()>& submit) const
 {
   if (!device)
     return IPCReply(IPC_ENOENT);

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -46,8 +46,8 @@ protected:
   virtual void OnDeviceChangeEnd();
   virtual bool ShouldAddDevice(const USB::Device& device) const;
 
-  std::optional<IPCReply> HandleTransfer(std::shared_ptr<USB::Device> device, u32 request,
-                                         std::function<s32()> submit) const;
+  std::optional<IPCReply> HandleTransfer(const std::shared_ptr<USB::Device>& device, u32 request,
+                                         const std::function<s32()>& submit) const;
 
   std::map<u64, std::shared_ptr<USB::Device>> m_devices;
   mutable std::recursive_mutex m_devices_mutex;

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -476,8 +476,8 @@ void LibusbDevice::TransferEndpoint::AddTransfer(std::unique_ptr<TransferCommand
   m_transfers.emplace(transfer, std::move(command));
 }
 
-void LibusbDevice::TransferEndpoint::HandleTransfer(libusb_transfer* transfer,
-                                                    std::function<s32(const TransferCommand&)> fn)
+void LibusbDevice::TransferEndpoint::HandleTransfer(
+    libusb_transfer* transfer, const std::function<s32(const TransferCommand&)>& fn)
 {
   std::lock_guard lk{m_transfers_mutex};
   const auto iterator = m_transfers.find(transfer);

--- a/Source/Core/Core/IOS/USB/LibusbDevice.h
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.h
@@ -60,7 +60,8 @@ private:
   {
   public:
     void AddTransfer(std::unique_ptr<TransferCommand> command, libusb_transfer* transfer);
-    void HandleTransfer(libusb_transfer* tr, std::function<s32(const TransferCommand&)> function);
+    void HandleTransfer(libusb_transfer* tr,
+                        const std::function<s32(const TransferCommand&)>& function);
     void CancelTransfers();
 
   private:

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -192,7 +192,7 @@ IPCReply USBV5ResourceManager::SuspendResume(USBV5Device& device, const IOCtlReq
 }
 
 std::optional<IPCReply> USBV5ResourceManager::HandleDeviceIOCtl(const IOCtlRequest& request,
-                                                                Handler handler)
+                                                                const Handler& handler)
 {
   if (request.buffer_in == 0 || request.buffer_in_size != 0x20)
     return IPCReply(IPC_EINVAL);

--- a/Source/Core/Core/IOS/USB/USBV5.h
+++ b/Source/Core/Core/IOS/USB/USBV5.h
@@ -82,7 +82,7 @@ protected:
   IPCReply SuspendResume(USBV5Device& device, const IOCtlRequest& request);
 
   using Handler = std::function<std::optional<IPCReply>(USBV5Device&)>;
-  std::optional<IPCReply> HandleDeviceIOCtl(const IOCtlRequest& request, Handler handler);
+  std::optional<IPCReply> HandleDeviceIOCtl(const IOCtlRequest& request, const Handler& handler);
   IPCReply GetUSBVersion(const IOCtlRequest& request) const;
 
   void OnDeviceChange(ChangeEvent event, std::shared_ptr<USB::Device> device) override;

--- a/Source/Core/Core/LibusbUtils.cpp
+++ b/Source/Core/Core/LibusbUtils.cpp
@@ -52,7 +52,7 @@ public:
 
   libusb_context* GetContext() const { return m_context; }
 
-  int GetDeviceList(GetDeviceListCallback callback) const
+  int GetDeviceList(const GetDeviceListCallback& callback) const
   {
     std::lock_guard lock{m_device_list_mutex};
 
@@ -113,9 +113,9 @@ bool Context::IsValid() const
   return m_impl->GetContext() != nullptr;
 }
 
-int Context::GetDeviceList(GetDeviceListCallback callback) const
+int Context::GetDeviceList(const GetDeviceListCallback& callback) const
 {
-  return m_impl->GetDeviceList(std::move(callback));
+  return m_impl->GetDeviceList(callback);
 }
 
 std::pair<int, ConfigDescriptor> MakeConfigDescriptor(libusb_device* device, u8 config_num)

--- a/Source/Core/Core/LibusbUtils.h
+++ b/Source/Core/Core/LibusbUtils.h
@@ -35,7 +35,7 @@ public:
   bool IsValid() const;
 
   // Only valid if the context is valid.
-  int GetDeviceList(GetDeviceListCallback callback) const;
+  int GetDeviceList(const GetDeviceListCallback& callback) const;
 
 private:
   class Impl;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -14,6 +14,7 @@
 #include <thread>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -123,8 +124,8 @@ NetPlayClient::~NetPlayClient()
 
 // called from ---GUI--- thread
 NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlayUI* dialog,
-                             const std::string& name, const NetTraversalConfig& traversal_config)
-    : m_dialog(dialog), m_player_name(name)
+                             std::string name, const NetTraversalConfig& traversal_config)
+    : m_dialog(dialog), m_player_name(std::move(name))
 {
   ClearBuffers();
 
@@ -2536,7 +2537,8 @@ bool NetPlayClient::DoAllPlayersHaveGame()
   });
 }
 
-static std::string SHA1Sum(const std::string& file_path, std::function<bool(int)> report_progress)
+static std::string SHA1Sum(const std::string& file_path,
+                           const std::function<bool(int)>& report_progress)
 {
   std::vector<u8> data(8 * 1024 * 1024);
   u64 read_offset = 0;

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -113,8 +113,8 @@ public:
   void ThreadFunc();
   void SendAsync(sf::Packet&& packet, u8 channel_id = DEFAULT_CHANNEL);
 
-  NetPlayClient(const std::string& address, const u16 port, NetPlayUI* dialog,
-                const std::string& name, const NetTraversalConfig& traversal_config);
+  NetPlayClient(const std::string& address, const u16 port, NetPlayUI* dialog, std::string name,
+                const NetTraversalConfig& traversal_config);
   ~NetPlayClient() override;
 
   std::vector<const Player*> GetPlayers();

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -203,7 +203,7 @@ void LoadPatches()
   }
 
   const size_t enabled_patch_count =
-      std::ranges::count_if(s_on_frame, [](Patch patch) { return patch.enabled; });
+      std::ranges::count_if(s_on_frame, [](const Patch& patch) { return patch.enabled; });
   if (enabled_patch_count > 0)
   {
     OSD::AddMessage(fmt::format("{} game patch(es) enabled", enabled_patch_count),

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -215,7 +215,7 @@ RCForkGuard::RCForkGuard(RegCache& rc_) : rc(&rc_), m_regs(rc_.m_regs), m_xregs(
 }
 
 RCForkGuard::RCForkGuard(RCForkGuard&& other) noexcept
-    : rc(other.rc), m_regs(std::move(other.m_regs)), m_xregs(std::move(other.m_xregs))
+    : rc(other.rc), m_regs(other.m_regs), m_xregs(other.m_xregs)
 {
   other.rc = nullptr;
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -113,7 +113,7 @@ JitBlock** JitBaseBlockCache::GetFastBlockMapFallback()
 }
 
 void JitBaseBlockCache::RunOnBlocks(const Core::CPUThreadGuard&,
-                                    std::function<void(const JitBlock&)> f) const
+                                    const std::function<void(const JitBlock&)>& f) const
 {
   for (const auto& e : block_map)
     f(e.second);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -162,7 +162,8 @@ public:
   // Code Cache
   u8** GetEntryPoints();
   JitBlock** GetFastBlockMapFallback();
-  void RunOnBlocks(const Core::CPUThreadGuard& guard, std::function<void(const JitBlock&)> f) const;
+  void RunOnBlocks(const Core::CPUThreadGuard& guard,
+                   const std::function<void(const JitBlock&)>& f) const;
   void WipeBlockProfilingData(const Core::CPUThreadGuard& guard);
   std::size_t GetBlockCount() const { return block_map.size(); }
 

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -195,10 +195,10 @@ void JitInterface::WipeBlockProfilingData(const Core::CPUThreadGuard& guard)
 }
 
 void JitInterface::RunOnBlocks(const Core::CPUThreadGuard& guard,
-                               std::function<void(const JitBlock&)> f) const
+                               const std::function<void(const JitBlock&)>& f) const
 {
   if (m_jit)
-    m_jit->GetBlockCache()->RunOnBlocks(guard, std::move(f));
+    m_jit->GetBlockCache()->RunOnBlocks(guard, f);
 }
 
 std::size_t JitInterface::GetBlockCount() const

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -54,7 +54,8 @@ public:
   void UpdateMembase();
   void JitBlockLogDump(const Core::CPUThreadGuard& guard, std::FILE* file) const;
   void WipeBlockProfilingData(const Core::CPUThreadGuard& guard);
-  void RunOnBlocks(const Core::CPUThreadGuard& guard, std::function<void(const JitBlock&)> f) const;
+  void RunOnBlocks(const Core::CPUThreadGuard& guard,
+                   const std::function<void(const JitBlock&)>& f) const;
   std::size_t GetBlockCount() const;
 
   // Memory Utilities

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -647,10 +647,10 @@ bool PPCSymbolDB::SaveSymbolMap(const std::string& filename) const
   std::lock_guard lock(m_mutex);
 
   // Write .text section
-  auto function_symbols =
-      m_functions |
-      std::views::filter([](auto f) { return f.second.type == Common::Symbol::Type::Function; }) |
-      std::views::transform([](auto f) { return f.second; });
+  auto function_symbols = m_functions | std::views::filter([](const auto& f) {
+                            return f.second.type == Common::Symbol::Type::Function;
+                          }) |
+                          std::views::transform([](const auto& f) { return f.second; });
   file.WriteString(".text section layout\n");
   for (const auto& symbol : function_symbols)
   {
@@ -665,10 +665,10 @@ bool PPCSymbolDB::SaveSymbolMap(const std::string& filename) const
   }
 
   // Write .data section
-  auto data_symbols =
-      m_functions |
-      std::views::filter([](auto f) { return f.second.type == Common::Symbol::Type::Data; }) |
-      std::views::transform([](auto f) { return f.second; });
+  auto data_symbols = m_functions | std::views::filter([](const auto& f) {
+                        return f.second.type == Common::Symbol::Type::Data;
+                      }) |
+                      std::views::transform([](const auto& f) { return f.second; });
   file.WriteString("\n.data section layout\n");
   for (const auto& symbol : data_symbols)
   {
@@ -683,7 +683,7 @@ bool PPCSymbolDB::SaveSymbolMap(const std::string& filename) const
   }
 
   // Write .note section
-  auto note_symbols = m_notes | std::views::transform([](auto f) { return f.second; });
+  auto note_symbols = m_notes | std::views::transform([](const auto& f) { return f.second; });
   file.WriteString("\n.note section layout\n");
   for (const auto& symbol : note_symbols)
   {

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -335,7 +335,7 @@ std::string SystemUpdater::GetDeviceId()
 class OnlineSystemUpdater final : public SystemUpdater
 {
 public:
-  OnlineSystemUpdater(UpdateCallback update_callback, const std::string& region);
+  OnlineSystemUpdater(UpdateCallback update_callback, std::string region);
   UpdateResult DoOnlineUpdate();
 
 private:
@@ -365,8 +365,8 @@ private:
   Common::HttpRequest m_http{std::chrono::minutes{3}};
 };
 
-OnlineSystemUpdater::OnlineSystemUpdater(UpdateCallback update_callback, const std::string& region)
-    : m_update_callback(std::move(update_callback)), m_requested_region(region)
+OnlineSystemUpdater::OnlineSystemUpdater(UpdateCallback update_callback, std::string region)
+    : m_update_callback(std::move(update_callback)), m_requested_region(std::move(region))
 {
 }
 

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -33,8 +33,8 @@ namespace DiscIO
 {
 bool IsGCZBlob(File::DirectIOFile& file);
 
-CompressedBlobReader::CompressedBlobReader(File::DirectIOFile file, const std::string& filename)
-    : m_file(std::move(file)), m_file_name(filename)
+CompressedBlobReader::CompressedBlobReader(File::DirectIOFile file, std::string filename)
+    : m_file(std::move(file)), m_file_name(std::move(filename))
 {
   m_file_size = m_file.GetSize();
   m_file.Seek(0, File::SeekOrigin::Begin);

--- a/Source/Core/DiscIO/CompressedBlob.h
+++ b/Source/Core/DiscIO/CompressedBlob.h
@@ -65,7 +65,7 @@ public:
   bool GetBlock(u64 block_num, u8* out_ptr) override;
 
 private:
-  CompressedBlobReader(File::DirectIOFile file, const std::string& filename);
+  CompressedBlobReader(File::DirectIOFile file, std::string filename);
 
   CompressedBlobHeader m_header;
   std::vector<u64> m_block_pointers;

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -837,9 +837,9 @@ static void GenerateBuilderNodesFromFileSystem(const VolumeDisc& volume, const P
   }
 }
 
-DirectoryBlobPartition::DirectoryBlobPartition(const std::string& root_directory,
+DirectoryBlobPartition::DirectoryBlobPartition(std::string root_directory,
                                                std::optional<bool> is_wii)
-    : m_root_directory(root_directory)
+    : m_root_directory(std::move(root_directory))
 {
   std::vector<u8> disc_header(DISCHEADER_SIZE);
   if (ReadFileToVector(m_root_directory + "sys/boot.bin", &disc_header) < 0x20)

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -176,7 +176,7 @@ class DirectoryBlobPartition
 {
 public:
   DirectoryBlobPartition() = default;
-  DirectoryBlobPartition(const std::string& root_directory, std::optional<bool> is_wii);
+  DirectoryBlobPartition(std::string root_directory, std::optional<bool> is_wii);
   DirectoryBlobPartition(
       VolumeDisc* volume, const Partition& partition, std::optional<bool> is_wii,
       const std::function<void(std::vector<FSTBuilderNode>* fst_nodes)>& sys_callback,

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.cpp
@@ -34,7 +34,7 @@ AchievementsWindow::AchievementsWindow(QWidget* parent) : QDialog(parent)
   m_event_hook = AchievementManager::GetInstance().update_event.Register(
       [this](AchievementManager::UpdatedItems updated_items) {
         QueueOnObject(this, [this, updated_items = std::move(updated_items)] {
-          AchievementsWindow::UpdateData(std::move(updated_items));
+          AchievementsWindow::UpdateData(updated_items);
         });
       });
   UpdateData(AchievementManager::UpdatedItems{.all = true});
@@ -80,7 +80,7 @@ void AchievementsWindow::ConnectWidgets()
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 }
 
-void AchievementsWindow::UpdateData(AchievementManager::UpdatedItems updated_items)
+void AchievementsWindow::UpdateData(const AchievementManager::UpdatedItems& updated_items)
 {
   m_settings_widget->UpdateData(updated_items.failed_login_code);
   if (updated_items.all)

--- a/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
+++ b/Source/Core/DolphinQt/Achievements/AchievementsWindow.h
@@ -22,7 +22,7 @@ class AchievementsWindow : public QDialog
   Q_OBJECT
 public:
   explicit AchievementsWindow(QWidget* parent);
-  void UpdateData(AchievementManager::UpdatedItems updated_items);
+  void UpdateData(const AchievementManager::UpdatedItems& updated_items);
   void ForceSettingsTab();
 
 private:

--- a/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
@@ -3,6 +3,8 @@
 
 #include "DolphinQt/Config/CheatWarningWidget.h"
 
+#include <utility>
+
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPixmap>
@@ -16,9 +18,8 @@
 #include "DolphinQt/QtUtils/QtUtils.h"
 #include "DolphinQt/Settings.h"
 
-CheatWarningWidget::CheatWarningWidget(const std::string& game_id, bool restart_required,
-                                       QWidget* parent)
-    : QWidget(parent), m_game_id(game_id), m_restart_required(restart_required)
+CheatWarningWidget::CheatWarningWidget(std::string game_id, bool restart_required, QWidget* parent)
+    : QWidget(parent), m_game_id(std::move(game_id)), m_restart_required(restart_required)
 {
   CreateWidgets();
   ConnectWidgets();

--- a/Source/Core/DolphinQt/Config/CheatWarningWidget.h
+++ b/Source/Core/DolphinQt/Config/CheatWarningWidget.h
@@ -14,7 +14,7 @@ class CheatWarningWidget : public QWidget
 {
   Q_OBJECT
 public:
-  explicit CheatWarningWidget(const std::string& game_id, bool restart_required, QWidget* parent);
+  explicit CheatWarningWidget(std::string game_id, bool restart_required, QWidget* parent);
 
 signals:
   void OpenCheatEnableSettings();

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.cpp
@@ -91,7 +91,7 @@ void ConfigStringChoice::OnConfigChanged()
   Load();
 }
 
-ConfigComplexChoice::ConfigComplexChoice(const InfoVariant setting1, const InfoVariant setting2,
+ConfigComplexChoice::ConfigComplexChoice(const InfoVariant& setting1, const InfoVariant& setting2,
                                          Config::Layer* layer)
     : m_layer(layer), m_setting1(setting1), m_setting2(setting2)
 {

--- a/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
+++ b/Source/Core/DolphinQt/Config/ConfigControls/ConfigChoice.h
@@ -109,7 +109,7 @@ class ConfigComplexChoice final : public ToolTipComboBox
   using OptionVariant = std::variant<Config::DefaultState, u32, int, bool>;
 
 public:
-  ConfigComplexChoice(const InfoVariant setting1, const InfoVariant setting2,
+  ConfigComplexChoice(const InfoVariant& setting1, const InfoVariant& setting2,
                       Config::Layer* layer = nullptr);
 
   void Add(const QString& name, const OptionVariant option1, const OptionVariant option2);

--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -101,7 +101,8 @@ void VerifyWidget::CreateWidgets()
   m_verify_button = new QPushButton(tr("Verify Integrity"), this);
 }
 
-std::pair<QCheckBox*, QLineEdit*> VerifyWidget::AddHashLine(QFormLayout* layout, QString text)
+std::pair<QCheckBox*, QLineEdit*> VerifyWidget::AddHashLine(QFormLayout* layout,
+                                                            const QString& text)
 {
   QLineEdit* line_edit = new QLineEdit(this);
   line_edit->setReadOnly(true);
@@ -225,7 +226,7 @@ void VerifyWidget::Verify()
     m_redump_line_edit->setText(QString::fromStdString(result->redump.message));
 }
 
-void VerifyWidget::SetProblemCellText(int row, int column, QString text)
+void VerifyWidget::SetProblemCellText(int row, int column, const QString& text)
 {
   QLabel* label = new QLabel(text);
   label->setTextInteractionFlags(Qt::TextSelectableByMouse);

--- a/Source/Core/DolphinQt/Config/VerifyWidget.h
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.h
@@ -32,13 +32,13 @@ public:
 private:
   void OnEmulationStateChanged(Core::State state);
   void CreateWidgets();
-  std::pair<QCheckBox*, QLineEdit*> AddHashLine(QFormLayout* layout, QString text);
+  std::pair<QCheckBox*, QLineEdit*> AddHashLine(QFormLayout* layout, const QString& text);
   void ConnectWidgets();
 
   bool CanVerifyRedump() const;
   void UpdateRedumpEnabled();
   void Verify();
-  void SetProblemCellText(int row, int column, QString text);
+  void SetProblemCellText(int row, int column, const QString& text);
 
   std::shared_ptr<DiscIO::Volume> m_volume;
   QTableWidget* m_problems;

--- a/Source/Core/DolphinQt/Debugger/AssemblyEditor.cpp
+++ b/Source/Core/DolphinQt/Debugger/AssemblyEditor.cpp
@@ -9,6 +9,7 @@
 #include <QToolTip>
 
 #include <filesystem>
+#include <utility>
 
 #include "Common/StringUtil.h"
 #include "DolphinQt/Debugger/GekkoSyntaxHighlight.h"
@@ -23,8 +24,8 @@ void AsmEditor::LineNumberArea::paintEvent(QPaintEvent* event)
   asm_editor->LineNumberAreaPaintEvent(event);
 }
 
-AsmEditor::AsmEditor(const QString& path, int editor_num, bool dark_scheme, QWidget* parent)
-    : QPlainTextEdit(parent), m_path(path), m_base_address(QStringLiteral("0")),
+AsmEditor::AsmEditor(QString path, int editor_num, bool dark_scheme, QWidget* parent)
+    : QPlainTextEdit(parent), m_path(std::move(path)), m_base_address(QStringLiteral("0")),
       m_editor_num(editor_num), m_dirty(false), m_dark_scheme(dark_scheme)
 {
   if (!m_path.isEmpty())

--- a/Source/Core/DolphinQt/Debugger/AssemblyEditor.h
+++ b/Source/Core/DolphinQt/Debugger/AssemblyEditor.h
@@ -18,7 +18,7 @@ class AsmEditor : public QPlainTextEdit
   Q_OBJECT;
 
 public:
-  AsmEditor(const QString& file_path, int editor_num, bool dark_scheme, QWidget* parent = nullptr);
+  AsmEditor(QString file_path, int editor_num, bool dark_scheme, QWidget* parent = nullptr);
   void LineNumberAreaPaintEvent(QPaintEvent* event);
   int LineNumberAreaWidth();
   const QString& Path() const { return m_path; }

--- a/Source/Core/DolphinQt/Debugger/GekkoSyntaxHighlight.cpp
+++ b/Source/Core/DolphinQt/Debugger/GekkoSyntaxHighlight.cpp
@@ -5,6 +5,8 @@
 
 #include "Common/Assembler/GekkoParser.h"
 
+#include <utility>
+
 #include <QLabel>
 #include <QPalette>
 
@@ -189,7 +191,7 @@ void GekkoSyntaxHighlight::highlightBlock(const QString& text)
 
 GekkoSyntaxHighlight::GekkoSyntaxHighlight(QTextDocument* document, QTextCharFormat base_format,
                                            bool dark_scheme)
-    : QSyntaxHighlighter(document), m_base_format(base_format)
+    : QSyntaxHighlighter(document), m_base_format(std::move(base_format))
 {
   QPalette base_scheme;
   m_theme_idx = dark_scheme ? 1 : 0;

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -517,8 +517,9 @@ void RegisterWidget::PopulateTable()
   m_table->resizeColumnsToContents();
 }
 
-void RegisterWidget::AddRegister(int row, int column, RegisterType type, std::string register_name,
-                                 std::function<u64()> get_reg, std::function<void(u64)> set_reg)
+void RegisterWidget::AddRegister(int row, int column, RegisterType type,
+                                 const std::string& register_name, std::function<u64()> get_reg,
+                                 std::function<void(u64)> set_reg)
 {
   auto* value = new RegisterColumn(type, std::move(get_reg), std::move(set_reg));
 

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.h
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.h
@@ -48,7 +48,7 @@ private:
   void OnItemChanged(QTableWidgetItem* item);
   void OnDebugFontChanged(const QFont& font);
 
-  void AddRegister(int row, int column, RegisterType type, std::string register_name,
+  void AddRegister(int row, int column, RegisterType type, const std::string& register_name,
                    std::function<u64()> get_reg, std::function<void(u64)> set_reg);
 
   void AutoStep(const std::string& reg) const;

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -518,7 +518,7 @@ void WatchWidget::ShowInMemory(int row)
   emit ShowMemory(m_system.GetPowerPC().GetDebugInterface().GetWatch(row).address);
 }
 
-void WatchWidget::AddWatch(QString name, u32 addr)
+void WatchWidget::AddWatch(const QString& name, u32 addr)
 {
   m_system.GetPowerPC().GetDebugInterface().SetWatch(addr, name.toStdString());
   Update();

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.h
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.h
@@ -27,7 +27,7 @@ public:
   explicit WatchWidget(QWidget* parent = nullptr);
   ~WatchWidget() override;
 
-  void AddWatch(QString name, u32 addr);
+  void AddWatch(const QString& name, u32 addr);
 signals:
   void RequestMemoryBreakpoint(u32 addr);
   void ShowMemory(u32 addr);

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -327,7 +327,7 @@ void GCMemcardManager::UpdateActions()
   m_fix_checksums_button->setEnabled(have_memcard);
 }
 
-void GCMemcardManager::SetSlotFile(Slot slot, QString path)
+void GCMemcardManager::SetSlotFile(Slot slot, const QString& path)
 {
   auto [error_code, memcard] = Memcard::GCMemcard::Open(path.toStdString());
 

--- a/Source/Core/DolphinQt/GCMemcardManager.h
+++ b/Source/Core/DolphinQt/GCMemcardManager.h
@@ -55,7 +55,7 @@ private:
 
   void UpdateActions();
   void UpdateSlotTable(ExpansionInterface::Slot slot);
-  void SetSlotFile(ExpansionInterface::Slot slot, QString path);
+  void SetSlotFile(ExpansionInterface::Slot slot, const QString& path);
   void SetSlotFileInteractive(ExpansionInterface::Slot slot);
   void SetActiveSlot(ExpansionInterface::Slot slot);
 

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -56,7 +56,7 @@ signals:
   void GameCountUpdated(int total_games, int visible_games) const;
   void OnStartWithRiivolution(const UICommon::GameFile& game);
   void NetPlayHost(const UICommon::GameFile& game);
-  void SelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
+  void SelectionChanged(const std::shared_ptr<const UICommon::GameFile>& game_file);
   void OpenGeneralSettings();
   void OpenGraphicsSettings();
 #ifdef USE_RETRO_ACHIEVEMENTS

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -54,7 +54,7 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
   connect(&Settings::Instance(), &Settings::MetadataRefreshRequested, this,
           [this] { m_load_thread.EmplaceItem(Command{CommandType::UpdateMetadata, {}}); });
 
-  m_load_thread.Reset("GameList Tracker", [this](Command command) {
+  m_load_thread.Reset("GameList Tracker", [this](const Command& command) {
     switch (command.type)
     {
     case CommandType::LoadCache:
@@ -356,7 +356,7 @@ void GameTracker::LoadGame(const QString& path)
     bool cache_changed = false;
     auto game = m_cache.AddOrGet(converted_path, &cache_changed);
     if (game)
-      emit GameLoaded(std::move(game));
+      emit GameLoaded(game);
     if (cache_changed && !m_refresh_in_progress)
       m_cache.Save();
   }

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -76,7 +76,7 @@ void Host::SetMainWindowHandle(void* handle)
   m_main_window_handle = handle;
 }
 
-static void RunWithGPUThreadInactive(std::function<void()> f)
+static void RunWithGPUThreadInactive(const std::function<void()>& f)
 {
   // Potentially any thread which shows panic alerts can be blocked on this returning.
   // This means that, in order to avoid deadlocks, we need to be careful with how we

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.cpp
@@ -106,7 +106,8 @@ void InfinityBaseWindow::CreateMainWindow()
   setLayout(main_layout);
 }
 
-void InfinityBaseWindow::AddFigureSlot(QVBoxLayout* vbox_group, QString name, FigureUIPosition slot)
+void InfinityBaseWindow::AddFigureSlot(QVBoxLayout* vbox_group, const QString& name,
+                                       FigureUIPosition slot)
 {
   auto* hbox_infinity = new QHBoxLayout();
 

--- a/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.h
+++ b/Source/Core/DolphinQt/InfinityBase/InfinityBaseWindow.h
@@ -37,7 +37,8 @@ protected:
 
 private:
   void CreateMainWindow();
-  void AddFigureSlot(QVBoxLayout* vbox_group, QString name, IOS::HLE::USB::FigureUIPosition slot);
+  void AddFigureSlot(QVBoxLayout* vbox_group, const QString& name,
+                     IOS::HLE::USB::FigureUIPosition slot);
   void OnEmulationStateChanged(Core::State state);
   void EmulateBase(bool emulate);
   void ClearFigure(IOS::HLE::USB::FigureUIPosition slot);

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -22,6 +22,7 @@
 
 #include <future>
 #include <optional>
+#include <utility>
 #include <variant>
 
 #if defined(__unix__) || defined(__unix) || defined(__APPLE__)
@@ -201,7 +202,7 @@ static WindowSystemInfo GetWindowSystemInfo(QWindow* window)
   return wsi;
 }
 
-static std::vector<std::string> StringListToStdVector(QStringList list)
+static std::vector<std::string> StringListToStdVector(const QStringList& list)
 {
   std::vector<std::string> result;
   result.reserve(list.size());
@@ -474,7 +475,7 @@ void MainWindow::CreateComponents()
   m_code_widget = new CodeWidget(this);
   m_assembler_widget = new AssemblerWidget(this);
 
-  const auto request_watch = [this](QString name, u32 addr) {
+  const auto request_watch = [this](const QString& name, u32 addr) {
     m_watch_widget->AddWatch(name, addr);
   };
   const auto request_breakpoint = [this](u32 addr) { m_breakpoint_widget->AddBP(addr); };

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1419,7 +1419,7 @@ void MenuBar::NANDExtractCertificates()
   }
 }
 
-void MenuBar::OnSelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file)
+void MenuBar::OnSelectionChanged(const std::shared_ptr<const UICommon::GameFile>& game_file)
 {
   m_game_selected = !!game_file;
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -131,7 +131,7 @@ signals:
   void ExportRecording();
   void ShowTASInput();
 
-  void SelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
+  void SelectionChanged(const std::shared_ptr<const UICommon::GameFile>& game_file);
   void RecordingStatusChanged(bool recording);
   void ReadOnlyModeChanged(bool read_only);
 
@@ -195,7 +195,7 @@ private:
   void LogInstructions();
   void SearchInstruction();
 
-  void OnSelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
+  void OnSelectionChanged(const std::shared_ptr<const UICommon::GameFile>& game_file);
   void OnRecordingStatusChanged(bool recording);
   void OnReadOnlyModeChanged(bool read_only);
   void OnDebugModeToggled(bool enabled);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -23,6 +23,7 @@
 #include <QTextBrowser>
 
 #include <algorithm>
+#include <utility>
 
 #ifdef HAS_LIBMGBA
 #include <fmt/ranges.h>
@@ -500,7 +501,7 @@ void NetPlayDialog::reject()
 
 void NetPlayDialog::show(std::string nickname, bool use_traversal)
 {
-  m_nickname = nickname;
+  m_nickname = std::move(nickname);
   m_use_traversal = use_traversal;
   m_buffer_size = 0;
   m_old_player_count = 0;

--- a/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
@@ -19,7 +19,7 @@ ModalMessageBox::ModalMessageBox(QWidget* parent, Qt::WindowModality modality)
 static inline int ExecMessageBox(ModalMessageBox::Icon icon, QWidget* parent, const QString& title,
                                  const QString& text, ModalMessageBox::StandardButtons buttons,
                                  ModalMessageBox::StandardButton default_button,
-                                 Qt::WindowModality modality, QString detailed_text)
+                                 Qt::WindowModality modality, const QString& detailed_text)
 {
   ModalMessageBox msg(parent, modality);
   msg.setIcon(icon);

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -534,7 +534,7 @@ QString Settings::GetDefaultGame() const
   return QString::fromStdString(Config::Get(Config::MAIN_DEFAULT_ISO));
 }
 
-void Settings::SetDefaultGame(QString path)
+void Settings::SetDefaultGame(const QString& path)
 {
   if (GetDefaultGame() != path)
   {
@@ -833,7 +833,7 @@ void Settings::RefreshWidgetVisibility()
   emit GameCountVisibilityChanged(IsGameCountVisible());
 }
 
-void Settings::SetDebugFont(QFont font)
+void Settings::SetDebugFont(const QFont& font)
 {
   if (GetDebugFont() != font)
   {

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -102,7 +102,7 @@ public:
   bool GetPreferredView() const;
   void SetPreferredView(bool list);
   QString GetDefaultGame() const;
-  void SetDefaultGame(QString path);
+  void SetDefaultGame(const QString& path);
   void RefreshGameList();
   void NotifyRefreshGameListStarted();
   void NotifyRefreshGameListComplete();
@@ -175,7 +175,7 @@ public:
   void SetAssemblerVisible(bool enabled);
   bool IsAssemblerVisible() const;
   QFont GetDebugFont() const;
-  void SetDebugFont(QFont font);
+  void SetDebugFont(const QFont& font);
 
   // Auto-Update
   QString GetAutoUpdateTrack() const;

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -336,11 +336,12 @@ void AdvancedPane::ConnectLayout()
     Update();
   });
 
-  connect(m_custom_rtc_datetime, &QDateTimeEdit::dateTimeChanged, [this](QDateTime date_time) {
-    Config::SetBaseOrCurrent(Config::MAIN_CUSTOM_RTC_VALUE,
-                             static_cast<u32>(date_time.toSecsSinceEpoch()));
-    Update();
-  });
+  connect(m_custom_rtc_datetime, &QDateTimeEdit::dateTimeChanged,
+          [this](const QDateTime& date_time) {
+            Config::SetBaseOrCurrent(Config::MAIN_CUSTOM_RTC_VALUE,
+                                     static_cast<u32>(date_time.toSecsSinceEpoch()));
+            Update();
+          });
 }
 
 void AdvancedPane::Update()

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -166,8 +166,8 @@ QGridLayout* TASInputWindow::CreateSliderValuePairLayout(
 TASSpinBox* TASInputWindow::CreateSliderValuePair(
     std::string_view group_name, std::string_view control_name, InputOverrider* overrider,
     QGridLayout* layout, int zero, int default_, int min, int max,
-    QKeySequence shortcut_key_sequence, Qt::Orientation orientation, QWidget* shortcut_widget,
-    std::optional<ControlState> scale)
+    const QKeySequence& shortcut_key_sequence, Qt::Orientation orientation,
+    QWidget* shortcut_widget, std::optional<ControlState> scale)
 {
   TASSpinBox* value = CreateSliderValuePair(layout, default_, max, shortcut_key_sequence,
                                             orientation, shortcut_widget);
@@ -194,7 +194,7 @@ TASSpinBox* TASInputWindow::CreateSliderValuePair(
 // The shortcut_widget argument needs to specify the container widget that will be hidden/shown.
 // This is done to avoid ambiguous shortcuts
 TASSpinBox* TASInputWindow::CreateSliderValuePair(QGridLayout* layout, int default_, int max,
-                                                  QKeySequence shortcut_key_sequence,
+                                                  const QKeySequence& shortcut_key_sequence,
                                                   Qt::Orientation orientation,
                                                   QWidget* shortcut_widget)
 {

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.h
@@ -64,12 +64,12 @@ protected:
   TASSpinBox* CreateSliderValuePair(std::string_view group_name, std::string_view control_name,
                                     InputOverrider* overrider, QGridLayout* layout, int zero,
                                     int default_, int min, int max,
-                                    QKeySequence shortcut_key_sequence, Qt::Orientation orientation,
-                                    QWidget* shortcut_widget,
+                                    const QKeySequence& shortcut_key_sequence,
+                                    Qt::Orientation orientation, QWidget* shortcut_widget,
                                     std::optional<ControlState> scale = {});
   TASSpinBox* CreateSliderValuePair(QGridLayout* layout, int default_, int max,
-                                    QKeySequence shortcut_key_sequence, Qt::Orientation orientation,
-                                    QWidget* shortcut_widget);
+                                    const QKeySequence& shortcut_key_sequence,
+                                    Qt::Orientation orientation, QWidget* shortcut_widget);
 
   void SetupScrollArea(QLayout* layout);
 

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -956,7 +956,7 @@ private:
 
   static bool IsRTLBinaryOp(TokenType type) { return type == TOK_ASSIGN; }
 
-  static bool IsBinaryOpWithPrecedence(Token tok, int precedence)
+  static bool IsBinaryOpWithPrecedence(const Token& tok, int precedence)
   {
     if (!tok.IsBinaryOperator())
       return false;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.cpp
@@ -4,6 +4,7 @@
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 
 #include <string>
+#include <utility>
 
 namespace ControllerEmu
 {
@@ -11,8 +12,8 @@ Buttons::Buttons(const std::string& name_) : Buttons(name_, name_)
 {
 }
 
-Buttons::Buttons(const std::string& ini_name, const std::string& group_name)
-    : ControlGroup(ini_name, group_name, GroupType::Buttons)
+Buttons::Buttons(std::string ini_name, std::string group_name)
+    : ControlGroup(std::move(ini_name), std::move(group_name), GroupType::Buttons)
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.h
@@ -15,7 +15,7 @@ class Buttons : public ControlGroup
 {
 public:
   explicit Buttons(const std::string& name_);
-  Buttons(const std::string& ini_name, const std::string& group_name);
+  Buttons(std::string ini_name, std::string group_name);
 
   template <typename C>
   void GetState(C* const buttons, const C* bitmasks) const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
@@ -13,8 +13,7 @@
 
 namespace ControllerEmu
 {
-ModifySettingsButton::ModifySettingsButton(std::string button_name)
-    : Buttons(std::move(button_name))
+ModifySettingsButton::ModifySettingsButton(const std::string& button_name) : Buttons(button_name)
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.h
@@ -13,7 +13,7 @@ namespace ControllerEmu
 class ModifySettingsButton : public Buttons
 {
 public:
-  explicit ModifySettingsButton(std::string button_name);
+  explicit ModifySettingsButton(const std::string& button_name);
 
   void AddInput(std::string button_name, bool toggle = false);
 

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -166,7 +166,7 @@ void ControllerInterface::RefreshDevices(RefreshReason reason)
     InvokeDevicesChangedCallbacks();
 }
 
-void ControllerInterface::PlatformPopulateDevices(std::function<void()> callback)
+void ControllerInterface::PlatformPopulateDevices(const std::function<void()>& callback)
 {
   if (!m_is_init)
     return;

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -97,7 +97,7 @@ public:
   // This is mandatory to use on device populations functions that can be called concurrently by
   // more than one thread, or that are called by a single other thread.
   // Without this, our devices list might end up in a mixed state.
-  void PlatformPopulateDevices(std::function<void()> callback);
+  void PlatformPopulateDevices(const std::function<void()>& callback);
   bool IsInit() const { return m_is_init; }
   void UpdateInput();
 

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -25,7 +26,8 @@ class CombinedInput final : public Device::Input
 public:
   using Inputs = std::pair<Device::Input*, Device::Input*>;
 
-  CombinedInput(std::string name, const Inputs& inputs) : m_name(std::move(name)), m_inputs(inputs)
+  CombinedInput(std::string name, Inputs inputs)
+      : m_name(std::move(name)), m_inputs(std::move(inputs))
   {
   }
   ControlState GetState() const override

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -179,7 +179,7 @@ struct Server
     m_description = std::move(other.m_description);
     m_address = std::move(other.m_address);
     m_port = other.m_port;
-    m_port_info = std::move(other.m_port_info);
+    m_port_info = other.m_port_info;
   }
 
   Server& operator=(const Server&) = delete;

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <string>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 #include "Common/FileUtil.h"
@@ -73,7 +74,7 @@ void InputBackend::PopulateDevices()
   }
 }
 
-PipeDevice::PipeDevice(int fd, const std::string& name) : m_fd(fd), m_name(name)
+PipeDevice::PipeDevice(int fd, std::string name) : m_fd(fd), m_name(std::move(name))
 {
   for (const auto& tok : s_button_tokens)
   {

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
@@ -26,7 +26,7 @@ std::unique_ptr<ciface::InputBackend> CreateInputBackend(ControllerInterface* co
 class PipeDevice : public Core::Device
 {
 public:
-  PipeDevice(int fd, const std::string& name);
+  PipeDevice(int fd, std::string name);
   ~PipeDevice();
 
   Core::DeviceRemoval UpdateInput() override;

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
@@ -505,7 +505,7 @@ void Device::RunTasks()
   {
     static constexpr u16 MPLUS_POLL_ADDR = WiimoteEmu::MotionPlus::PASSTHROUGH_MODE_OFFSET;
     ReadData(AddressSpace::I2CBus, WiimoteEmu::MotionPlus::INACTIVE_DEVICE_ADDR, MPLUS_POLL_ADDR, 1,
-             [this](ReadResponse response) {
+             [this](const ReadResponse& response) {
                if (!response)
                {
                  DEBUG_LOG_FMT(WIIMOTE, "WiiRemote: M+ poll failed.");

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -15,6 +15,8 @@
 #include <chrono>
 #include <mutex>
 #include <optional>
+#include <utility>
+
 using namespace std::chrono_literals;
 
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
@@ -477,7 +479,7 @@ static void ScanThreadFunc()
 void SetAdapterCallback(std::function<void(void)> func)
 {
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
-  s_detect_callback = func;
+  s_detect_callback = std::move(func);
 #endif
 }
 

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -3,6 +3,7 @@
 
 #include "InputCommon/InputConfig.h"
 
+#include <utility>
 #include <vector>
 
 #include "Common/FileUtil.h"
@@ -16,10 +17,11 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/InputProfile.h"
 
-InputConfig::InputConfig(const std::string& ini_name, const std::string& gui_name,
-                         const std::string& profile_directory_name, const std::string& profile_key)
-    : m_ini_name(ini_name), m_gui_name(gui_name), m_profile_directory_name(profile_directory_name),
-      m_profile_key(profile_key)
+InputConfig::InputConfig(std::string ini_name, std::string gui_name,
+                         std::string profile_directory_name, std::string profile_key)
+    : m_ini_name(std::move(ini_name)), m_gui_name(std::move(gui_name)),
+      m_profile_directory_name(std::move(profile_directory_name)),
+      m_profile_key(std::move(profile_key))
 {
 }
 

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -24,8 +24,8 @@ class EmulatedController;
 class InputConfig
 {
 public:
-  InputConfig(const std::string& ini_name, const std::string& gui_name,
-              const std::string& profile_directory_name, const std::string& profile_key);
+  InputConfig(std::string ini_name, std::string gui_name, std::string profile_directory_name,
+              std::string profile_key);
 
   ~InputConfig();
 

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -54,9 +54,8 @@ public:
       std::optional<Config::System> system = Config::GetSystemFromName(system_str);
       if (system)
       {
-        m_values.emplace_back(
-            Config::Location{std::move(*system), std::move(section), std::move(key)},
-            std::move(value));
+        m_values.emplace_back(Config::Location{*system, std::move(section), std::move(key)},
+                              std::move(value));
       }
     }
   }

--- a/Source/Core/VideoBackends/OGL/OGLPipeline.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLPipeline.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoBackends/OGL/OGLPipeline.h"
 
+#include <utility>
+
 #include "VideoBackends/OGL/OGLShader.h"
 #include "VideoBackends/OGL/OGLVertexManager.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
@@ -27,12 +29,12 @@ static GLenum MapToGLPrimitive(PrimitiveType primitive_type)
   }
 }
 OGLPipeline::OGLPipeline(const AbstractPipelineConfig& config, const GLVertexFormat* vertex_format,
-                         const RasterizationState& rasterization_state,
-                         const DepthState& depth_state, const BlendingState& blending_state,
-                         PipelineProgram* program, GLuint gl_primitive)
+                         RasterizationState rasterization_state, DepthState depth_state,
+                         BlendingState blending_state, PipelineProgram* program,
+                         GLuint gl_primitive)
     : AbstractPipeline(config), m_vertex_format(vertex_format),
-      m_rasterization_state(rasterization_state), m_depth_state(depth_state),
-      m_blending_state(blending_state), m_program(program), m_gl_primitive(gl_primitive)
+      m_rasterization_state(std::move(rasterization_state)), m_depth_state(std::move(depth_state)),
+      m_blending_state(std::move(blending_state)), m_program(program), m_gl_primitive(gl_primitive)
 {
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLPipeline.h
+++ b/Source/Core/VideoBackends/OGL/OGLPipeline.h
@@ -15,9 +15,8 @@ class OGLPipeline final : public AbstractPipeline
 {
 public:
   explicit OGLPipeline(const AbstractPipelineConfig& config, const GLVertexFormat* vertex_format,
-                       const RasterizationState& rasterization_state, const DepthState& depth_state,
-                       const BlendingState& blending_state, PipelineProgram* program,
-                       GLenum gl_primitive);
+                       RasterizationState rasterization_state, DepthState depth_state,
+                       BlendingState blending_state, PipelineProgram* program, GLenum gl_primitive);
   ~OGLPipeline() override;
 
   const GLVertexFormat* GetVertexFormat() const { return m_vertex_format; }

--- a/Source/Core/VideoCommon/Assets/CustomAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/CustomAsset.cpp
@@ -8,8 +8,8 @@
 namespace VideoCommon
 {
 CustomAsset::CustomAsset(std::shared_ptr<CustomAssetLibrary> library,
-                         const CustomAssetLibrary::AssetID& asset_id, u64 asset_handle)
-    : m_owning_library(std::move(library)), m_asset_id(asset_id), m_handle(asset_handle)
+                         CustomAssetLibrary::AssetID asset_id, u64 asset_handle)
+    : m_owning_library(std::move(library)), m_asset_id(std::move(asset_id)), m_handle(asset_handle)
 {
 }
 

--- a/Source/Core/VideoCommon/Assets/CustomAsset.h
+++ b/Source/Core/VideoCommon/Assets/CustomAsset.h
@@ -20,8 +20,8 @@ public:
   using ClockType = std::chrono::steady_clock;
   using TimeType = ClockType::time_point;
 
-  CustomAsset(std::shared_ptr<CustomAssetLibrary> library,
-              const CustomAssetLibrary::AssetID& asset_id, u64 session_id);
+  CustomAsset(std::shared_ptr<CustomAssetLibrary> library, CustomAssetLibrary::AssetID asset_id,
+              u64 session_id);
   virtual ~CustomAsset() = default;
   CustomAsset(const CustomAsset&) = delete;
   CustomAsset(CustomAsset&&) = delete;

--- a/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
+++ b/Source/Core/VideoCommon/Assets/ShaderAsset.cpp
@@ -116,7 +116,7 @@ static bool ParseShaderValue(const CustomAssetLibrary::AssetID& asset_id,
     ShaderProperty::RGB rgb;
     if (!ParseNumeric<float, 3>(asset_id, json_value, code_name, &rgb.value))
       return false;
-    *value = std::move(rgb);
+    *value = rgb;
     return true;
   }
   else if (type == "rgba")
@@ -124,7 +124,7 @@ static bool ParseShaderValue(const CustomAssetLibrary::AssetID& asset_id,
     ShaderProperty::RGBA rgba;
     if (!ParseNumeric<float, 4>(asset_id, json_value, code_name, &rgba.value))
       return false;
-    *value = std::move(rgba);
+    *value = rgba;
     return true;
   }
   else if (type == "bool")

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomPipeline.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomPipeline.cpp
@@ -9,8 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/Assets/CustomAssetLibrary.h"
 
-void CustomPipeline::UpdatePixelData(std::shared_ptr<VideoCommon::CustomAssetLibrary>,
-                                     std::span<const u32>,
+void CustomPipeline::UpdatePixelData(const VideoCommon::CustomAssetLibrary*, std::span<const u32>,
                                      const VideoCommon::CustomAssetLibrary::AssetID&)
 {
 }

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomPipeline.h
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomPipeline.h
@@ -11,7 +11,7 @@
 
 struct CustomPipeline
 {
-  void UpdatePixelData(std::shared_ptr<VideoCommon::CustomAssetLibrary> library,
+  void UpdatePixelData(const VideoCommon::CustomAssetLibrary* library,
                        std::span<const u32> texture_units,
                        const VideoCommon::CustomAssetLibrary::AssetID& material_to_load);
 };

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomShaderCache.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/CustomShaderCache.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoCommon/GraphicsModSystem/Runtime/CustomShaderCache.h"
 
+#include <utility>
+
 #include "VideoCommon/AbstractGfx.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/VideoEvents.h"
@@ -100,11 +102,11 @@ void CustomShaderCache::AsyncCreatePipeline(const VideoCommon::GXPipelineUid& ui
   class PipelineWorkItem final : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    PipelineWorkItem(CustomShaderCache* shader_cache, const VideoCommon::GXPipelineUid& uid,
-                     const CustomShaderInstance& custom_shaders, PipelineIterator iterator,
-                     const AbstractPipelineConfig& pipeline_config)
-        : m_shader_cache(shader_cache), m_uid(uid), m_iterator(iterator), m_config(pipeline_config),
-          m_custom_shaders(custom_shaders)
+    PipelineWorkItem(CustomShaderCache* shader_cache, VideoCommon::GXPipelineUid uid,
+                     CustomShaderInstance custom_shaders, PipelineIterator iterator,
+                     AbstractPipelineConfig pipeline_config)
+        : m_shader_cache(shader_cache), m_uid(std::move(uid)), m_iterator(iterator),
+          m_config(std::move(pipeline_config)), m_custom_shaders(std::move(custom_shaders))
     {
       SetStagesReady();
     }
@@ -184,11 +186,11 @@ void CustomShaderCache::AsyncCreatePipeline(const VideoCommon::GXUberPipelineUid
   class PipelineWorkItem final : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    PipelineWorkItem(CustomShaderCache* shader_cache, const VideoCommon::GXUberPipelineUid& uid,
-                     const CustomShaderInstance& custom_shaders, UberPipelineIterator iterator,
-                     const AbstractPipelineConfig& pipeline_config)
-        : m_shader_cache(shader_cache), m_uid(uid), m_iterator(iterator), m_config(pipeline_config),
-          m_custom_shaders(custom_shaders)
+    PipelineWorkItem(CustomShaderCache* shader_cache, VideoCommon::GXUberPipelineUid uid,
+                     CustomShaderInstance custom_shaders, UberPipelineIterator iterator,
+                     AbstractPipelineConfig pipeline_config)
+        : m_shader_cache(shader_cache), m_uid(std::move(uid)), m_iterator(iterator),
+          m_config(std::move(pipeline_config)), m_custom_shaders(std::move(custom_shaders))
     {
       SetStagesReady();
     }
@@ -281,8 +283,9 @@ void CustomShaderCache::QueuePixelShaderCompile(const PixelShaderUid& uid,
   {
   public:
     PixelShaderWorkItem(CustomShaderCache* shader_cache, const PixelShaderUid& uid,
-                        const CustomShaderInstance& custom_shaders, PixelShaderIterator iter)
-        : m_shader_cache(shader_cache), m_uid(uid), m_custom_shaders(custom_shaders), m_iter(iter)
+                        CustomShaderInstance custom_shaders, PixelShaderIterator iter)
+        : m_shader_cache(shader_cache), m_uid(uid), m_custom_shaders(std::move(custom_shaders)),
+          m_iter(iter)
     {
     }
 
@@ -319,8 +322,9 @@ void CustomShaderCache::QueuePixelShaderCompile(const UberShader::PixelShaderUid
   {
   public:
     PixelShaderWorkItem(CustomShaderCache* shader_cache, const UberShader::PixelShaderUid& uid,
-                        const CustomShaderInstance& custom_shaders, UberPixelShaderIterator iter)
-        : m_shader_cache(shader_cache), m_uid(uid), m_custom_shaders(custom_shaders), m_iter(iter)
+                        CustomShaderInstance custom_shaders, UberPixelShaderIterator iter)
+        : m_shader_cache(shader_cache), m_uid(uid), m_custom_shaders(std::move(custom_shaders)),
+          m_iter(iter)
     {
     }
 

--- a/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
+++ b/Source/Core/VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.cpp
@@ -247,23 +247,22 @@ void GraphicsModManager::Load(const GraphicsModGroupConfig& config)
     }
   }
 
+  const auto create_action =
+      [filesystem_library = std::move(filesystem_library)](
+          const std::string_view& action_name, const picojson::value& json_data,
+          GraphicsModConfig mod_config) -> std::unique_ptr<GraphicsModAction> {
+    auto action = GraphicsModActionFactory::Create(action_name, json_data, filesystem_library);
+    if (action == nullptr)
+    {
+      return nullptr;
+    }
+    return std::make_unique<DecoratedAction>(std::move(action), std::move(mod_config));
+  };
+
   for (const auto& mod : mods)
   {
     for (const GraphicsModFeatureConfig& feature : mod.m_features)
     {
-      const auto create_action =
-          [filesystem_library](const std::string_view& action_name,
-                               const picojson::value& json_data,
-                               GraphicsModConfig mod_config) -> std::unique_ptr<GraphicsModAction> {
-        auto action =
-            GraphicsModActionFactory::Create(action_name, json_data, std::move(filesystem_library));
-        if (action == nullptr)
-        {
-          return nullptr;
-        }
-        return std::make_unique<DecoratedAction>(std::move(action), std::move(mod_config));
-      };
-
       const auto internal_group = fmt::format("{}.{}", mod.m_title, feature.m_group);
 
       const auto add_target = [&](const GraphicsTargetConfig& target) {

--- a/Source/Core/VideoCommon/NetPlayGolfUI.cpp
+++ b/Source/Core/VideoCommon/NetPlayGolfUI.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoCommon/NetPlayGolfUI.h"
 
+#include <utility>
+
 #include <fmt/format.h>
 #include <imgui.h>
 
@@ -13,8 +15,8 @@ constexpr float DEFAULT_WINDOW_HEIGHT = 45.0f;
 
 std::unique_ptr<NetPlayGolfUI> g_netplay_golf_ui;
 
-NetPlayGolfUI::NetPlayGolfUI(std::shared_ptr<NetPlay::NetPlayClient> netplay_client)
-    : m_netplay_client{netplay_client}
+NetPlayGolfUI::NetPlayGolfUI(std::weak_ptr<NetPlay::NetPlayClient> netplay_client)
+    : m_netplay_client{std::move(netplay_client)}
 {
 }
 

--- a/Source/Core/VideoCommon/NetPlayGolfUI.h
+++ b/Source/Core/VideoCommon/NetPlayGolfUI.h
@@ -13,7 +13,7 @@ class NetPlayClient;
 class NetPlayGolfUI
 {
 public:
-  explicit NetPlayGolfUI(std::shared_ptr<NetPlay::NetPlayClient> netplay_client);
+  explicit NetPlayGolfUI(std::weak_ptr<NetPlay::NetPlayClient> netplay_client);
   ~NetPlayGolfUI();
 
   void Display();

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -142,14 +142,14 @@ void AddTypedMessage(MessageType type, std::string message, u32 ms, u32 argb,
   for (auto it = range.first; it != range.second; ++it)
     it->second.should_discard = true;
 
-  s_messages.emplace(type, Message(std::move(message), ms, argb, std::move(icon)));
+  s_messages.emplace(type, Message(std::move(message), ms, argb, icon));
 }
 
 void AddMessage(std::string message, u32 ms, u32 argb,
                 const VideoCommon::CustomTextureData::ArraySlice::Level* icon)
 {
   std::lock_guard lock{s_messages_mutex};
-  s_messages.emplace(MessageType::Typeless, Message(std::move(message), ms, argb, std::move(icon)));
+  s_messages.emplace(MessageType::Typeless, Message(std::move(message), ms, argb, icon));
 }
 
 void DrawMessages()

--- a/Source/Core/VideoCommon/PerformanceTracker.cpp
+++ b/Source/Core/VideoCommon/PerformanceTracker.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <utility>
 
 #include <implot.h>
 
@@ -18,9 +19,9 @@ static constexpr double SAMPLE_RC_RATIO = 0.25;
 static constexpr u64 MAX_DT_QUEUE_SIZE = 1UL << 12;
 static constexpr u64 MAX_QUALITY_GRAPH_SIZE = 1UL << 8;
 
-PerformanceTracker::PerformanceTracker(const std::optional<std::string> log_name,
+PerformanceTracker::PerformanceTracker(std::optional<std::string> log_name,
                                        const std::optional<DT> sample_window_duration)
-    : m_log_name{log_name}, m_sample_window_duration{sample_window_duration}
+    : m_log_name{std::move(log_name)}, m_sample_window_duration{sample_window_duration}
 {
   Reset();
 }

--- a/Source/Core/VideoCommon/PerformanceTracker.h
+++ b/Source/Core/VideoCommon/PerformanceTracker.h
@@ -14,7 +14,7 @@
 class PerformanceTracker
 {
 public:
-  PerformanceTracker(const std::optional<std::string> log_name = std::nullopt,
+  PerformanceTracker(std::optional<std::string> log_name = std::nullopt,
                      const std::optional<DT> sample_window_duration = std::nullopt);
   ~PerformanceTracker() = default;
 

--- a/Source/Core/VideoCommon/Resources/MaterialResource.cpp
+++ b/Source/Core/VideoCommon/Resources/MaterialResource.cpp
@@ -62,8 +62,8 @@ MaterialResource::MaterialResource(Resource::ResourceContext resource_context)
 }
 
 MaterialResource::MaterialResource(Resource::ResourceContext resource_context,
-                                   const GXPipelineUid& pipeline_uid)
-    : Resource(std::move(resource_context)), m_uid(pipeline_uid)
+                                   GXPipelineUid pipeline_uid)
+    : Resource(std::move(resource_context)), m_uid(std::move(pipeline_uid))
 {
   m_material_asset = m_resource_context.asset_cache->CreateAsset<MaterialAsset>(
       m_resource_context.primary_asset_id, m_resource_context.asset_library, this);
@@ -221,7 +221,7 @@ Resource::TaskComplete MaterialResource::ProcessData()
              VideoCommon::GXPipelineUid* uid, FramebufferState frame_buffer_state)
         : m_material_resource_data(std::move(material_resource_data)),
           m_shader_resource_data(std::move(shader_resource_data)), m_uid(uid),
-          m_frame_buffer_state(frame_buffer_state)
+          m_frame_buffer_state(std::move(frame_buffer_state))
     {
     }
 

--- a/Source/Core/VideoCommon/Resources/MaterialResource.h
+++ b/Source/Core/VideoCommon/Resources/MaterialResource.h
@@ -29,7 +29,7 @@ class MaterialResource final : public Resource
 {
 public:
   explicit MaterialResource(Resource::ResourceContext resource_context);
-  MaterialResource(Resource::ResourceContext resource_context, const GXPipelineUid& pipeline_uid);
+  MaterialResource(Resource::ResourceContext resource_context, GXPipelineUid pipeline_uid);
 
   struct TextureLikeReference
   {

--- a/Source/Core/VideoCommon/Resources/ShaderResource.cpp
+++ b/Source/Core/VideoCommon/Resources/ShaderResource.cpp
@@ -4,6 +4,7 @@
 #include "VideoCommon/Resources/ShaderResource.h"
 
 #include <string_view>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -382,11 +383,11 @@ CompileVertexShader(VertexShaderUid* uid, std::string_view preprocessor_settings
 }
 }  // namespace
 ShaderResource::ShaderResource(Resource::ResourceContext resource_context,
-                               const std::optional<GXPipelineUid>& pipeline_uid,
-                               const std::string& preprocessor_setting,
+                               std::optional<GXPipelineUid> pipeline_uid,
+                               std::string preprocessor_setting,
                                const ShaderHostConfig& shader_host_config)
     : Resource(std::move(resource_context)), m_shader_host_config{.bits = shader_host_config.bits},
-      m_uid(pipeline_uid), m_preprocessor_settings(preprocessor_setting)
+      m_uid(std::move(pipeline_uid)), m_preprocessor_settings(std::move(preprocessor_setting))
 {
   m_shader_asset = m_resource_context.asset_cache->CreateAsset<RasterSurfaceShaderAsset>(
       m_resource_context.primary_asset_id, m_resource_context.asset_library, this);

--- a/Source/Core/VideoCommon/Resources/ShaderResource.h
+++ b/Source/Core/VideoCommon/Resources/ShaderResource.h
@@ -18,8 +18,7 @@ class ShaderResource final : public Resource
 {
 public:
   ShaderResource(Resource::ResourceContext resource_context,
-                 const std::optional<GXPipelineUid>& pipeline_uid,
-                 const std::string& preprocessor_settings,
+                 std::optional<GXPipelineUid> pipeline_uid, std::string preprocessor_setting,
                  const ShaderHostConfig& shader_host_config);
 
   class Data

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoCommon/ShaderCache.h"
 
+#include <utility>
+
 #include <fmt/format.h>
 
 #include "Common/Assert.h"
@@ -1018,8 +1020,8 @@ void ShaderCache::QueuePipelineCompile(const GXPipelineUid& uid, u32 priority)
   class PipelineWorkItem final : public AsyncShaderCompiler::WorkItem
   {
   public:
-    PipelineWorkItem(ShaderCache* shader_cache_, const GXPipelineUid& uid_, u32 priority_)
-        : shader_cache(shader_cache_), uid(uid_), priority(priority_)
+    PipelineWorkItem(ShaderCache* shader_cache_, GXPipelineUid uid_, u32 priority_)
+        : shader_cache(shader_cache_), uid(std::move(uid_)), priority(priority_)
     {
       // Check if all the stages required for this pipeline have been compiled.
       // If not, this work item becomes a no-op, and re-queues the pipeline for the next frame.
@@ -1090,8 +1092,8 @@ void ShaderCache::QueueUberPipelineCompile(const GXUberPipelineUid& uid, u32 pri
   class UberPipelineWorkItem final : public AsyncShaderCompiler::WorkItem
   {
   public:
-    UberPipelineWorkItem(ShaderCache* shader_cache_, const GXUberPipelineUid& uid_, u32 priority_)
-        : shader_cache(shader_cache_), uid(uid_), priority(priority_)
+    UberPipelineWorkItem(ShaderCache* shader_cache_, GXUberPipelineUid uid_, u32 priority_)
+        : shader_cache(shader_cache_), uid(std::move(uid_)), priority(priority_)
     {
       // Check if all the stages required for this UberPipeline have been compiled.
       // If not, this work item becomes a no-op, and re-queues the UberPipeline for the next frame.

--- a/Source/Core/VideoCommon/ShaderCompileUtils.cpp
+++ b/Source/Core/VideoCommon/ShaderCompileUtils.cpp
@@ -4,14 +4,15 @@
 #include "VideoCommon/ShaderCompileUtils.h"
 
 #include <ranges>
+#include <utility>
 
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
 namespace VideoCommon
 {
-ShaderIncluder::ShaderIncluder(const std::string& user_path, const std::string& system_path)
-    : m_root_user_path(user_path), m_root_system_path(system_path)
+ShaderIncluder::ShaderIncluder(std::string user_path, std::string system_path)
+    : m_root_user_path(std::move(user_path)), m_root_system_path(std::move(system_path))
 {
 }
 

--- a/Source/Core/VideoCommon/ShaderCompileUtils.h
+++ b/Source/Core/VideoCommon/ShaderCompileUtils.h
@@ -15,7 +15,7 @@ namespace VideoCommon
 class ShaderIncluder final : public glslang::TShader::Includer
 {
 public:
-  ShaderIncluder(const std::string& user_path, const std::string& system_path);
+  ShaderIncluder(std::string user_path, std::string system_path);
   ~ShaderIncluder() override = default;
 
   std::vector<std::string> GetIncludes() const;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -657,7 +657,7 @@ void TextureCacheBase::DoSaveState(PointerWrap& p)
     }
   }
 
-  auto doList = [&p](auto list) {
+  auto doList = [&p](const auto& list) {
     u32 list_size = static_cast<u32>(list.size());
     p.Do(list_size);
     for (const auto& it : list)

--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -191,7 +191,7 @@ protected:
     ResetCodeBuffer();
   }
 
-  void ExpectBytes(const std::vector<u8> expected_bytes)
+  void ExpectBytes(const std::vector<u8>& expected_bytes)
   {
     const std::vector code_bytes(code_buffer, emitter->GetWritableCodePtr());
 


### PR DESCRIPTION
Accomplished using `run-clang-tidy` with `performance-move-const-arg,performance-unnecessary-value-param,modernize-pass-by-value`.

Changed arguments to const references, removed them where inappropriate (e.g. sink parameters). Same with std::move.

Manually reviewed each change to make sure that it makes sense, and do something more appropriate if possible.