### PR TITLE
GameSettings: Don't force immediate XFB off in Ultimate Spider-Man.

### DIFF
--- a/Data/Sys/GameSettings/GUT.ini
+++ b/Data/Sys/GameSettings/GUT.ini
@@ -1,17 +1,7 @@
 # GUTD52, GUTE52, GUTF52, GUTI52, GUTJC0, GUTP52, GUTS52 - Ultimate Spider-Man
 
 [Core]
-# Values set here will override the main Dolphin settings.
 MMU = True
 
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
 [Video_Hacks]
-ImmediateXFBEnable = False
 BBoxEnable = True
-
-[Video_Settings]


### PR DESCRIPTION
This game seems to work fine with Immediate XFB for me even prior to #14512.

Unless someone knows of a particular thing in the game that breaks I think it works with immediate XFB?