### PR TITLE
GameSettings: Set safe texture cache accuracy for Game Boy Player

### DIFF
--- a/Data/Sys/GameSettings/UGP.ini
+++ b/Data/Sys/GameSettings/UGP.ini
@@ -8,5 +8,5 @@ Overclock = 1.25
 OverclockEnable = True
 
 [Video_Settings]
-# Fixes old frames being shown when a game updates the center/bottom of the screen without updating the top.
-SafeTextureCacheColorSamples = 2048
+# Fixes old frames being shown when a game only updates a small part of the screen. Examples include gradually revealed text and the HP bars in Pokémon.
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
For the HP bars in games like Pokémon Emerald, not even 2048 is enough. Let's go all the way to Safe.