### PR TITLE
GameINI: Add Simple Multiplayer Camera code to Tales of Symphonia (JP)

### DIFF
--- a/Data/Sys/GameSettings/GTOJAF.ini
+++ b/Data/Sys/GameSettings/GTOJAF.ini
@@ -23,6 +23,8 @@ E0000000 80008000
 *Partial port of Multiplayer Camera v3 by dcx2
 *[https://wiird.gamehacking.org/forum/index.php/topic,8455.msg73593.html#msg73593]
 *
+*Keeps camera zoomed out during battles to ensure all party members are visible.
+*
 *Ported by frugs
 
 [Gecko_RetroAchievements_Verified]

--- a/Data/Sys/GameSettings/GTOJAF.ini
+++ b/Data/Sys/GameSettings/GTOJAF.ini
@@ -11,5 +11,19 @@ $Remove Blur
 04023828 4E800020
 0403EBE4 4E800020
 
+$Simple Multiplayer Camera [frugs]
+F320EB58 70C5FD02
+38000010 3D808000
+900C1844 00000000
+22001844 00000000
+0520EF68 38000010
+0520F298 38000010
+E0000000 80008000
+8000000F 00000000
+*Partial port of Multiplayer Camera v3 by dcx2
+*[https://wiird.gamehacking.org/forum/index.php/topic,8455.msg73593.html#msg73593]
+*
+*Ported by frugs
+
 [Gecko_RetroAchievements_Verified]
 $Remove Blur


### PR DESCRIPTION
Added partial port of dcx2's Multiplayer Camera v3 for Tales of Symphonia (US) to game INI for Tales of Symphonia (JP).