### PR TITLE
GameSettings: Disable fast depth calc to fix missing text and allow immediate XFB in Def Jam: Fight for NY.

### DIFF
--- a/Data/Sys/GameSettings/GNW.ini
+++ b/Data/Sys/GameSettings/GNW.ini
@@ -1,10 +1,5 @@
-# GNWE69, GNWP69 - Def Jam Fight For NY
+# GNWE69, GNWP69 - Def Jam: Fight for NY
 
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
+[Video_Settings]
+# Avoids missing text in menus.
+FastDepthCalc = False


### PR DESCRIPTION
This game seems fine with immediate XFB.

Menus are unusable without `FastDepthCalc = False`.