### PR TITLE
Mixer: Fix WAV file dumping.

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -214,10 +214,11 @@ void Mixer::PushSamples(const s16* samples, std::size_t num_samples)
   {
     // Big-endian RL-orderered stereo samples.
 
-    while (num_samples--)
+    const s16* ptr = samples;
+    for (std::size_t i = 0; i != num_samples; ++i)
     {
-      m_dma_mixer.PushSample(Common::swap16(samples[1]), Common::swap16(samples[0]));
-      samples += 2;
+      m_dma_mixer.PushSample(Common::swap16(ptr[1]), Common::swap16(ptr[0]));
+      ptr += 2;
     }
   }
 
@@ -236,10 +237,11 @@ void Mixer::PushStreamingSamples(const s16* samples, std::size_t num_samples)
   {
     // Big-endian RL-orderered stereo samples.
 
-    while (num_samples--)
+    const s16* ptr = samples;
+    for (std::size_t i = 0; i != num_samples; ++i)
     {
-      m_streaming_mixer.PushSample(Common::swap16(samples[1]), Common::swap16(samples[0]));
-      samples += 2;
+      m_streaming_mixer.PushSample(Common::swap16(ptr[1]), Common::swap16(ptr[0]));
+      ptr += 2;
     }
   }
 


### PR DESCRIPTION
I broke this in #14528.

It slipped my mind that the later `AddStereoSamplesBE` calls need to use `samples` and `num_samples`.