### PR TITLE
WIP: Add HDR rendering (and tonemapping)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ CMakeLists.txt.user
 /.vscode/
 # Ignore flatpak-builder's cache dir
 .flatpak-builder
+*.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,3 @@ CMakeLists.txt.user
 /.vscode/
 # Ignore flatpak-builder's cache dir
 .flatpak-builder
-*.vcxproj

--- a/Data/Sys/Shaders/AutoHDR.glsl
+++ b/Data/Sys/Shaders/AutoHDR.glsl
@@ -60,9 +60,12 @@ void main()
 
 	// Then calculate it again but with "per channel", which would expand gamut (not hue conservative)
 	float3 sdr_ratio_3 = color.rgb;
-	float3 auto_hdr_extra_ratio_3 = pow(clamp(sdr_ratio_3, 0.0, 1.0), AUTO_HDR_SHOULDER_POW) * (auto_hdr_max_white - 1.f);
-	float3 auto_hdr_total_ratio_3 = sdr_ratio_3 + auto_hdr_extra_ratio_3;
-	float3 per_channel_color_scale = (sdr_ratio_3 > 0.0) ? (auto_hdr_total_ratio_3 / sdr_ratio_3) : 1.0;
+	const float3 auto_hdr_extra_ratio_3 = pow(clamp(sdr_ratio_3, float3(0.0, 0.0, 0.0), float3(1.0, 1.0, 1.0)),
+																						float3(AUTO_HDR_SHOULDER_POW, AUTO_HDR_SHOULDER_POW, AUTO_HDR_SHOULDER_POW)) * (auto_hdr_max_white - 1.0);
+	const float3 auto_hdr_total_ratio_3 = sdr_ratio_3 + auto_hdr_extra_ratio_3;
+	float3 per_channel_color_scale = float3((sdr_ratio_3.r > 0.0) ? (auto_hdr_total_ratio_3.r / sdr_ratio_3.r) : 1.0,
+																					(sdr_ratio_3.g > 0.0) ? (auto_hdr_total_ratio_3.g / sdr_ratio_3.g) : 1.0,
+																					(sdr_ratio_3.b > 0.0) ? (auto_hdr_total_ratio_3.b / sdr_ratio_3.b) : 1.0);
 
 	color.rgb *= lerp(single_color_scale.xxx, per_channel_color_scale, AUTO_HDR_SATURATION_EXPANSION.xxx);
 

--- a/Data/Sys/Shaders/AutoHDR.glsl
+++ b/Data/Sys/Shaders/AutoHDR.glsl
@@ -4,20 +4,12 @@
 [configuration]
 
 [OptionRangeFloat]
-GUIName = HDR Display Max Nits
-OptionName = HDR_DISPLAY_MAX_NITS
+GUIName = HDR Peak White Nits
+OptionName = HDR_PEAK_WHITE_NITS
 MinValue = 80
-MaxValue = 2000
+MaxValue = 1000
 StepAmount = 1
 DefaultValue = 400
-
-[OptionRangeFloat]
-GUIName = Shoulder Start Alpha
-OptionName = AUTO_HDR_SHOULDER_START_ALPHA
-MinValue = 0
-MaxValue = 1
-StepAmount = 0.01
-DefaultValue = 0
 
 [OptionRangeFloat]
 GUIName = Shoulder Pow
@@ -26,6 +18,14 @@ MinValue = 1
 MaxValue = 10
 StepAmount = 0.05
 DefaultValue = 2.5
+
+[OptionRangeFloat]
+GUIName = Saturation Expansion
+OptionName = AUTO_HDR_SATURATION_EXPANSION
+MinValue = 0
+MaxValue = 1
+StepAmount = 0.01
+DefaultValue = 0.2
 
 [/configuration]
 */
@@ -47,21 +47,24 @@ void main()
 	}
 
 	const float hdr_paper_white = hdr_paper_white_nits / hdr_sdr_white_nits;
+	const float auto_hdr_max_white = clamp(HDR_PEAK_WHITE_NITS / hdr_paper_white, hdr_sdr_white_nits, peak_white_nits / hdr_paper_white) / hdr_sdr_white_nits;
 
 	// Restore the original SDR (0-1) brightness (we might or might not restore it later)
 	color.rgb /= hdr_paper_white;
 
-	// Find the color luminance (it works better than average)
+	// First do the HDR extrapolation on luminance (hue conservative)
 	float sdr_ratio = luminance(color.rgb);
+	const float auto_hdr_extra_ratio = pow(clamp(sdr_ratio, 0.0, 1.0), AUTO_HDR_SHOULDER_POW) * (auto_hdr_max_white - 1.0);
+	const float auto_hdr_total_ratio = sdr_ratio + auto_hdr_extra_ratio;
+	float single_color_scale = (sdr_ratio > 0.0) ? (auto_hdr_total_ratio / sdr_ratio) : 1.0;
 
-	const float auto_hdr_max_white = max(HDR_DISPLAY_MAX_NITS / (hdr_paper_white_nits / hdr_sdr_white_nits), hdr_sdr_white_nits) / hdr_sdr_white_nits;
-	if (sdr_ratio > AUTO_HDR_SHOULDER_START_ALPHA && AUTO_HDR_SHOULDER_START_ALPHA < 1.0)
-	{
-		const float auto_hdr_shoulder_ratio = 1.0 - (max(1.0 - sdr_ratio, 0.0) / (1.0 - AUTO_HDR_SHOULDER_START_ALPHA));
-		const float auto_hdr_extra_ratio = pow(auto_hdr_shoulder_ratio, AUTO_HDR_SHOULDER_POW) * (auto_hdr_max_white - 1.0);
-		const float auto_hdr_total_ratio = sdr_ratio + auto_hdr_extra_ratio;
-		color.rgb *= auto_hdr_total_ratio / sdr_ratio;
-	}
+	// Then calculate it again but with "per channel", which would expand gamut (not hue conservative)
+	float3 sdr_ratio_3 = color.rgb;
+	float3 auto_hdr_extra_ratio_3 = pow(clamp(sdr_ratio_3, 0.0, 1.0), AUTO_HDR_SHOULDER_POW) * (auto_hdr_max_white - 1.f);
+	float3 auto_hdr_total_ratio_3 = sdr_ratio_3 + auto_hdr_extra_ratio_3;
+	float3 per_channel_color_scale = (sdr_ratio_3 > 0.0) ? (auto_hdr_total_ratio_3 / sdr_ratio_3) : 1.0;
+
+	color.rgb *= lerp(single_color_scale.xxx, per_channel_color_scale, AUTO_HDR_SATURATION_EXPANSION.xxx);
 
 	color.rgb *= hdr_paper_white;
 

--- a/Data/Sys/Shaders/default_pre_post_process.glsl
+++ b/Data/Sys/Shaders/default_pre_post_process.glsl
@@ -462,7 +462,7 @@ void main()
 		float color_luminance = Luminance(color.rgb, true);
 		float sdr_color_luminance = Luminance(sdr_color.rgb, true);
 
-		const float sdr_hue_restoration = 0.5; // TODO: use Oklab, and maybe expose as part of the HDR/color correction settings
+		const float sdr_hue_restoration = 0.5;  // TODO: use Oklab, and maybe expose as part of the HDR/color correction settings
 		if (sdr_color_luminance > 0.0)
 			color.rgb = lerp(color.rgb, (sdr_color.rgb / sdr_color_luminance) * color_luminance, sdr_hue_restoration);
 	}
@@ -490,7 +490,7 @@ void main()
 
 		// Start compressing highlights from a high value in linear, to avoid too much of the SDR range from dimming down.
 		// We do it by channel, which should retain a look similar to the original clipped rendering.
-		const float shoulder_start = 0.75; // TODO: maybe expose as part of the HDR/color correction settings
+		const float shoulder_start = 0.75;  // TODO: maybe expose as part of the HDR/color correction settings
 		color.rgb = ReinhardRanged(color.rgb, shoulder_start, peak_white);
 	}
 

--- a/Data/Sys/Shaders/default_pre_post_process.glsl
+++ b/Data/Sys/Shaders/default_pre_post_process.glsl
@@ -4,22 +4,22 @@
 // https://www.unravel.com.au/understanding-color-spaces
 
 // SMPTE 170M - BT.601 (NTSC-M) -> BT.709
-mat3 from_NTSCM = transpose(mat3(
+mat3 from_NTSCM = mat3(
 	0.939497225737661,		0.0502268452914346,		0.0102759289709032,
 	0.0177558637510127,		0.965824605885027,		0.0164195303639603,
-	-0.00162163209967010,	-0.00437400622653655,	1.00599563832621));
+	-0.00162163209967010,	-0.00437400622653655,	1.00599563832621);
 
 // ARIB TR-B9 (9300K+27MPCD with chromatic adaptation) (NTSC-J) -> BT.709
-mat3 from_NTSCJ = transpose(mat3(
+mat3 from_NTSCJ = mat3(
 	0.768497526,		-0.210804164,	  0.000297427177,
 	0.0397904068,		1.04825413,			0.00555809540,
-	0.00147510506,	0.0328789241,		1.36515128));
+	0.00147510506,	0.0328789241,		1.36515128);
 
 // EBU - BT.470BG/BT.601 (PAL) -> BT.709
-mat3 from_PAL = transpose(mat3(
+mat3 from_PAL = mat3(
 	1.04408168421813,		-0.0440816842181253,	0.000000000000000,
 	0.000000000000000,	1.00000000000000,			0.000000000000000,
-	0.000000000000000,	0.0118044782106489,		0.988195521789351));
+	0.000000000000000,	0.0118044782106489,		0.988195521789351);
 
 float3 LinearTosRGBGamma(float3 color)
 {
@@ -500,7 +500,7 @@ void main()
 		color.rgb *= hdr_paper_white;
 	}
 	
-	// Do gamut mapping to make sure all colors are within the BT.709 gamut.
+	// Do simple gamut mapping to make sure all colors are within the BT.709 gamut.
 	// HDR doesn't need it as all the color spaces above are within BT.2020.
 	if (OptionEnabled(correct_color_space) && !OptionEnabled(hdr_output))
 	{

--- a/Data/Sys/Shaders/default_pre_post_process.glsl
+++ b/Data/Sys/Shaders/default_pre_post_process.glsl
@@ -54,6 +54,21 @@ float Luminance(float3 color, bool native_color_space)
 	return dot(color, Rec709_Luminance);
 }
 
+/***** TONEMAPPING *****/
+
+// Reinhard highlight compression that is identity up to shoulder_start, then smoothly compresses toward out_peak (never exceeding it).
+// Continuous at shoulder_start.
+// 
+// Assumes inputs are in [0..+INF) (negative values pass through unchanged below).
+// Assumes out_peak > shoulder_start.
+float3 ReinhardRanged(float3 color, float shoulder_start, float out_peak)
+{
+  const float out_range = out_peak - shoulder_start;
+  const float3 color_below_shoulder_start = min(color, shoulder_start);
+  const float3 color_beyond_shoulder_start = color - color_below_shoulder_start;
+  return color_below_shoulder_start + ((color_beyond_shoulder_start / (color_beyond_shoulder_start + out_range)) * out_range);
+}
+
 /***** COLOR SAMPLING *****/
 
 // Non filtered gamma corrected sample (nearest neighbor)
@@ -438,6 +453,20 @@ void main()
 		color.rgb = pow(color.rgb, float3(game_gamma));
 	}
 
+	// Given that colors were never meant to be HDR (go beyond 1 in float) on the original hardware,
+	// restore part of the clipped hue, otherwise some highlights can end up having a different "color".
+	// This needs to be done before color correction, in the original color space.
+	if (OptionEnabled(hdr_render))
+	{
+		float3 sdr_color = clamp(color.rgb, 0.0, 1.0);
+		float color_luminance = Luminance(color.rgb, true);
+		float sdr_color_luminance = Luminance(sdr_color.rgb, true);
+
+		const float sdr_hue_restoration = 0.5; // TODO: use Oklab
+		if (sdr_color_luminance > 0.0)
+			color.rgb = lerp(color.rgb, (sdr_color.rgb / sdr_color_luminance) * color_luminance, sdr_hue_restoration);
+	}
+
 	if (OptionEnabled(correct_color_space))
 	{
 		if (game_color_space == 0)
@@ -448,10 +477,48 @@ void main()
 			color.rgb = color.rgb * from_PAL;
 	}
 
+	// Do tonemapping if we rendered in HDR. The peak brightness is adjusted for SDR (1) and HDR (display dependent)
+	if (OptionEnabled(hdr_render))
+	{
+		float paper_white_nits = hdr_sdr_white_nits;
+		if (OptionEnabled(hdr_output))
+		{
+			paper_white_nits = hdr_paper_white_nits;
+		}
+		// This will be 1 in SDR
+		float peak_white = peak_white_nits / paper_white_nits;
+
+		// Start compressing highlights from a high value in linear, to avoid too much of the SDR range from dimming down
+		const float shoulder_start = 0.75;
+		color.rgb = ReinhardRanged(color.rgb, shoulder_start, peak_white);
+	}
+
 	if (OptionEnabled(hdr_output))
 	{
 		float hdr_paper_white = hdr_paper_white_nits / hdr_sdr_white_nits;
 		color.rgb *= hdr_paper_white;
+	}
+	
+	// Do gamut mapping to make sure all colors are within the BT.709 gamut.
+	// HDR doesn't need it as all the color spaces above are within BT.2020.
+	if (OptionEnabled(correct_color_space) && !OptionEnabled(hdr_output))
+	{
+		float color_luminance = Luminance(color.rgb, false);
+
+		float min_channel = min(color.r, min(color.g, color.b));
+		// Desaturate (move towards luminance/grayscale) until we are not out of gamut anymore (until no channel is below 0)
+		if (min_channel < 0.0 && color_luminance >= 0.0)
+		{
+			// Both division elements are meant to be negative so the ratio resolves to a positive value
+			float desaturate_alpha = (min_channel - color_luminance) != 0.0 ? (min_channel / (min_channel - color_luminance)) : 0.0;
+			color.rgb = lerp(color.rgb, color_luminance.xxx, desaturate_alpha.xxx);
+		}
+		float max_channel = max(color.r, max(color.g, color.b));
+		// Divide by the max channel if it's out of range, so nothing clips
+		if (max_channel > 1.0)
+		{
+			color.rgb /= max_channel;
+		}
 	}
 
 	if (OptionEnabled(linear_space_output))

--- a/Data/Sys/Shaders/default_pre_post_process.glsl
+++ b/Data/Sys/Shaders/default_pre_post_process.glsl
@@ -462,7 +462,7 @@ void main()
 		float color_luminance = Luminance(color.rgb, true);
 		float sdr_color_luminance = Luminance(sdr_color.rgb, true);
 
-		const float sdr_hue_restoration = 0.5; // TODO: use Oklab
+		const float sdr_hue_restoration = 0.5; // TODO: use Oklab, and maybe expose as part of the HDR/color correction settings
 		if (sdr_color_luminance > 0.0)
 			color.rgb = lerp(color.rgb, (sdr_color.rgb / sdr_color_luminance) * color_luminance, sdr_hue_restoration);
 	}
@@ -485,11 +485,12 @@ void main()
 		{
 			paper_white_nits = hdr_paper_white_nits;
 		}
-		// This will be 1 in SDR
+		// This will be 1 in SDR. In HDR it's relative to paper white, as it's multiplied in later.
 		float peak_white = peak_white_nits / paper_white_nits;
 
-		// Start compressing highlights from a high value in linear, to avoid too much of the SDR range from dimming down
-		const float shoulder_start = 0.75;
+		// Start compressing highlights from a high value in linear, to avoid too much of the SDR range from dimming down.
+		// We do it by channel, which should retain a look similar to the original clipped rendering.
+		const float shoulder_start = 0.75; // TODO: maybe expose as part of the HDR/color correction settings
 		color.rgb = ReinhardRanged(color.rgb, shoulder_start, peak_white);
 	}
 

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -148,6 +148,7 @@ const Info<bool> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION{
     {System::GFX, "Enhancements", "ArbitraryMipmapDetection"}, false};
 const Info<float> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD{
     {System::GFX, "Enhancements", "ArbitraryMipmapDetectionThreshold"}, 14.0f};
+const Info<bool> GFX_ENHANCE_HDR_RENDER{{System::GFX, "Enhancements", "HDRRender"}, false};
 const Info<bool> GFX_ENHANCE_HDR_OUTPUT{{System::GFX, "Enhancements", "HDROutput"}, false};
 
 // Color.Correction

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -120,6 +120,7 @@ extern const Info<bool> GFX_ENHANCE_FORCE_TRUE_COLOR;
 extern const Info<bool> GFX_ENHANCE_DISABLE_COPY_FILTER;
 extern const Info<bool> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION;
 extern const Info<float> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD;
+extern const Info<bool> GFX_ENHANCE_HDR_RENDER;
 extern const Info<bool> GFX_ENHANCE_HDR_OUTPUT;
 
 // Color.Correction

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -113,6 +113,7 @@ public:
       layer->Set(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING, m_settings.force_texture_filtering);
       layer->Set(Config::GFX_ENHANCE_MAX_ANISOTROPY, m_settings.max_anisotropy);
       layer->Set(Config::GFX_ENHANCE_FORCE_TRUE_COLOR, m_settings.force_true_color);
+      layer->Set(Config::GFX_ENHANCE_HDR_RENDER, m_settings.hdr_render);
       layer->Set(Config::GFX_ENHANCE_DISABLE_COPY_FILTER, m_settings.disable_copy_filter);
       layer->Set(Config::GFX_DISABLE_FOG, m_settings.disable_fog);
       layer->Set(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION,

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -393,6 +393,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-stereo-mode", static_cast<int>(Config::Get(Config::GFX_STEREO_MODE)));
   builder.AddData("cfg-gfx-stereo-per-eye-resolution-full",
                   Config::Get(Config::GFX_STEREO_PER_EYE_RESOLUTION_FULL));
+  builder.AddData("cfg-gfx-hdr-render", Config::Get(Config::GFX_ENHANCE_HDR_RENDER));
   // Note: An int for some reason. Keeping as-is to not break analytics history.
   builder.AddData("cfg-gfx-hdr", static_cast<int>(Config::Get(Config::GFX_ENHANCE_HDR_OUTPUT)));
   builder.AddData("cfg-gfx-per-pixel-lighting", Config::Get(Config::GFX_ENABLE_PIXEL_LIGHTING));

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -901,6 +901,7 @@ void NetPlayClient::OnStartGame(sf::Packet& packet)
     packet >> m_net_settings.force_texture_filtering;
     packet >> m_net_settings.max_anisotropy;
     packet >> m_net_settings.force_true_color;
+    packet >> m_net_settings.hdr_render;
     packet >> m_net_settings.disable_copy_filter;
     packet >> m_net_settings.disable_fog;
     packet >> m_net_settings.arbitrary_mipmap_detection;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -89,6 +89,7 @@ struct NetSettings
   TextureFilteringMode force_texture_filtering = TextureFilteringMode::Default;
   AnisotropicFilteringMode max_anisotropy = AnisotropicFilteringMode::Default;
   bool force_true_color = false;
+  bool hdr_render = false;
   bool disable_copy_filter = false;
   bool disable_fog = false;
   bool arbitrary_mipmap_detection = false;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1442,6 +1442,7 @@ bool NetPlayServer::SetupNetSettings()
   settings.force_texture_filtering = Config::Get(Config::GFX_ENHANCE_FORCE_TEXTURE_FILTERING);
   settings.max_anisotropy = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
   settings.force_true_color = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
+  settings.hdr_render = Config::Get(Config::GFX_ENHANCE_HDR_RENDER);
   settings.disable_copy_filter = Config::Get(Config::GFX_ENHANCE_DISABLE_COPY_FILTER);
   settings.disable_fog = Config::Get(Config::GFX_DISABLE_FOG);
   settings.arbitrary_mipmap_detection = Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
@@ -1651,6 +1652,7 @@ bool NetPlayServer::StartGame()
   spac << m_settings.force_texture_filtering;
   spac << m_settings.max_anisotropy;
   spac << m_settings.force_true_color;
+  spac << m_settings.hdr_render;
   spac << m_settings.disable_copy_filter;
   spac << m_settings.disable_fog;
   spac << m_settings.arbitrary_mipmap_detection;

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -163,7 +163,8 @@ void EnhancementsWidget::CreateWidgets()
       new ConfigBool(tr("Arbitrary Mipmap Detection"),
                      Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION, m_game_layer);
   m_arbitrary_mipmap_detection->setEnabled(!ReadSetting(Config::GFX_ENABLE_GPU_TEXTURE_DECODING));
-  m_hdr = new ConfigBool(tr("HDR Post-Processing"), Config::GFX_ENHANCE_HDR_OUTPUT, m_game_layer);
+  m_hdr_render = new ConfigBool(tr("HDR Rendering"), Config::GFX_ENHANCE_HDR_RENDER, m_game_layer);
+  m_hdr_output = new ConfigBool(tr("HDR Post-Processing"), Config::GFX_ENHANCE_HDR_OUTPUT, m_game_layer);
 
   int row = 0;
   enhancements_layout->addWidget(new QLabel(tr("Internal Resolution:")), row, 0);
@@ -182,6 +183,11 @@ void EnhancementsWidget::CreateWidgets()
   enhancements_layout->addWidget(m_output_resampling_combo, row, 1, 1, -1);
   ++row;
 
+  enhancements_layout->addWidget(new QLabel(tr("Rendering Quality:")), row, 0);
+  enhancements_layout->addWidget(m_force_24bit_color, row, 1);
+  enhancements_layout->addWidget(m_hdr_render, row, 2);
+  ++row;
+
   enhancements_layout->addWidget(new QLabel(tr("Color Correction:")), row, 0);
   enhancements_layout->addWidget(m_configure_color_correction, row, 1, 1, -1);
   ++row;
@@ -196,7 +202,6 @@ void EnhancementsWidget::CreateWidgets()
   ++row;
 
   enhancements_layout->addWidget(m_widescreen_hack, row, 0);
-  enhancements_layout->addWidget(m_force_24bit_color, row, 1, 1, -1);
   ++row;
 
   enhancements_layout->addWidget(m_disable_fog, row, 0);
@@ -204,7 +209,7 @@ void EnhancementsWidget::CreateWidgets()
   ++row;
 
   enhancements_layout->addWidget(m_disable_copy_filter, row, 0);
-  enhancements_layout->addWidget(m_hdr, row, 1, 1, -1);
+  enhancements_layout->addWidget(m_hdr_output, row, 1, 1, -1);
   ++row;
 
   // Stereoscopy
@@ -349,7 +354,7 @@ void EnhancementsWidget::OnBackendChanged()
 {
   m_output_resampling_combo->setEnabled(g_backend_info.bSupportsPostProcessing);
   m_configure_color_correction->setEnabled(g_backend_info.bSupportsPostProcessing);
-  m_hdr->setEnabled(g_backend_info.bSupportsHDROutput);
+  m_hdr_output->setEnabled(g_backend_info.bSupportsHDROutput);
 
   // Stereoscopy
   const bool supports_stereoscopy = g_backend_info.bSupportsGeometryShaders;
@@ -573,7 +578,11 @@ void EnhancementsWidget::AddDescriptions()
       "reduce stutter in games that frequently load new textures.<br><br>This setting is disabled "
       "when GPU Texture Decoding is enabled.<br><br><dolphin_emphasis>If unsure, leave this "
       "unchecked.</dolphin_emphasis>");
-  static const char TR_HDR_DESCRIPTION[] = QT_TR_NOOP(
+  static const char TR_HDR_RENDER_DESCRIPTION[] = QT_TR_NOOP(
+      "Forces rendering to run with higher bit depth float (HDR) textures, floating point math,\n"
+      "and a wider range.<br><br><dolphin_emphasis>If unsure, leave "
+      "this unchecked.</dolphin_emphasis>");
+  static const char TR_HDR_OUTPUT_DESCRIPTION[] = QT_TR_NOOP(
       "Enables scRGB HDR output (if supported by your graphics backend and monitor)."
       " Fullscreen might be required."
       "<br><br>This gives post process shaders more room for accuracy, allows \"AutoHDR\" "
@@ -613,7 +622,9 @@ void EnhancementsWidget::AddDescriptions()
 
   m_arbitrary_mipmap_detection->SetDescription(tr(TR_ARBITRARY_MIPMAP_DETECTION_DESCRIPTION));
 
-  m_hdr->SetDescription(tr(TR_HDR_DESCRIPTION));
+  m_hdr_render->SetDescription(tr(TR_HDR_RENDER_DESCRIPTION));
+
+  m_hdr_output->SetDescription(tr(TR_HDR_OUTPUT_DESCRIPTION));
 
   m_3d_mode->SetTitle(tr("Stereoscopic 3D Mode"));
   m_3d_mode->SetDescription(tr(TR_3D_MODE_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -585,9 +585,9 @@ void EnhancementsWidget::AddDescriptions()
   static const char TR_HDR_OUTPUT_DESCRIPTION[] = QT_TR_NOOP(
       "Enables scRGB HDR output (if supported by your graphics backend and monitor)."
       " Fullscreen might be required."
-      "<br><br>This gives post process shaders more room for accuracy, allows \"AutoHDR\" "
+      "<br><br>This gives post process shaders more room for accuracy, allows \"HDR\" "
       "post-process shaders to work, and allows to fully display the PAL and NTSC-J color spaces."
-      "<br><br>Note that games still render in SDR internally."
+      "<br><br>Note that games might still render in SDR internally."
       "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
   m_ir_combo->SetTitle(tr("Internal Resolution"));

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -60,7 +60,8 @@ private:
   ConfigBool* m_force_24bit_color;
   ConfigBool* m_disable_copy_filter;
   ConfigBool* m_arbitrary_mipmap_detection;
-  ConfigBool* m_hdr;
+  ConfigBool* m_hdr_render;
+  ConfigBool* m_hdr_output;
 
   // Stereoscopy
   ConfigChoice* m_3d_mode;

--- a/Source/Core/VideoBackends/D3D/D3DGfx.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DGfx.cpp
@@ -178,7 +178,7 @@ void Gfx::OnConfigChanged(u32 bits)
   if (bits & CONFIG_CHANGE_BIT_STEREO_MODE && m_swap_chain)
     m_swap_chain->SetStereo(SwapChain::WantsStereo());
 
-  if (bits & CONFIG_CHANGE_BIT_HDR && m_swap_chain)
+  if (bits & CONFIG_CHANGE_BIT_HDR_OUTPUT && m_swap_chain)
     m_swap_chain->SetHDR(SwapChain::WantsHDR());
 }
 

--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -155,6 +155,7 @@ void DXTexture::CopyRectangleFromTexture(const AbstractTexture* src,
   const DXTexture* srcentry = static_cast<const DXTexture*>(src);
   ASSERT(src_rect.GetWidth() == dst_rect.GetWidth() &&
          src_rect.GetHeight() == dst_rect.GetHeight());
+  ASSERT(AbstractTexture::GetTexelSizeForFormat(src->GetFormat()) == AbstractTexture::GetTexelSizeForFormat(GetFormat()));
 
   D3D11_BOX src_box;
   src_box.left = src_rect.left;
@@ -252,6 +253,8 @@ void DXStagingTexture::CopyFromTexture(const AbstractTexture* src,
          src_rect.top >= 0 && static_cast<u32>(src_rect.bottom) <= src->GetHeight());
   ASSERT(dst_rect.left >= 0 && static_cast<u32>(dst_rect.right) <= m_config.width &&
          dst_rect.top >= 0 && static_cast<u32>(dst_rect.bottom) <= m_config.height);
+  // Formats are generally not compatible with each other
+  ASSERT(AbstractTexture::GetTexelSizeForFormat(src->GetFormat()) == AbstractTexture::GetTexelSizeForFormat(GetFormat()));
 
   if (IsMapped())
     DXStagingTexture::Unmap();
@@ -287,6 +290,7 @@ void DXStagingTexture::CopyToTexture(const MathUtil::Rectangle<int>& src_rect, A
          src_rect.top >= 0 && static_cast<u32>(src_rect.bottom) <= GetHeight());
   ASSERT(dst_rect.left >= 0 && static_cast<u32>(dst_rect.right) <= dst->GetWidth() &&
          dst_rect.top >= 0 && static_cast<u32>(dst_rect.bottom) <= dst->GetHeight());
+  //ASSERT(dst->GetFormat() == m_tex.Get()->GetFormat());
 
   if (IsMapped())
     DXStagingTexture::Unmap();

--- a/Source/Core/VideoBackends/D3D12/D3D12Gfx.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3D12Gfx.cpp
@@ -422,7 +422,7 @@ void Gfx::OnConfigChanged(u32 bits)
     m_swap_chain->SetStereo(SwapChain::WantsStereo());
   }
 
-  if (m_swap_chain && bits & CONFIG_CHANGE_BIT_HDR)
+  if (m_swap_chain && bits & CONFIG_CHANGE_BIT_HDR_OUTPUT)
   {
     ExecuteCommandList(true);
     m_swap_chain->SetHDR(SwapChain::WantsHDR());

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -257,6 +257,35 @@ Shader::CompileShader(D3D_FEATURE_LEVEL feature_level, ShaderStage stage, std::s
   Microsoft::WRL::ComPtr<ID3DBlob> errors;
   HRESULT hr = d3d_compile(hlsl->data(), hlsl->size(), nullptr, macros, nullptr, "main", target,
                            flags, 0, &code, &errors);
+
+  if (SUCCEEDED(hr) && code)
+  {
+    Microsoft::WRL::ComPtr<ID3DBlob> code_with_hlsl;
+
+    // Include a tiny header so you can recognize it later.
+    struct DebugHeader
+    {
+      uint32_t magic = 0x4C534C48;  // 'HLSL'
+      uint32_t version = 1;
+      uint32_t source_size = 0;
+    };
+
+    DebugHeader header;
+    header.source_size = static_cast<uint32_t>(hlsl->size());
+
+    std::vector<uint8_t> payload(sizeof(DebugHeader) + hlsl->size() + 1);
+    std::memcpy(payload.data(), &header, sizeof(header));
+    std::memcpy(payload.data() + sizeof(DebugHeader), hlsl->data(), hlsl->size());
+    payload[sizeof(DebugHeader) + hlsl->size()] = 0;  // null terminator for convenience
+
+    HRESULT set_hr =
+        D3DSetBlobPart(code->GetBufferPointer(), code->GetBufferSize(), D3D_BLOB_PRIVATE_DATA, 0,
+                       payload.data(), payload.size(), &code_with_hlsl);
+
+    if (SUCCEEDED(set_hr))
+      code = code_with_hlsl;
+  }
+
   if (FAILED(hr))
   {
     static int num_failures = 0;

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
@@ -188,6 +188,8 @@ bool SwapChain::CreateSwapChain(bool stereo, bool hdr)
     return false;
   }
 
+  QueryDisplayHDRCapabilities();
+
   return true;
 }
 
@@ -200,6 +202,21 @@ void SwapChain::DestroySwapChain()
     m_swap_chain->SetFullscreenState(FALSE, nullptr);
 
   m_swap_chain.Reset();
+}
+
+void SwapChain::QueryDisplayHDRCapabilities()
+{
+  Microsoft::WRL::ComPtr<IDXGIOutput> output;
+  Microsoft::WRL::ComPtr<IDXGIOutput6> output6;
+  DXGI_OUTPUT_DESC1 desc{};
+
+  if (FAILED(m_swap_chain->GetContainingOutput(&output)) || FAILED(output.As(&output6)) ||
+      FAILED(output6->GetDesc1(&desc)))
+  {
+    return;
+  }
+
+  g_backend_info.hdr_peak_white_nits = desc.MaxLuminance;
 }
 
 bool SwapChain::ResizeSwapChain()
@@ -225,6 +242,8 @@ bool SwapChain::ResizeSwapChain()
     m_width = desc.BufferDesc.Width;
     m_height = desc.BufferDesc.Height;
   }
+
+  QueryDisplayHDRCapabilities();
 
   return CreateSwapChainBuffers();
 }

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
@@ -53,7 +53,7 @@ bool SwapChain::WantsStereo()
 
 bool SwapChain::WantsHDR()
 {
-  return g_ActiveConfig.bHDR;
+  return g_ActiveConfig.bHDROutput;
 }
 
 u32 SwapChain::GetSwapChainFlags() const

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
@@ -74,7 +74,7 @@ bool SwapChain::CreateSwapChain(bool stereo, bool hdr)
   m_stereo = false;
   m_hdr = false;
 
-  // Try using the Win8 version if available.
+  // Try using the Win8+ version if available.
   Microsoft::WRL::ComPtr<IDXGIFactory2> dxgi_factory2;
   HRESULT hr = m_dxgi_factory.As(&dxgi_factory2);
   if (SUCCEEDED(hr))
@@ -165,6 +165,21 @@ bool SwapChain::CreateSwapChain(bool stereo, bool hdr)
       // scRGB always returns false (DX bug).
       hr = swap_chain4->CheckColorSpaceSupport(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020,
                                                &color_space_support);
+
+      // IDXGISwapChain3::CheckColorSpaceSupport often returns false negatives,
+      // so add a secondary check based on whether the display is currently in HDR mode,
+      // which implies HDR is supported.
+      Microsoft::WRL::ComPtr<IDXGIOutput> output;
+      Microsoft::WRL::ComPtr<IDXGIOutput6> output6;
+      DXGI_OUTPUT_DESC1 desc{};
+      if (SUCCEEDED(swap_chain4->GetContainingOutput(&output)) && SUCCEEDED(output.As(&output6)) &&
+          SUCCEEDED(output6->GetDesc1(&desc)) &&
+          desc.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020)
+      {
+        color_space_support |= DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT;
+        hr = S_OK;
+      }
+
       if (SUCCEEDED(hr) && (color_space_support & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT))
       {
         hr = swap_chain4->ResizeBuffers(SWAP_CHAIN_BUFFER_COUNT, 0, 0,

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.h
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <dxgi1_5.h>
+#include <dxgi1_6.h>
 #include <wrl/client.h>
 
 #include "Common/CommonTypes.h"
@@ -57,6 +57,8 @@ protected:
 
   virtual bool CreateSwapChainBuffers() = 0;
   virtual void DestroySwapChainBuffers() = 0;
+
+  void QueryDisplayHDRCapabilities();
 
   WindowSystemInfo m_wsi;
   Microsoft::WRL::ComPtr<IDXGIFactory> m_dxgi_factory;

--- a/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKGfx.cpp
@@ -414,7 +414,7 @@ void VKGfx::OnConfigChanged(u32 bits)
   }
 
   // For quad-buffered stereo we need to change the layer count, so recreate the swap chain.
-  if (m_swap_chain && ((bits & CONFIG_CHANGE_BIT_STEREO_MODE) || (bits & CONFIG_CHANGE_BIT_HDR)))
+  if (m_swap_chain && ((bits & CONFIG_CHANGE_BIT_STEREO_MODE) || (bits & CONFIG_CHANGE_BIT_HDR_OUTPUT)))
   {
     ExecuteCommandBuffer(false, true);
     m_swap_chain->RecreateSwapChain();

--- a/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKSwapChain.cpp
@@ -196,7 +196,7 @@ bool SwapChain::SelectSurfaceFormat()
 
   // Pick the best format.
   // "g_ActiveConfig" might not have been been updated yet.
-  if (g_Config.bHDR && surface_format_RGBA16F_scRGB)
+  if (g_Config.bHDROutput && surface_format_RGBA16F_scRGB)
     surface_format = surface_format_RGBA16F_scRGB;
   else if (surface_format_RGB10_A2)
     surface_format = surface_format_RGB10_A2;

--- a/Source/Core/VideoCommon/AbstractGfx.cpp
+++ b/Source/Core/VideoCommon/AbstractGfx.cpp
@@ -110,7 +110,7 @@ void AbstractGfx::ScaleTexture(AbstractFramebuffer* dst_framebuffer,
                                const AbstractTexture* src_texture,
                                const MathUtil::Rectangle<int>& src_rect)
 {
-  ASSERT(dst_framebuffer->GetColorFormat() == AbstractTextureFormat::RGBA8);
+  ASSERT(dst_framebuffer->GetColorFormat() == AbstractTextureFormat::RGBA8); // TODO: add FP16 support (duplicate g_shader_cache->GetRGBA8CopyPipeline() with FP format)
 
   BeginUtilityDrawing();
 

--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -38,7 +38,7 @@ bool AbstractTexture::Save(const std::string& filename, unsigned int level, int 
   ASSERT(level < m_config.levels);
   // We can't copy from float (HDR) textures to RGBA8
   // (most other formats would probably fail as well)
-  ASSERT(m_config.format != AbstractTextureFormat::RGBA16F);
+  ASSERT(m_config.format != AbstractTextureFormat::RGBA16F); // TODO?
 
   // Determine dimensions of image we want to save.
   u32 level_width = std::max(1u, m_config.width >> level);

--- a/Source/Core/VideoCommon/FrameDumper.cpp
+++ b/Source/Core/VideoCommon/FrameDumper.cpp
@@ -83,6 +83,7 @@ bool FrameDumper::CheckFrameDumpRenderTexture(u32 target_width, u32 target_heigh
   // Recreate texture, but release before creating so we don't temporarily use twice the RAM.
   m_frame_dump_render_framebuffer.reset();
   m_frame_dump_render_texture.reset();
+  // TODO: HDR?
   m_frame_dump_render_texture = g_gfx->CreateTexture(
       TextureConfig(target_width, target_height, 1, 1, 1, AbstractTextureFormat::RGBA8,
                     AbstractTextureFlag_RenderTarget, AbstractTextureType::Texture_2DArray),
@@ -105,6 +106,7 @@ bool FrameDumper::CheckFrameDumpReadbackTexture(u32 target_width, u32 target_hei
     return true;
 
   rbtex.reset();
+  // TODO: HDR?
   rbtex = g_gfx->CreateStagingTexture(StagingTextureType::Readback,
                                       TextureConfig(target_width, target_height, 1, 1, 1,
                                                     AbstractTextureFormat::RGBA8, 0,

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -126,7 +126,8 @@ AbstractTextureFormat FramebufferManager::GetEFBColorFormat()
   // Multisampling depends on user settings.
   // The distinction becomes important for certain operations, i.e. the
   // alpha channel should be ignored if the EFB does not have one.
-  return AbstractTextureFormat::RGBA16F;
+  // If HDR rendering is enable, we forcing high bit depth float.
+  return g_ActiveConfig.bHDRRender ? AbstractTextureFormat::RGBA16F : AbstractTextureFormat::RGBA8;
 }
 
 AbstractTextureFormat FramebufferManager::GetEFBDepthFormat()

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -122,11 +122,11 @@ AbstractTextureFormat FramebufferManager::GetEFBColorFormat()
   // - 24-bit RGB (8-bit components) with 24-bit Z
   // - 24-bit RGBA (6-bit components) with 24-bit Z
   // - Multisampled 16-bit RGB (5-6-5 format) with 16-bit Z
-  // We only use one EFB format here: 32-bit ARGB with 32-bit Z.
+  // We only use one EFB format here: 64-bit RGBA (16F) with 32-bit Z.
   // Multisampling depends on user settings.
   // The distinction becomes important for certain operations, i.e. the
   // alpha channel should be ignored if the EFB does not have one.
-  return AbstractTextureFormat::RGBA8;
+  return AbstractTextureFormat::RGBA16F;
 }
 
 AbstractTextureFormat FramebufferManager::GetEFBDepthFormat()
@@ -628,7 +628,7 @@ bool FramebufferManager::CompileReadbackPipelines()
   config.rasterization_state = RenderState::GetNoCullRasterizationState(PrimitiveType::Triangles);
   config.depth_state = RenderState::GetNoDepthTestingDepthState();
   config.blending_state = RenderState::GetNoBlendingBlendState();
-  config.framebuffer_state = RenderState::GetColorFramebufferState(GetEFBColorFormat());
+  config.framebuffer_state = RenderState::GetColorFramebufferState(AbstractTextureFormat::RGBA8);
   config.usage = AbstractPipelineUsage::Utility;
   m_efb_color_cache.copy_pipeline = g_gfx->CreatePipeline(config);
   if (!m_efb_color_cache.copy_pipeline)
@@ -702,7 +702,7 @@ bool FramebufferManager::CreateReadbackFramebuffer()
   {
     const TextureConfig color_config(IsUsingTiledEFBCache() ? m_efb_cache_tile_size : EFB_WIDTH,
                                      IsUsingTiledEFBCache() ? m_efb_cache_tile_size : EFB_HEIGHT, 1,
-                                     1, 1, GetEFBColorFormat(), AbstractTextureFlag_RenderTarget,
+                                     1, 1, AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget,
                                      AbstractTextureType::Texture_2DArray);
     m_efb_color_cache.texture = g_gfx->CreateTexture(color_config, "EFB color cache");
     if (!m_efb_color_cache.texture)
@@ -740,7 +740,7 @@ bool FramebufferManager::CreateReadbackFramebuffer()
   // Staging texture use the full EFB dimensions, as this is the buffer for the whole cache.
   m_efb_color_cache.readback_texture =
       g_gfx->CreateStagingTexture(StagingTextureType::Mutable,
-                                  TextureConfig(EFB_WIDTH, EFB_HEIGHT, 1, 1, 1, GetEFBColorFormat(),
+                                  TextureConfig(EFB_WIDTH, EFB_HEIGHT, 1, 1, 1, AbstractTextureFormat::RGBA8,
                                                 0, AbstractTextureType::Texture_2DArray));
   m_efb_depth_cache.readback_texture = g_gfx->CreateStagingTexture(
       StagingTextureType::Mutable,

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -126,7 +126,7 @@ AbstractTextureFormat FramebufferManager::GetEFBColorFormat()
   // Multisampling depends on user settings.
   // The distinction becomes important for certain operations, i.e. the
   // alpha channel should be ignored if the EFB does not have one.
-  return AbstractTextureFormat::RGBA8;
+  return AbstractTextureFormat::RGBA16F;
 }
 
 AbstractTextureFormat FramebufferManager::GetEFBDepthFormat()

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -122,11 +122,11 @@ AbstractTextureFormat FramebufferManager::GetEFBColorFormat()
   // - 24-bit RGB (8-bit components) with 24-bit Z
   // - 24-bit RGBA (6-bit components) with 24-bit Z
   // - Multisampled 16-bit RGB (5-6-5 format) with 16-bit Z
-  // We only use one EFB format here: 64-bit RGBA (16F) with 32-bit Z.
+  // We only use one EFB format here: 32-bit ARGB with 32-bit Z.
   // Multisampling depends on user settings.
   // The distinction becomes important for certain operations, i.e. the
   // alpha channel should be ignored if the EFB does not have one.
-  return AbstractTextureFormat::RGBA16F;
+  return AbstractTextureFormat::RGBA8;
 }
 
 AbstractTextureFormat FramebufferManager::GetEFBDepthFormat()
@@ -628,7 +628,7 @@ bool FramebufferManager::CompileReadbackPipelines()
   config.rasterization_state = RenderState::GetNoCullRasterizationState(PrimitiveType::Triangles);
   config.depth_state = RenderState::GetNoDepthTestingDepthState();
   config.blending_state = RenderState::GetNoBlendingBlendState();
-  config.framebuffer_state = RenderState::GetColorFramebufferState(AbstractTextureFormat::RGBA8);
+  config.framebuffer_state = RenderState::GetColorFramebufferState(GetEFBColorFormat());
   config.usage = AbstractPipelineUsage::Utility;
   m_efb_color_cache.copy_pipeline = g_gfx->CreatePipeline(config);
   if (!m_efb_color_cache.copy_pipeline)
@@ -702,7 +702,7 @@ bool FramebufferManager::CreateReadbackFramebuffer()
   {
     const TextureConfig color_config(IsUsingTiledEFBCache() ? m_efb_cache_tile_size : EFB_WIDTH,
                                      IsUsingTiledEFBCache() ? m_efb_cache_tile_size : EFB_HEIGHT, 1,
-                                     1, 1, AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget,
+                                     1, 1, GetEFBColorFormat(), AbstractTextureFlag_RenderTarget,
                                      AbstractTextureType::Texture_2DArray);
     m_efb_color_cache.texture = g_gfx->CreateTexture(color_config, "EFB color cache");
     if (!m_efb_color_cache.texture)
@@ -740,7 +740,7 @@ bool FramebufferManager::CreateReadbackFramebuffer()
   // Staging texture use the full EFB dimensions, as this is the buffer for the whole cache.
   m_efb_color_cache.readback_texture =
       g_gfx->CreateStagingTexture(StagingTextureType::Mutable,
-                                  TextureConfig(EFB_WIDTH, EFB_HEIGHT, 1, 1, 1, AbstractTextureFormat::RGBA8,
+                                  TextureConfig(EFB_WIDTH, EFB_HEIGHT, 1, 1, 1, GetEFBColorFormat(),
                                                 0, AbstractTextureType::Texture_2DArray));
   m_efb_depth_cache.readback_texture = g_gfx->CreateStagingTexture(
       StagingTextureType::Mutable,

--- a/Source/Core/VideoCommon/LightingShaderGen.cpp
+++ b/Source/Core/VideoCommon/LightingShaderGen.cpp
@@ -146,8 +146,8 @@ void GenerateLightingShaderHeader(ShaderCode& object, const LightingUidData& uid
           GenerateLightShader(object, uid_data, i, j + 2, true);
       }
     }
-    object.Write("\tlacc = clamp(lacc, 0, 255);\n");
-    object.Write("\treturn vec4((mat * (lacc + (lacc >> 7))) >> 8) / 255.0;\n");
+    object.Write("\tlacc = clamp(lacc, 0, 2550);\n"); // TODO: HDR branches
+    object.Write("\treturn vec4((mat * ((lacc * 256 + 127) / 255)) >> 8) / 255.0;\n");
     object.Write("}}\n\n");
   }
 }

--- a/Source/Core/VideoCommon/LightingShaderGen.cpp
+++ b/Source/Core/VideoCommon/LightingShaderGen.cpp
@@ -78,7 +78,7 @@ static void GenerateLightShader(ShaderCode& object, const LightingUidData& uid_d
 // vertex shader
 // lights/colors
 // materials name is I_MATERIALS in vs and I_PMATERIALS in ps
-void GenerateLightingShaderHeader(ShaderCode& object, const LightingUidData& uid_data)
+void GenerateLightingShaderHeader(ShaderCode& object, const ShaderHostConfig& host_config, const LightingUidData& uid_data)
 {
   for (u32 j = 0; j < NUM_XF_COLOR_CHANNELS; j++)
   {
@@ -146,7 +146,10 @@ void GenerateLightingShaderHeader(ShaderCode& object, const LightingUidData& uid
           GenerateLightShader(object, uid_data, i, j + 2, true);
       }
     }
-    object.Write("\tlacc = clamp(lacc, 0, 2550);\n"); // TODO: HDR branches
+    if (host_config.hdr)
+      object.Write("\tlacc = clamp(lacc, int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n");
+    else
+      object.Write("\tlacc = clamp(lacc, 0, 255);\n");
     object.Write("\treturn vec4((mat * ((lacc * 256 + 127) / 255)) >> 8) / 255.0;\n");
     object.Write("}}\n\n");
   }

--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -7,6 +7,7 @@
 #include "Common/CommonTypes.h"
 
 class ShaderCode;
+union ShaderHostConfig;
 
 #define LIGHT_COL "{}[{}].color.{}"
 #define LIGHT_COL_PARAMS(index, swizzle) (I_LIGHTS), (index), (swizzle)
@@ -44,6 +45,6 @@ constexpr char s_lighting_struct[] = "struct Light {\n"
                                      "\tfloat4 dir;\n"
                                      "};\n";
 
-void GenerateLightingShaderHeader(ShaderCode& object, const LightingUidData& uid_data);
+void GenerateLightingShaderHeader(ShaderCode& object, const ShaderHostConfig& host_config, const LightingUidData& uid_data);
 void GetLightingShaderUid(LightingUidData& uid_data);
 void GenerateCustomLighting(ShaderCode* out, const LightingUidData& uid_data);

--- a/Source/Core/VideoCommon/PipelineUtils.cpp
+++ b/Source/Core/VideoCommon/PipelineUtils.cpp
@@ -34,6 +34,49 @@ GXPipelineUid ApplyDriverBugs(const GXPipelineUid& in)
     ps->ztest = EmulatedZ::Early;
   }
 
+  bool hdr_target = bpmem.zcontrol.pixel_format == PixelFormat::RGB8_Z24 ||
+                    bpmem.zcontrol.pixel_format == PixelFormat::RGBA6_Z24 ||
+                    bpmem.zcontrol.pixel_format == PixelFormat::RGB565_Z16; // TODO: is this one needed?
+  if (g_ActiveConfig.bHDRRender && hdr_target)
+  {
+    // Work around with blend problems that arise from using HDR.
+    // Alpha is always clamped so it's not a problem, but color is not.
+
+    if (blend.color_update && blend.blend_enable)
+    {
+      // If the source factor was the inverse of the dest
+      // (often used to draw bloom on top of the scene, to avoid clipping highlights),
+      // we simply let the source go in unscaled, otherwise if the dest is > 1,
+      // it'd flip in intensity and visually look broken.
+      if (blend.src_factor == SrcBlendFactor::InvDstClr)
+      {
+        blend.src_factor = SrcBlendFactor::One;
+      }
+      // Similarly, if the dest uses the inv source as factor,
+      // clamp it to <= 1 shaders, to avoid it flipping.
+      if (blend.dst_factor == DstBlendFactor::InvSrcClr)
+      {
+        ps->force_clamp_color = true;
+      }
+      // For some reason this is needed or water breaks in ZTP. // TODO: WHY? We could probably reduce the branches. Actually it's not completely fixed...
+      if (blend.dst_factor_alpha == DstBlendFactor::InvSrcAlpha
+          || blend.dst_factor_alpha == DstBlendFactor::InvSrcClr
+          || blend.src_factor_alpha == SrcBlendFactor::InvDstAlpha
+          || blend.src_factor_alpha == SrcBlendFactor::InvDstClr)
+      {
+        ps->force_clamp_color = true;
+      }
+    }
+    // Logic operators work in int and break if values are outside of 8 bit range
+    if (blend.color_update && blend.logic_op_enable && blend.logic_mode != LogicOp::Copy)
+    {
+        ps->force_clamp_color = true;
+    }
+
+    // TODO: add code to always clamp alpha to 0-1 on sampling, given that we might have summed source and target alpha
+    // and in FLOAT textures that doesn't stop at 0-1. Simple clamp on sampling in uber shader for compatibility.
+  }
+
   // If framebuffer fetch is available, we can emulate logic ops in the fragment shader
   // and don't need the below blend approximation
   if (blend.logic_op_enable && !g_backend_info.bSupportsLogicOp &&
@@ -95,7 +138,7 @@ GXPipelineUid ApplyDriverBugs(const GXPipelineUid& in)
       }
     }
   }
-  if (g_ActiveConfig.bHDRRender)
+  if (g_ActiveConfig.bHDRRender && hdr_target)
   {
     // TODO: make a copy of the RTV and force SW blends if there's subtractive color blends or any logical blend,
     // the same code could also be used to force original HW accurate blends.

--- a/Source/Core/VideoCommon/PipelineUtils.cpp
+++ b/Source/Core/VideoCommon/PipelineUtils.cpp
@@ -95,6 +95,11 @@ GXPipelineUid ApplyDriverBugs(const GXPipelineUid& in)
       }
     }
   }
+  if (g_ActiveConfig.bHDRRender)
+  {
+    // TODO: make a copy of the RTV and force SW blends if there's subtractive color blends or any logical blend,
+    // the same code could also be used to force original HW accurate blends.
+  }
 
   // force dual src off if we can't support it
   if (!g_backend_info.bSupportsDualSourceBlend)

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -346,7 +346,8 @@ void WritePixelShaderCommonHeader(ShaderCode& out, APIType api_type,
 
   out.Write("UBO_BINDING(std140, 1) uniform PSBlock {{\n");
 
-  out.Write("\tint4 " I_COLORS "[4];\n"
+  out.Write("\tfloat4 " I_FREELOOK "[4];\n"
+            "\tint4 " I_COLORS "[4];\n"
             "\tint4 " I_KCOLORS "[4];\n"
             "\tint4 " I_ALPHA ";\n"
             "\tint4 " I_TEXDIMS "[8];\n"
@@ -725,6 +726,16 @@ uint WrapCoord(int coord, uint wrap, int size) {{
 }}
 )");
   }
+
+  out.Write("mat4x4 dolphin_freelook_matrix()\n");
+  out.Write("{{\n");
+  out.Write("\tmat4x4 result;\n");
+  out.Write("\tresult[0] = " I_FREELOOK "[0];\n"
+            "\tresult[1] = " I_FREELOOK "[1];\n"
+            "\tresult[2] = " I_FREELOOK "[2];\n"
+            "\tresult[3] = " I_FREELOOK "[3];\n");
+  out.Write("\treturn result;\n");
+  out.Write("}}\n\n");
 }
 
 static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, int n,
@@ -993,7 +1004,8 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   out.Write("\tDolphinFragmentOutput frag_output;\n");
   out.Write("\tprocess_fragment(frag_input, frag_output);\n");
-  out.Write("\tivec4 prev = frag_output.main & 255;\n");
+  // out.Write("\tivec4 prev = frag_output.main & 255;\n");
+  out.Write("\tivec4 prev = frag_output.main;\n");
 
   // NOTE: Fragment may not be discarded if alpha test always fails and early depth test is enabled
   // (in this case we need to write a depth value if depth test passes regardless of the alpha
@@ -1454,8 +1466,11 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   }
   out.Write("\ttevin_d = int4({}, {});\n", tev_c_input_table[cc.d], tev_a_input_table[ac.d]);
 
-  out.Write("\t// color combine\n");
-  out.Write("\t{} = clamp(", tev_c_output_table[cc.dest]);
+  out.Write("\t// color combine (unclamp)?\n");
+  if (cc.clamp)
+    out.Write("\t{} = max(", tev_c_output_table[cc.dest]);
+    else
+    out.Write("\t{} = clamp(", tev_c_output_table[cc.dest]);
   if (cc.bias != TevBias::Compare)
   {
     WriteTevRegular(out, "rgb", cc.bias, cc.op, cc.clamp, cc.scale);
@@ -1482,7 +1497,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
       out.Write("   tevin_d.rgb + {}", tev_rgb_comparison_gt[cc.compare_mode]);
   }
   if (cc.clamp)
-    out.Write(", int3(0,0,0), int3(255,255,255))");
+    out.Write(", int3(0,0,0))");
   else
     out.Write(", int3(-1024,-1024,-1024), int3(1023,1023,1023))");
   out.Write(";\n");

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1450,7 +1450,7 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
   // TODO: naming and placement
   // Let HDR colors go up to "infinite", as opposed to a limiter greater range (10x in gamma space, which is huge)
   constexpr bool hdr_no_color_clamp = false;
-  constexpr bool hdr_no_color_alpha_clamp = false;
+  constexpr bool hdr_no_color_alpha_clamp = false; // TODO: implement
   // Let HDR alpha go beyond 255, which is generally not a good idea given that it can mess up
   // blends etc
   constexpr bool hdr_no_alpha_clamp = false;
@@ -1460,42 +1460,54 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
     // TODO: force tighter clamping if cc.op is set to subtraction? Otherwise we could end up with 255-2550 (e.g.)
     // Always clamp if the source is an alpha. Constants are already 8 bit so need no clamping.
     // Always clamp the alpha channel.
-    if (cc.a == TevColorArg::PrevAlpha || cc.a == TevColorArg::Alpha0 ||
-        cc.a == TevColorArg::Alpha1 || cc.a == TevColorArg::Alpha2)
+    if (!hdr_no_color_alpha_clamp)
     {
-      out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
-                tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
-    }
-    // TODO: test/polish these cases, it's a bit random, especially on alpha, which isn't related to "cc.a"
-    else if (cc.a == TevColorArg::TexAlpha || cc.a == TevColorArg::RasAlpha)
-    {
-      out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
-                tev_a_input_table[ac.a]);
+        out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 2550));\n",
+                  tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+        out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 2550));\n",
+                  tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
+        out.Write("\ttevin_c = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 2550));\n",
+                  tev_c_input_table[cc.c], tev_a_input_table[ac.c]);
     }
     else
     {
-      out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
-                tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+      if (cc.a == TevColorArg::PrevAlpha || cc.a == TevColorArg::Alpha0 ||
+          cc.a == TevColorArg::Alpha1 || cc.a == TevColorArg::Alpha2)
+      {
+        out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
+                  tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+      }
+      // TODO: test/polish these cases, it's a bit random, especially on alpha, which isn't related to "cc.a"
+      else if (cc.a == TevColorArg::TexAlpha || cc.a == TevColorArg::RasAlpha)
+      {
+        out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
+                  tev_a_input_table[ac.a]);
+      }
+      else
+      {
+        out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
+                  tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+      }
+      if (cc.b == TevColorArg::PrevAlpha || cc.b == TevColorArg::Alpha0 ||
+          cc.b == TevColorArg::Alpha1 || cc.b == TevColorArg::Alpha2)
+      {
+        out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
+                  tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
+      }
+      else if (cc.b == TevColorArg::TexAlpha || cc.b == TevColorArg::RasAlpha)
+      {
+        out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
+                  tev_a_input_table[ac.b]);
+      }
+      else
+      {
+        out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
+                  tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
+      }
+      // Always force clamp the lerp blend factor
+      out.Write("\ttevin_c = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
+                tev_c_input_table[cc.c], tev_a_input_table[ac.c]);
     }
-    if (cc.b == TevColorArg::PrevAlpha || cc.b == TevColorArg::Alpha0 ||
-        cc.b == TevColorArg::Alpha1 || cc.b == TevColorArg::Alpha2)
-    {
-      out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
-                tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
-    }
-    else if (cc.b == TevColorArg::TexAlpha || cc.b == TevColorArg::RasAlpha)
-    {
-      out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
-                tev_a_input_table[ac.b]);
-    }
-    else
-    {
-      out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
-                tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
-    }
-    // Always force clamp the lerp blend factor
-    out.Write("\ttevin_c = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
-              tev_c_input_table[cc.c], tev_a_input_table[ac.c]);
   }
   else if(DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VECTOR_BITWISE_AND))
   {

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1676,11 +1676,11 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
     else
       out.Write("   tevin_d.a + {}", tev_a_comparison_gt[ac.compare_mode]);
   }
-  if (ac.clamp && hdr_no_alpha_clamp)
+  if (ac.clamp && host_config.hdr && hdr_no_alpha_clamp)
     out.Write(", 0, 2550)");
   else if (ac.clamp)
     out.Write(", 0, 255)");
-  else if (hdr_no_alpha_clamp)
+  else if (host_config.hdr && hdr_no_alpha_clamp)
     out.Write(", -10240, 10230)");
   else
     out.Write(", -1024, 1023)");

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -162,6 +162,12 @@ constexpr Common::EnumMap<const char*, TevOutput::Color2> tev_a_output_table{
 
 constexpr Common::EnumMap<char, ColorChannel::Alpha> rgba_swizzle{'r', 'g', 'b', 'a'};
 
+struct OverwrittenTevColorSources
+{
+  std::array<bool, 4> color{};
+  std::array<bool, 4> alpha{};
+};
+
 PixelShaderUid GetPixelShaderUid()
 {
   PixelShaderUid out;
@@ -346,6 +352,7 @@ void WritePixelShaderCommonHeader(ShaderCode& out, APIType api_type,
 
   out.Write("UBO_BINDING(std140, 1) uniform PSBlock {{\n");
 
+  // See "PixelShaderConstants"
   out.Write("\tint4 " I_COLORS "[4];\n"
             "\tint4 " I_KCOLORS "[4];\n"
             "\tint4 " I_ALPHA ";\n"
@@ -472,7 +479,10 @@ void UpdateBoundingBox(float2 rawpos) {{
   {
     out.Write(R"(
 int4 readTexture(in sampler2DArray tex, uint u, uint v, int layer, int lod) {{
-  return iround(texelFetch(tex, int3(u, v, layer), lod) * 255.0);
+  int4 result iround(texelFetch(tex, int3(u, v, layer), lod) * 255.0);
+  result.rgb = max(result.rgb, 0);  // Float textures overfloat protection
+  result.a = clamp(result.a, 0, 255);  // Float textures overfloat protection
+  return result;
 }}
 
 int4 readTextureLinear(in sampler2DArray tex, uint2 uv1, uint2 uv2, int layer, int lod, int2 frac_uv) {{)");
@@ -555,13 +565,16 @@ uint WrapCoord(int coord, uint wrap, int size) {{
     {
       out.Write("  uint texmode0 = samp_texmode0(texmap);\n"
                 "  float lod_bias = float({}) / 256.0f;\n"
-                "  return iround(255.0 * texture(tex, coords, lod_bias));\n",
+                "  int4 result = iround(255.0 * texture(tex, coords, lod_bias));\n",
                 BitfieldExtract<&SamplerState::TM0::lod_bias>("texmode0"));
     }
     else
     {
-      out.Write("  return iround(255.0 * texture(tex, coords));\n");
+      out.Write("  int4 result = iround(255.0 * texture(tex, coords));\n");
     }
+    out.Write("  result.rgb = max(result.rgb, 0);  // Float textures overfloat protection\n");
+    out.Write("  result.a = clamp(result.a, 0, 255);  // Float textures overfloat protection\n");
+    out.Write("  return result;\n");
 
     out.Write("}}\n");
   }
@@ -734,11 +747,13 @@ static void WriteTevRegular(ShaderCode& out, std::string_view components, TevBia
 static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_data, APIType api_type,
                            bool per_pixel_depth, bool use_dual_source);
 static void WriteFog(ShaderCode& out, const pixel_shader_uid_data* uid_data);
-static void WriteLogicOp(ShaderCode& out, const pixel_shader_uid_data* uid_data);
+static void WriteLogicOp(ShaderCode& out,  const ShaderHostConfig& host_config,
+                         const pixel_shader_uid_data* uid_data);
 static void WriteLogicOpBlend(ShaderCode& out, const pixel_shader_uid_data* uid_data);
 static void WriteColor(ShaderCode& out, APIType api_type, const pixel_shader_uid_data* uid_data,
                        bool use_dual_source);
-static void WriteBlend(ShaderCode& out, const pixel_shader_uid_data* uid_data);
+static void WriteBlend(ShaderCode& out, const ShaderHostConfig& host_config,
+                       const pixel_shader_uid_data* uid_data);
 
 static void WriteEmulatedFragmentBodyHeader(APIType api_type, const ShaderHostConfig& host_config,
                                             const pixel_shader_uid_data* uid_data, ShaderCode& out);
@@ -999,17 +1014,41 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   out.Write("\tDolphinFragmentOutput frag_output;\n");
   out.Write("\tprocess_fragment(frag_input, frag_output);\n");
+
+  out.Write("\tivec4 prev = frag_output.main;\n");
   if (host_config.hdr)
   {
-    out.Write("\tivec4 prev = frag_output.main;\n");
-    // Apply bitmask on alpha only
-    out.Write("\tprev.a = prev.a & 255;\n");
-    // Clamp alpha for extra safety given it could have gone beyond 255
-    //out.Write("\tprev.a = clamp(prev.a, 0, 255);\n"); // TODO
+    TevStageCombiner::ColorCombiner last_cc;
+    TevStageCombiner::AlphaCombiner last_ac;
+    last_cc.hex = uid_data->stagehash[uid_data->genMode_numtevstages].cc;
+    last_ac.hex = uid_data->stagehash[uid_data->genMode_numtevstages].ac;
+
+    // If the last stage clamp was true, we'd already be clamped here
+    // (possibly with an extended range in HDR),
+    // otherwise, the original HW would truncate from 11bit to 8bit,
+    // so we need to replicate that in HDR.
+    if (!last_cc.clamp)
+    {
+      out.Write("\tprev.rgb = prev.rgb & 255;\n");
+    }
+    // Force clamp to the original range if we allowed more range in HDR
+    else if (uid_data->force_clamp_color)
+    {
+      out.Write("\tprev.rgb = min(prev.rgb, 255);\n");
+    }
+    if (!last_ac.clamp)
+    {
+      out.Write("\tprev.a = prev.a & 255;\n");
+    }
+    // Force clamp alpha as it wouldn't have been
+    else
+    {
+      out.Write("\tprev.a = min(prev.a, 255);\n");
+    }
   }
-  else
+  else // TODO: delete, merge with branch above, this can be optimized away
   {
-    out.Write("\tivec4 prev = frag_output.main & 255;\n");
+    out.Write("\tprev = prev & 255;\n");
   }
 
   // NOTE: Fragment may not be discarded if alpha test always fails and early depth test is enabled
@@ -1120,7 +1159,7 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   // TODO: force clamp to 255 in HDR after certain logic operations?
   if (uid_data->logic_op_enable)  // Implies "use_framebuffer_fetch"
-    WriteLogicOp(out, uid_data);
+    WriteLogicOp(out, host_config, uid_data);
   else if (uid_data->emulate_logic_op_with_blend)
     WriteLogicOpBlend(out, uid_data);
 
@@ -1130,7 +1169,7 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
   WriteColor(out, api_type, uid_data, use_dual_source);
 
   if (uid_data->blend_enable)  // Implies "use_framebuffer_fetch"
-    WriteBlend(out, uid_data);
+    WriteBlend(out, host_config, uid_data);
   else if (use_framebuffer_fetch)
     out.Write("\treal_ocol0 = ocol0;\n");
 
@@ -1144,7 +1183,8 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
 static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
                        const pixel_shader_uid_data* uid_data, int n,
-                       APIType api_type, bool stereo)
+                       APIType api_type, bool stereo,
+                       OverwrittenTevColorSources& overwritten_sources)
 {
   using Common::EnumMap;
 
@@ -1454,7 +1494,7 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
   if (ac.dest >= TevOutput::Color0)
     out.SetConstantsUsed(C_COLORS + u32(ac.dest.Value()), C_COLORS + u32(ac.dest.Value()));
 
-  // TODO: naming and placement
+  // TODO: naming and placement and values
   // Let HDR colors go up to "infinite", as opposed to a limiter greater range (10x in gamma space, which is huge)
   constexpr bool hdr_no_color_clamp = false;
   // Tev result (d) was already in 10 bit, so widening it might not be necessary, but it should help preserve more range
@@ -1490,8 +1530,77 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
       // than they were, or go below 0.
       // Always clamp the alpha channel.
 
+      out.Write("\ttevin_a = int4({}, {});\n", tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+      out.Write("\ttevin_b = int4({}, {});\n", tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
+      out.Write("\ttevin_c = int4({}, {});\n", tev_c_input_table[cc.c], tev_a_input_table[ac.c]);
+
+      // Super Mario Galaxy passes color larger than 255 from the CPU,
+      // and relies on masking for them to wrap to different values.
+      // We want to force the masking, but only up until a color has been
+      // overwritten by another tev output, otherwise we keep the wider range.
+      if (((cc.a == TevColorArg::PrevColor || cc.a == TevColorArg::PrevAlpha)
+            && !overwritten_sources.color[(int)TevOutput::Prev]) ||
+          ((cc.a == TevColorArg::Color0 || cc.a == TevColorArg::Alpha0)
+            && !overwritten_sources.color[(int)TevOutput::Color0]) ||
+          ((cc.a == TevColorArg::Color1 || cc.a == TevColorArg::Alpha1)
+            && !overwritten_sources.color[(int)TevOutput::Color1]) ||
+          ((cc.a == TevColorArg::Color2 || cc.a == TevColorArg::Alpha2)
+            && !overwritten_sources.color[(int)TevOutput::Color2]) ||
+          cc.a == TevColorArg::Konst)
+      {
+        out.Write("\ttevin_a.rgb = tevin_a.rgb & 255;\n");
+      }
+      if ((ac.a == TevAlphaArg::PrevAlpha && !overwritten_sources.alpha[(int)TevOutput::Prev]) ||
+          (ac.a == TevAlphaArg::Alpha0 && !overwritten_sources.alpha[(int)TevOutput::Color0]) ||
+          (ac.a == TevAlphaArg::Alpha1 && !overwritten_sources.alpha[(int)TevOutput::Color1]) ||
+          (ac.a == TevAlphaArg::Alpha2 && !overwritten_sources.alpha[(int)TevOutput::Color2]) ||
+          ac.a == TevAlphaArg::Konst)
+      {
+        out.Write("\ttevin_a.a = tevin_a.a & 255;\n");
+      }
+      if (((cc.b == TevColorArg::PrevColor || cc.b == TevColorArg::PrevAlpha)
+            && !overwritten_sources.color[(int)TevOutput::Prev]) ||
+          ((cc.b == TevColorArg::Color0 || cc.b == TevColorArg::Alpha0)
+            && !overwritten_sources.color[(int)TevOutput::Color0]) ||
+          ((cc.b == TevColorArg::Color1 || cc.b == TevColorArg::Alpha1)
+            && !overwritten_sources.color[(int)TevOutput::Color1]) ||
+          ((cc.b == TevColorArg::Color2 || cc.b == TevColorArg::Alpha2)
+            && !overwritten_sources.color[(int)TevOutput::Color2]) ||
+          cc.b == TevColorArg::Konst)
+      {
+        out.Write("\ttevin_b.rgb = tevin_b.rgb & 255;\n");
+      }
+      if ((ac.b == TevAlphaArg::PrevAlpha && !overwritten_sources.alpha[(int)TevOutput::Prev]) ||
+          (ac.b == TevAlphaArg::Alpha0 && !overwritten_sources.alpha[(int)TevOutput::Color0]) ||
+          (ac.b == TevAlphaArg::Alpha1 && !overwritten_sources.alpha[(int)TevOutput::Color1]) ||
+          (ac.b == TevAlphaArg::Alpha2 && !overwritten_sources.alpha[(int)TevOutput::Color2]) ||
+          ac.b == TevAlphaArg::Konst)
+      {
+        out.Write("\ttevin_b.a = tevin_b.a & 255;\n");
+      }
+      if (((cc.c == TevColorArg::PrevColor || cc.c == TevColorArg::PrevAlpha)
+            && !overwritten_sources.color[(int)TevOutput::Prev]) ||
+          ((cc.c == TevColorArg::Color0 || cc.c == TevColorArg::Alpha0)
+            && !overwritten_sources.color[(int)TevOutput::Color0]) ||
+          ((cc.c == TevColorArg::Color1 || cc.c == TevColorArg::Alpha1)
+            && !overwritten_sources.color[(int)TevOutput::Color1]) ||
+          ((cc.c == TevColorArg::Color2 || cc.c == TevColorArg::Alpha2)
+            && !overwritten_sources.color[(int)TevOutput::Color2]) ||
+          cc.c == TevColorArg::Konst)
+      {
+        out.Write("\ttevin_c.rgb = tevin_c.rgb & 255;\n");
+      }
+      if ((ac.c == TevAlphaArg::PrevAlpha && !overwritten_sources.alpha[(int)TevOutput::Prev]) ||
+          (ac.c == TevAlphaArg::Alpha0 && !overwritten_sources.alpha[(int)TevOutput::Color0]) ||
+          (ac.c == TevAlphaArg::Alpha1 && !overwritten_sources.alpha[(int)TevOutput::Color1]) ||
+          (ac.c == TevAlphaArg::Alpha2 && !overwritten_sources.alpha[(int)TevOutput::Color2]) ||
+          ac.c == TevAlphaArg::Konst)
+      {
+        out.Write("\ttevin_c.a = tevin_c.a & 255;\n");
+      }
+
       // A
-      if (false) // TODO: setting this to "cc.a == TevColorArg::Color1 || cc.a == TevColorArg::Color2" fixes some marios galaxy broken stars
+      if (false) // TODO: clean
       {
         out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
                   tev_a_input_table[ac.a]);
@@ -1501,9 +1610,8 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
           cc.a == TevColorArg::TexAlpha || cc.a == TevColorArg::RasAlpha ||
           cc.op == TevOp::Sub)
       {
-        out.Write("\ttevin_a.rgb = clamp({}, int3(0, 0, 0), int3(255, 255, 255));\n",
-                  tev_c_input_table[cc.a]);
-        out.Write("\ttevin_a.a = {} & 255;\n", tev_a_input_table[ac.a]);
+        out.Write("\ttevin_a.rgb = clamp(tevin_a.rgb, int3(0, 0, 0), int3(255, 255, 255));\n");
+        out.Write("\ttevin_a.a = tevin_a.a & 255;\n");
       }
       // TODO: test/polish these cases, it's a bit random, especially on alpha, which isn't related to "cc.a"
       else if (false)
@@ -1513,9 +1621,8 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
       }
       else
       {
-        out.Write("\ttevin_a.rgb = clamp({}, int3(0, 0, 0), int3(2550, 2550, 2550));\n",
-                  tev_c_input_table[cc.a]);
-        out.Write("\ttevin_a.a = {} & 255;\n", tev_a_input_table[ac.a]);
+        out.Write("\ttevin_a.rgb = clamp(tevin_a.rgb, int3(0, 0, 0), int3(2550, 2550, 2550));\n");
+        out.Write("\ttevin_a.a = tevin_a.a & 255;\n");
         //out.Write("\ttevin_a.a = clamp({}, 0, 255);\n", tev_a_input_table[ac.a]); // TODO: try hdr_no_color_alpha_clamp
       }
 
@@ -1530,9 +1637,8 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
           cc.b == TevColorArg::TexAlpha || cc.b == TevColorArg::RasAlpha ||
           cc.op == TevOp::Sub)
       {
-        out.Write("\ttevin_b.rgb = clamp({}, int3(0, 0, 0), int3(255, 255, 255));\n",
-                  tev_c_input_table[cc.b]);
-        out.Write("\ttevin_b.a = {} & 255;\n", tev_a_input_table[ac.b]);
+        out.Write("\ttevin_b.rgb = clamp(tevin_b.rgb, int3(0, 0, 0), int3(255, 255, 255));\n");
+        out.Write("\ttevin_b.a = tevin_b.a & 255;\n");
       }
       else if (false)
       {
@@ -1541,9 +1647,8 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
       }
       else
       {
-        out.Write("\ttevin_b.rgb = clamp({}, int3(0, 0, 0), int3(2550, 2550, 2550));\n",
-                  tev_c_input_table[cc.b]);
-        out.Write("\ttevin_b.a = {} & 255;\n", tev_a_input_table[ac.b]);
+        out.Write("\ttevin_b.rgb = clamp(tevin_b.rgb, int3(0, 0, 0), int3(2550, 2550, 2550));\n");
+        out.Write("\ttevin_b.a = tevin_b.a & 255;\n");
       }
 
       // C
@@ -1554,8 +1659,7 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
       }
       else if (hdr_no_color_c_clamp)
       {
-        out.Write("\ttevin_c = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
-                  tev_c_input_table[cc.c], tev_a_input_table[ac.c]);
+        out.Write("\ttevin_c = clamp(tevin_c, int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n");
       }
       // If the alpha source is from a texture or vertex color, don't clamp it, let it be HDR
       else if (cc.c == TevColorArg::TexColor || cc.c == TevColorArg::RasColor)
@@ -1567,13 +1671,11 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
       // Otherwise force clamp the lerp blend factor
       else
       {
-        out.Write("\ttevin_c.rgb = clamp({}, int3(0, 0, 0), int3(255, 255, 255));\n",
-                  tev_c_input_table[cc.c]);
-        out.Write("\ttevin_c.a = {} & 255;\n", tev_a_input_table[ac.c]);
+        out.Write("\ttevin_c.rgb = clamp(tevin_c.rgb, int3(0, 0, 0), int3(255, 255, 255));\n");
+        out.Write("\ttevin_c.a = tevin_c.a & 255;\n");
 
         // TODO: when to ever force the original case for safety?
-        //out.Write("\ttevin_c = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.c],
-        //          tev_a_input_table[ac.c]);
+        //out.Write("\ttevin_c = tevin_c&int4(255, 255, 255, 255);\n");
       }
     }
   }
@@ -1603,6 +1705,7 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
     out.Write("\t{} = max(", tev_c_output_table[cc.dest]);
   else
     out.Write("\t{} = clamp(", tev_c_output_table[cc.dest]);
+  overwritten_sources.color[(int)cc.dest.Value()] = true;
   if (cc.bias != TevBias::Compare)
   {
     WriteTevRegular(out, "rgb", cc.bias, cc.op, cc.clamp, cc.scale);
@@ -1651,6 +1754,7 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
 
   out.Write("\t// alpha combine\n");
   out.Write("\t{} = clamp(", tev_a_output_table[ac.dest]);
+  overwritten_sources.alpha[(int)ac.dest.Value()] = true;
   if (ac.bias != TevBias::Compare)
   {
     WriteTevRegular(out, "a", ac.bias, ac.op, ac.clamp, ac.scale);
@@ -1902,7 +2006,8 @@ static void WriteFog(ShaderCode& out, const pixel_shader_uid_data* uid_data)
   out.Write("\tprev.rgb = (prev.rgb * (256 - ifog) + " I_FOGCOLOR ".rgb * ifog) >> 8;\n");
 }
 
-static void WriteLogicOp(ShaderCode& out, const pixel_shader_uid_data* uid_data)
+static void WriteLogicOp(ShaderCode& out, const ShaderHostConfig& host_config,
+                         const pixel_shader_uid_data* uid_data)
 {
   static constexpr std::array<const char*, 16> logic_op_mode{
       "int4(0, 0, 0, 0)",          // CLEAR
@@ -1924,6 +2029,11 @@ static void WriteLogicOp(ShaderCode& out, const pixel_shader_uid_data* uid_data)
   };
 
   out.Write("\tint4 fb_value = iround(initial_ocol0 * 255.0);\n");
+  // Prevent overflow with logic ops
+  if (host_config.hdr)
+  {
+    out.Write("\tfb_value = clamp(fb_value, 0, 255);\n");
+  }
   out.Write("\tprev = ({}) & 0xff;\n", logic_op_mode[uid_data->logic_op_mode]);
 }
 
@@ -1939,8 +2049,10 @@ static void WriteLogicOpBlend(ShaderCode& out, const pixel_shader_uid_data* uid_
     // Do nothing!
     break;
   case LogicOp::CopyInverted:
+  {
     out.Write("\tprev ^= 255;\n"); // TODO: HDR support?
     break;
+  }
   case LogicOp::Set:
   case LogicOp::Invert:  // In cooperation with blend
     out.Write("\tprev = int4(255, 255, 255, 255);\n");
@@ -1975,21 +2087,24 @@ static void WriteColor(ShaderCode& out, APIType api_type, const pixel_shader_uid
   {
     out.SetConstantsUsed(C_ALPHA, C_ALPHA);
     out.Write("\tocol0.a = float(" I_ALPHA ".a >> 2) / 63.0;\n");
-
-    // Use dual-source color blending to perform dst alpha in a single pass
-    if (use_dual_source)
-      out.Write("\tocol1 = float4(0.0, 0.0, 0.0, float(prev.a) / 255.0);\n");
   }
   else
   {
     out.Write("\tocol0.a = float(prev.a >> 2) / 63.0;\n");
-    if (use_dual_source)
-      out.Write("\tocol1 = float4(0.0, 0.0, 0.0, float(prev.a) / 255.0);\n");
+  }
+
+  // Use dual-source color blending to perform dst alpha in a single pass
+  if (use_dual_source)
+  {
+    out.Write("\tocol1 = float4(0.0, 0.0, 0.0, float(prev.a) / 255.0);\n");
+    out.Write("\tocol1.a = clamp(ocol1.a, 0.0, 1.0);\n"); // TODO: HDR only. Also, useless??? Doesn't do anything
   }
 }
 
 // TODO: force any dest color subtractions to run through here in HDR, and clamp them to avoid them going negative. Do the same for inv source blends (no need to force SW blends for them).
-static void WriteBlend(ShaderCode& out, const pixel_shader_uid_data* uid_data)
+// With the new updates, we just need to clamp the DEST
+static void WriteBlend(ShaderCode& out, const ShaderHostConfig& host_config,
+                       const pixel_shader_uid_data* uid_data)
 {
   if (uid_data->blend_enable)
   {
@@ -2082,7 +2197,7 @@ void WriteFragmentBody(APIType api_type, const ShaderHostConfig& host_config,
   out.Write("\tint4 c0 = " I_COLORS "[1], c1 = " I_COLORS "[2], c2 = " I_COLORS
             "[3], prev = " I_COLORS "[0];\n"
             "\tint4 rastemp = int4(0, 0, 0, 0), rawtextemp = int4(0, 0, 0, 0), "
-            "textemp = int4(0, 0, 0, 0), konsttemp = int4(0, 0, 0, 0);\n"
+            "textemp = int4(0, 0, 0, 0), konsttemp = int4(0, 0, 0, 0);\n" // TODO: konsttemp is never used?
             "\tint3 comp16 = int3(1, 256, 0), comp24 = int3(1, 256, 256*256);\n"
             "\tint alphabump=0;\n"
             "\tint3 tevcoord=int3(0, 0, 0);\n"
@@ -2162,10 +2277,11 @@ void WriteFragmentBody(APIType api_type, const ShaderHostConfig& host_config,
     }
   }
 
+  OverwrittenTevColorSources overwritten_sources;
   for (u32 i = 0; i < numStages; i++)
   {
     // Build the equation for this stage
-    WriteStage(out, host_config, uid_data, i, api_type, stereo);
+    WriteStage(out, host_config, uid_data, i, api_type, stereo, overwritten_sources);
   }
 
   {
@@ -2182,6 +2298,13 @@ void WriteFragmentBody(APIType api_type, const ShaderHostConfig& host_config,
     if (last_ac.dest != TevOutput::Prev)
     {
       out.Write("\tprev.a = {};\n", tev_a_output_table[last_ac.dest]);
+    }
+
+    // Avoid NaNs which can persist on float textures
+    // Useless
+    if (host_config.hdr)
+    {
+      //out.Write("\tif (isnan(prev.a)) prev.a = 0.0;\n");
     }
   }
 

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -996,6 +996,9 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
   // out.Write("\tivec4 prev = frag_output.main & 255;\n");
   out.Write("\tivec4 prev = frag_output.main;\n");
 
+  // alpha bitmask
+  out.Write("\tprev.a = prev.a & 255;\n");
+
   // NOTE: Fragment may not be discarded if alpha test always fails and early depth test is enabled
   // (in this case we need to write a depth value if depth test passes regardless of the alpha
   // testing result)
@@ -1446,23 +1449,23 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   }
   else
   {
-    out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
+    out.Write("\ttevin_a = int4({}, {});\n", tev_c_input_table[cc.a],
               tev_a_input_table[ac.a]);
-    if (cc.b == TevColorArg::PrevColor)
-      out.Write(
-          "\ttevin_b = int4(min(prev.rgb, int3(255,255,255)), {})&int4(255, 255, 255, 255);\n",
-          tev_a_input_table[ac.b]);
-    else
-      out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
+    //if (cc.b == TevColorArg::PrevColor)
+    //  out.Write(
+    //      "\ttevin_b = int4(min(prev.rgb, int3(255,255,255)), {});\n",
+    //      tev_a_input_table[ac.b]);
+    //else
+      out.Write("\ttevin_b = int4({}, {});\n", tev_c_input_table[cc.b],
                 tev_a_input_table[ac.b]);
 
-    if (cc.c == TevColorArg::PrevColor)
-      out.Write(
-          "\ttevin_c = int4(min(prev.rgb, int3(255,255,255)), {})&int4(255, 255, 255, 255);\n",
-          tev_a_input_table[ac.c]);
+    //if (cc.c == TevColorArg::PrevColor)
+    //  out.Write(
+    //      "\ttevin_c = int4(min(prev.rgb, int3(255,255,255)), {});\n",
+    //      tev_a_input_table[ac.c]);
 
-    else
-      out.Write("\ttevin_c = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.c],
+    //else
+      out.Write("\ttevin_c = int4({}, {});\n", tev_c_input_table[cc.c],
                 tev_a_input_table[ac.c]);
   }
   out.Write("\ttevin_d = int4({}, {});\n", tev_c_input_table[cc.d], tev_a_input_table[ac.d]);

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -727,8 +727,8 @@ uint WrapCoord(int coord, uint wrap, int size) {{
   }
 }
 
-static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, int n,
-                       APIType api_type, bool stereo);
+static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
+                       const pixel_shader_uid_data* uid_data, int n, APIType api_type, bool stereo);
 static void WriteTevRegular(ShaderCode& out, std::string_view components, TevBias bias, TevOp op,
                             bool clamp, TevScale scale);
 static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_data, APIType api_type,
@@ -751,7 +751,7 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 {
   ShaderCode out;
 
-  const bool per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
+  const bool per_pixel_lighting = host_config.per_pixel_lighting;
   const bool msaa = host_config.msaa;
   const bool ssaa = host_config.ssaa;
   const bool stereo = host_config.stereo;
@@ -993,11 +993,18 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   out.Write("\tDolphinFragmentOutput frag_output;\n");
   out.Write("\tprocess_fragment(frag_input, frag_output);\n");
-  // out.Write("\tivec4 prev = frag_output.main & 255;\n");
-  out.Write("\tivec4 prev = frag_output.main;\n");
-
-  // alpha bitmask
-  out.Write("\tprev.a = prev.a & 255;\n");
+  if (host_config.hdr)
+  {
+    out.Write("\tivec4 prev = frag_output.main;\n");
+    // apply bitmask on alpha only
+    //out.Write("\tprev.a = prev.a & 255;\n");
+    // Clamp alpha for extra safety given it could have gone beyond 255
+    out.Write("\tprev.a = clamp(prev.a, 0, 255);\n");
+  }
+  else
+  {
+    out.Write("\tivec4 prev = frag_output.main & 255;\n");
+  }
 
   // NOTE: Fragment may not be discarded if alpha test always fails and early depth test is enabled
   // (in this case we need to write a depth value if depth test passes regardless of the alpha
@@ -1128,7 +1135,8 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
   return out;
 }
 
-static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, int n,
+static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
+                       const pixel_shader_uid_data* uid_data, int n,
                        APIType api_type, bool stereo)
 {
   using Common::EnumMap;
@@ -1371,6 +1379,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   cc.hex = stage.cc;
   ac.hex = stage.ac;
 
+  // TODO: clamp alpha output if it compres from a color input in a swizzle?
   if (cc.a == TevColorArg::RasAlpha || cc.a == TevColorArg::RasColor ||
       cc.b == TevColorArg::RasAlpha || cc.b == TevColorArg::RasColor ||
       cc.c == TevColorArg::RasAlpha || cc.c == TevColorArg::RasColor ||
@@ -1438,7 +1447,57 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   if (ac.dest >= TevOutput::Color0)
     out.SetConstantsUsed(C_COLORS + u32(ac.dest.Value()), C_COLORS + u32(ac.dest.Value()));
 
-  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VECTOR_BITWISE_AND))
+  // TODO: naming and placement
+  // Let HDR colors go up to "infinite", as opposed to a limiter greater range (10x in gamma space, which is huge)
+  constexpr bool hdr_no_color_clamp = false;
+  constexpr bool hdr_no_color_alpha_clamp = false;
+  // Let HDR alpha go beyond 255, which is generally not a good idea given that it can mess up
+  // blends etc
+  constexpr bool hdr_no_alpha_clamp = false;
+
+  if (host_config.hdr)
+  {
+    // TODO: force tighter clamping if cc.op is set to subtraction? Otherwise we could end up with 255-2550 (e.g.)
+    // Always clamp if the source is an alpha. Constants are already 8 bit so need no clamping.
+    // Always clamp the alpha channel.
+    if (cc.a == TevColorArg::PrevAlpha || cc.a == TevColorArg::Alpha0 ||
+        cc.a == TevColorArg::Alpha1 || cc.a == TevColorArg::Alpha2)
+    {
+      out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
+                tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+    }
+    // TODO: test/polish these cases, it's a bit random, especially on alpha, which isn't related to "cc.a"
+    else if (cc.a == TevColorArg::TexAlpha || cc.a == TevColorArg::RasAlpha)
+    {
+      out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
+                tev_a_input_table[ac.a]);
+    }
+    else
+    {
+      out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
+                tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+    }
+    if (cc.b == TevColorArg::PrevAlpha || cc.b == TevColorArg::Alpha0 ||
+        cc.b == TevColorArg::Alpha1 || cc.b == TevColorArg::Alpha2)
+    {
+      out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
+                tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
+    }
+    else if (cc.b == TevColorArg::TexAlpha || cc.b == TevColorArg::RasAlpha)
+    {
+      out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
+                tev_a_input_table[ac.b]);
+    }
+    else
+    {
+      out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
+                tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
+    }
+    // Always force clamp the lerp blend factor
+    out.Write("\ttevin_c = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
+              tev_c_input_table[cc.c], tev_a_input_table[ac.c]);
+  }
+  else if(DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VECTOR_BITWISE_AND))
   {
     out.Write("\ttevin_a = int4({} & 255, {} & 255);\n", tev_c_input_table[cc.a],
               tev_a_input_table[ac.a]);
@@ -1449,29 +1508,18 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   }
   else
   {
-    out.Write("\ttevin_a = int4({}, {});\n", tev_c_input_table[cc.a],
+    out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
               tev_a_input_table[ac.a]);
-    //if (cc.b == TevColorArg::PrevColor)
-    //  out.Write(
-    //      "\ttevin_b = int4(min(prev.rgb, int3(255,255,255)), {});\n",
-    //      tev_a_input_table[ac.b]);
-    //else
-      out.Write("\ttevin_b = int4({}, {});\n", tev_c_input_table[cc.b],
-                tev_a_input_table[ac.b]);
-
-    //if (cc.c == TevColorArg::PrevColor)
-    //  out.Write(
-    //      "\ttevin_c = int4(min(prev.rgb, int3(255,255,255)), {});\n",
-    //      tev_a_input_table[ac.c]);
-
-    //else
-      out.Write("\ttevin_c = int4({}, {});\n", tev_c_input_table[cc.c],
-                tev_a_input_table[ac.c]);
+    out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
+              tev_a_input_table[ac.b]);
+    out.Write("\ttevin_c = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.c],
+              tev_a_input_table[ac.c]);
   }
+  // TODO: clamp to 10x in HDR either way?
   out.Write("\ttevin_d = int4({}, {});\n", tev_c_input_table[cc.d], tev_a_input_table[ac.d]);
 
-  out.Write("\t// color combine (unclamp)?\n");
-  if (cc.clamp)
+  out.Write("\t// color combine\n");
+  if (cc.clamp && host_config.hdr && hdr_no_color_clamp)
     out.Write("\t{} = max(", tev_c_output_table[cc.dest]);
   else
     out.Write("\t{} = clamp(", tev_c_output_table[cc.dest]);
@@ -1481,6 +1529,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   }
   else
   {
+    // TODO: sohould we ever just force clamping/marking for comparisons?
     static constexpr EnumMap<const char*, TevCompareMode::RGB8> tev_rgb_comparison_gt{
         "((tevin_a.r > tevin_b.r) ? tevin_c.rgb : int3(0,0,0))",  // TevCompareMode::R8
         "((idot(tevin_a.rgb, comp16) > idot(tevin_b.rgb, comp16)) ? tevin_c.rgb : int3(0,0,0))",  // GR16
@@ -1500,11 +1549,22 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     else
       out.Write("   tevin_d.rgb + {}", tev_rgb_comparison_gt[cc.compare_mode]);
   }
-  if (cc.clamp)
-    // out.Write(", int3(0,0,0), int3(255,255,255))");
-    out.Write(", int3(0,0,0))");
+  if (host_config.hdr)
+  {
+    if (cc.clamp && hdr_no_color_clamp)
+      out.Write(", int3(0,0,0))");
+    else if (cc.clamp)
+      out.Write(", int3(0,0,0), int3(2550,2550,2550))");
+    else
+      out.Write(", int3(-10240,-10240,-10240), int3(10230,10230,10230))"); // TODO: is it ever good to unclamp this? Probably?
+  }
   else
-    out.Write(", int3(-2550,-2550,-2550), int3(2550,2550,2550))");
+  {
+    if (cc.clamp)
+      out.Write(", int3(0,0,0), int3(255,255,255))");
+    else
+      out.Write(", int3(-1024,-1024,-1024), int3(1023,1023,1023))");
+  }
   out.Write(";\n");
 
   out.Write("\t// alpha combine\n");
@@ -1534,7 +1594,9 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     else
       out.Write("   tevin_d.a + {}", tev_a_comparison_gt[ac.compare_mode]);
   }
-  if (ac.clamp)
+  if (ac.clamp && hdr_no_alpha_clamp)
+    out.Write(", 0, 2550)");
+  else if (ac.clamp)
     out.Write(", 0, 255)");
   else
     out.Write(", -1024, 1023)");
@@ -1586,7 +1648,7 @@ static void WriteTevRegular(ShaderCode& out, std::string_view components, TevBia
   out.Write("(((tevin_d.{}{}){})", components, tev_bias_table[bias], tev_scale_table_left[scale]);
   out.Write(" {} ", tev_op_table[op]);
   out.Write("(((((tevin_a.{0}<<8) + "
-            "(tevin_b.{0}-tevin_a.{0})*(tevin_c.{0}+(tevin_c.{0}>>7))){1}){2})>>8)",
+            "(tevin_b.{0}-tevin_a.{0})*((tevin_c.{0} * 256 + 127) / 255)){1}){2})>>8)",
             components, tev_scale_table_left[scale],
             (scale != TevScale::Divide2) ? tev_lerp_bias[op] : "");
   out.Write("){}", tev_scale_table_right[scale]);
@@ -2018,7 +2080,7 @@ void WriteFragmentBody(APIType api_type, const ShaderHostConfig& host_config,
   for (u32 i = 0; i < numStages; i++)
   {
     // Build the equation for this stage
-    WriteStage(out, uid_data, i, api_type, stereo);
+    WriteStage(out, host_config, uid_data, i, api_type, stereo);
   }
 
   {

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1450,9 +1450,8 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
   // TODO: naming and placement
   // Let HDR colors go up to "infinite", as opposed to a limiter greater range (10x in gamma space, which is huge)
   constexpr bool hdr_no_color_clamp = false;
-  constexpr bool hdr_no_color_alpha_clamp = false; // TODO: implement
-  // Let HDR alpha go beyond 255, which is generally not a good idea given that it can mess up
-  // blends etc
+  constexpr bool hdr_no_color_alpha_clamp = false;
+  // Let HDR alpha go beyond 255, which is generally not a good idea given that it can mess up blends etc
   constexpr bool hdr_no_alpha_clamp = false;
 
   if (host_config.hdr)

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -346,8 +346,7 @@ void WritePixelShaderCommonHeader(ShaderCode& out, APIType api_type,
 
   out.Write("UBO_BINDING(std140, 1) uniform PSBlock {{\n");
 
-  out.Write("\tfloat4 " I_FREELOOK "[4];\n"
-            "\tint4 " I_COLORS "[4];\n"
+  out.Write("\tint4 " I_COLORS "[4];\n"
             "\tint4 " I_KCOLORS "[4];\n"
             "\tint4 " I_ALPHA ";\n"
             "\tint4 " I_TEXDIMS "[8];\n"
@@ -726,16 +725,6 @@ uint WrapCoord(int coord, uint wrap, int size) {{
 }}
 )");
   }
-
-  out.Write("mat4x4 dolphin_freelook_matrix()\n");
-  out.Write("{{\n");
-  out.Write("\tmat4x4 result;\n");
-  out.Write("\tresult[0] = " I_FREELOOK "[0];\n"
-            "\tresult[1] = " I_FREELOOK "[1];\n"
-            "\tresult[2] = " I_FREELOOK "[2];\n"
-            "\tresult[3] = " I_FREELOOK "[3];\n");
-  out.Write("\treturn result;\n");
-  out.Write("}}\n\n");
 }
 
 static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, int n,
@@ -1004,8 +993,7 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   out.Write("\tDolphinFragmentOutput frag_output;\n");
   out.Write("\tprocess_fragment(frag_input, frag_output);\n");
-  // out.Write("\tivec4 prev = frag_output.main & 255;\n");
-  out.Write("\tivec4 prev = frag_output.main;\n");
+  out.Write("\tivec4 prev = frag_output.main & 255;\n");
 
   // NOTE: Fragment may not be discarded if alpha test always fails and early depth test is enabled
   // (in this case we need to write a depth value if depth test passes regardless of the alpha
@@ -1466,11 +1454,8 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   }
   out.Write("\ttevin_d = int4({}, {});\n", tev_c_input_table[cc.d], tev_a_input_table[ac.d]);
 
-  out.Write("\t// color combine (unclamp)?\n");
-  if (cc.clamp)
-    out.Write("\t{} = max(", tev_c_output_table[cc.dest]);
-    else
-    out.Write("\t{} = clamp(", tev_c_output_table[cc.dest]);
+  out.Write("\t// color combine\n");
+  out.Write("\t{} = clamp(", tev_c_output_table[cc.dest]);
   if (cc.bias != TevBias::Compare)
   {
     WriteTevRegular(out, "rgb", cc.bias, cc.op, cc.clamp, cc.scale);
@@ -1497,7 +1482,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
       out.Write("   tevin_d.rgb + {}", tev_rgb_comparison_gt[cc.compare_mode]);
   }
   if (cc.clamp)
-    out.Write(", int3(0,0,0))");
+    out.Write(", int3(0,0,0), int3(255,255,255))");
   else
     out.Write(", int3(-1024,-1024,-1024), int3(1023,1023,1023))");
   out.Write(";\n");

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -905,7 +905,7 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   if (per_pixel_lighting)
   {
-    GenerateLightingShaderHeader(out, uid_data->lighting);
+    GenerateLightingShaderHeader(out, host_config, uid_data->lighting);
   }
 
   WriteFragmentDefinitions(api_type, host_config, uid_data, out);
@@ -945,6 +945,12 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
     // intermediate value with multiple reads & modifications, so we pull out the "real" output
     // value above and use a temporary for calculations, then set the output value once at the
     // end of the shader.
+    out.Write("\tfloat4 ocol0;\n");
+  }
+  else if (false) // TODO...
+  {
+    // Force SW blends. Read the render target value from a copy we just made of it.
+    out.Write("\tfloat4 initial_ocol0 = iround(texelFetch(framebuffer_tex, int3(rawpos.x, rawpos.y, 0), 0) * 255.0);\n");
     out.Write("\tfloat4 ocol0;\n");
   }
 
@@ -996,10 +1002,10 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
   if (host_config.hdr)
   {
     out.Write("\tivec4 prev = frag_output.main;\n");
-    // apply bitmask on alpha only
-    //out.Write("\tprev.a = prev.a & 255;\n");
+    // Apply bitmask on alpha only
+    out.Write("\tprev.a = prev.a & 255;\n");
     // Clamp alpha for extra safety given it could have gone beyond 255
-    out.Write("\tprev.a = clamp(prev.a, 0, 255);\n");
+    //out.Write("\tprev.a = clamp(prev.a, 0, 255);\n"); // TODO
   }
   else
   {
@@ -1112,7 +1118,8 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   WriteFog(out, uid_data);
 
-  if (uid_data->logic_op_enable)
+  // TODO: force clamp to 255 in HDR after certain logic operations?
+  if (uid_data->logic_op_enable)  // Implies "use_framebuffer_fetch"
     WriteLogicOp(out, uid_data);
   else if (uid_data->emulate_logic_op_with_blend)
     WriteLogicOpBlend(out, uid_data);
@@ -1122,7 +1129,7 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
   const bool use_dual_source = !uid_data->no_dual_src || uid_data->blend_enable;
   WriteColor(out, api_type, uid_data, use_dual_source);
 
-  if (uid_data->blend_enable)
+  if (uid_data->blend_enable)  // Implies "use_framebuffer_fetch"
     WriteBlend(out, uid_data);
   else if (use_framebuffer_fetch)
     out.Write("\treal_ocol0 = ocol0;\n");
@@ -1450,6 +1457,9 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
   // TODO: naming and placement
   // Let HDR colors go up to "infinite", as opposed to a limiter greater range (10x in gamma space, which is huge)
   constexpr bool hdr_no_color_clamp = false;
+  // Tev result (d) was already in 10 bit, so widening it might not be necessary, but it should help preserve more range
+  constexpr bool hdr_no_color_d_clamp = true;
+  constexpr bool hdr_no_color_c_clamp = false;
   constexpr bool hdr_no_color_alpha_clamp = false;
   // Let HDR alpha go beyond 255, which is generally not a good idea given that it can mess up blends etc
   constexpr bool hdr_no_alpha_clamp = false;
@@ -1457,9 +1467,7 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
   if (host_config.hdr)
   {
     // TODO: force tighter clamping if cc.op is set to subtraction? Otherwise we could end up with 255-2550 (e.g.)
-    // Always clamp if the source is an alpha. Constants are already 8 bit so need no clamping.
-    // Always clamp the alpha channel.
-    if (!hdr_no_color_alpha_clamp)
+    if (hdr_no_color_alpha_clamp)
     {
         out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 2550));\n",
                   tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
@@ -1470,42 +1478,103 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
     }
     else
     {
-      if (cc.a == TevColorArg::PrevAlpha || cc.a == TevColorArg::Alpha0 ||
-          cc.a == TevColorArg::Alpha1 || cc.a == TevColorArg::Alpha2)
+      // The prev color and color 0, 1 and 2 are the previous tev stage outputs.
+      // If they are read in the first stage, on original HW they'd return
+      // whatever was the last value written on them from a previous pass.
+      // This means they were 10 bit signed, unless the previous stage output was clamped.
+      // The tex and ras colors respectively come from the bound texture and vertex shader,
+      // and are guaranteed to be 0-255.
+
+      // Always clamp if the source is an alpha. Constants are already 8 bit so need no clamping.
+      // Always clamp if the tev op is subtraction, we don't want to make subtractions "stronger"
+      // than they were, or go below 0.
+      // Always clamp the alpha channel.
+
+      // A
+      if (false) // TODO: setting this to "cc.a == TevColorArg::Color1 || cc.a == TevColorArg::Color2" fixes some marios galaxy broken stars
       {
-        out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
-                  tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+        out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
+                  tev_a_input_table[ac.a]);
+      }
+      else if (cc.a == TevColorArg::PrevAlpha || cc.a == TevColorArg::Alpha0 ||
+          cc.a == TevColorArg::Alpha1 || cc.a == TevColorArg::Alpha2 ||
+          cc.a == TevColorArg::TexAlpha || cc.a == TevColorArg::RasAlpha ||
+          cc.op == TevOp::Sub)
+      {
+        out.Write("\ttevin_a.rgb = clamp({}, int3(0, 0, 0), int3(255, 255, 255));\n",
+                  tev_c_input_table[cc.a]);
+        out.Write("\ttevin_a.a = {} & 255;\n", tev_a_input_table[ac.a]);
       }
       // TODO: test/polish these cases, it's a bit random, especially on alpha, which isn't related to "cc.a"
-      else if (cc.a == TevColorArg::TexAlpha || cc.a == TevColorArg::RasAlpha)
+      else if (false)
       {
         out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
                   tev_a_input_table[ac.a]);
       }
       else
       {
-        out.Write("\ttevin_a = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
-                  tev_c_input_table[cc.a], tev_a_input_table[ac.a]);
+        out.Write("\ttevin_a.rgb = clamp({}, int3(0, 0, 0), int3(2550, 2550, 2550));\n",
+                  tev_c_input_table[cc.a]);
+        out.Write("\ttevin_a.a = {} & 255;\n", tev_a_input_table[ac.a]);
+        //out.Write("\ttevin_a.a = clamp({}, 0, 255);\n", tev_a_input_table[ac.a]); // TODO: try hdr_no_color_alpha_clamp
       }
-      if (cc.b == TevColorArg::PrevAlpha || cc.b == TevColorArg::Alpha0 ||
-          cc.b == TevColorArg::Alpha1 || cc.b == TevColorArg::Alpha2)
+
+      // B
+      if (false)
       {
-        out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
-                  tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
+        out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
+                  tev_a_input_table[ac.b]);
       }
-      else if (cc.b == TevColorArg::TexAlpha || cc.b == TevColorArg::RasAlpha)
+      else if (cc.b == TevColorArg::PrevAlpha || cc.b == TevColorArg::Alpha0 ||
+          cc.b == TevColorArg::Alpha1 || cc.b == TevColorArg::Alpha2 ||
+          cc.b == TevColorArg::TexAlpha || cc.b == TevColorArg::RasAlpha ||
+          cc.op == TevOp::Sub)
+      {
+        out.Write("\ttevin_b.rgb = clamp({}, int3(0, 0, 0), int3(255, 255, 255));\n",
+                  tev_c_input_table[cc.b]);
+        out.Write("\ttevin_b.a = {} & 255;\n", tev_a_input_table[ac.b]);
+      }
+      else if (false)
       {
         out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
                   tev_a_input_table[ac.b]);
       }
       else
       {
-        out.Write("\ttevin_b = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n",
-                  tev_c_input_table[cc.b], tev_a_input_table[ac.b]);
+        out.Write("\ttevin_b.rgb = clamp({}, int3(0, 0, 0), int3(2550, 2550, 2550));\n",
+                  tev_c_input_table[cc.b]);
+        out.Write("\ttevin_b.a = {} & 255;\n", tev_a_input_table[ac.b]);
       }
-      // Always force clamp the lerp blend factor
-      out.Write("\ttevin_c = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
-                tev_c_input_table[cc.c], tev_a_input_table[ac.c]);
+
+      // C
+      if (false)
+      {
+        out.Write("\ttevin_c = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.c],
+                  tev_a_input_table[ac.c]);
+      }
+      else if (hdr_no_color_c_clamp)
+      {
+        out.Write("\ttevin_c = clamp(int4({}, {}), int4(0, 0, 0, 0), int4(255, 255, 255, 255));\n",
+                  tev_c_input_table[cc.c], tev_a_input_table[ac.c]);
+      }
+      // If the alpha source is from a texture or vertex color, don't clamp it, let it be HDR
+      else if (cc.c == TevColorArg::TexColor || cc.c == TevColorArg::RasColor)
+      {
+        out.Write("\ttevin_c.rgb = clamp({}, int3(0, 0, 0), int3(2550, 2550, 2550));\n",
+                  tev_c_input_table[cc.c]);
+        out.Write("\ttevin_c.a = {} & 255;\n", tev_a_input_table[ac.c]);
+      }
+      // Otherwise force clamp the lerp blend factor
+      else
+      {
+        out.Write("\ttevin_c.rgb = clamp({}, int3(0, 0, 0), int3(255, 255, 255));\n",
+                  tev_c_input_table[cc.c]);
+        out.Write("\ttevin_c.a = {} & 255;\n", tev_a_input_table[ac.c]);
+
+        // TODO: when to ever force the original case for safety?
+        //out.Write("\ttevin_c = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.c],
+        //          tev_a_input_table[ac.c]);
+      }
     }
   }
   else if(DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VECTOR_BITWISE_AND))
@@ -1526,7 +1595,7 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
     out.Write("\ttevin_c = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.c],
               tev_a_input_table[ac.c]);
   }
-  // TODO: clamp to 10x in HDR either way?
+  // TODO: clamp to 10x in HDR either way? Given it might have ended up being huge in HDR
   out.Write("\ttevin_d = int4({}, {});\n", tev_c_input_table[cc.d], tev_a_input_table[ac.d]);
 
   out.Write("\t// color combine\n");
@@ -1566,8 +1635,10 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
       out.Write(", int3(0,0,0))");
     else if (cc.clamp)
       out.Write(", int3(0,0,0), int3(2550,2550,2550))");
+    else if (hdr_no_color_d_clamp)
+      out.Write(", int3(-10240,-10240,-10240), int3(10230,10230,10230))"); // TODO: is it ever good to unclamp this? Probably? See "tev_scale_table_left"
     else
-      out.Write(", int3(-10240,-10240,-10240), int3(10230,10230,10230))"); // TODO: is it ever good to unclamp this? Probably?
+      out.Write(", int3(-1024,-1024,-1024), int3(1023,1023,1023))");
   }
   else
   {
@@ -1609,6 +1680,8 @@ static void WriteStage(ShaderCode& out, const ShaderHostConfig& host_config,
     out.Write(", 0, 2550)");
   else if (ac.clamp)
     out.Write(", 0, 255)");
+  else if (hdr_no_alpha_clamp)
+    out.Write(", -10240, 10230)");
   else
     out.Write(", -1024, 1023)");
 
@@ -1649,7 +1722,7 @@ static void WriteTevRegular(ShaderCode& out, std::string_view components, TevBia
       '-',  // TevOp::Sub = 1,
   };
 
-  // Regular TEV stage: (d + bias + lerp(a,b,c)) * scale
+  // Regular TEV stage: (((d + d_bias) * d_scale) +/- lerp(a,b,c)) * scale
   // The GameCube/Wii GPU uses a very sophisticated algorithm for scale-lerping:
   // - c is scaled from 0..255 to 0..256, which allows dividing the result by 256 instead of 255
   // - if scale is bigger than one, it is moved inside the lerp calculation for increased accuracy
@@ -1866,7 +1939,7 @@ static void WriteLogicOpBlend(ShaderCode& out, const pixel_shader_uid_data* uid_
     // Do nothing!
     break;
   case LogicOp::CopyInverted:
-    out.Write("\tprev ^= 255;\n");
+    out.Write("\tprev ^= 255;\n"); // TODO: HDR support?
     break;
   case LogicOp::Set:
   case LogicOp::Invert:  // In cooperation with blend
@@ -1915,6 +1988,7 @@ static void WriteColor(ShaderCode& out, APIType api_type, const pixel_shader_uid
   }
 }
 
+// TODO: force any dest color subtractions to run through here in HDR, and clamp them to avoid them going negative. Do the same for inv source blends (no need to force SW blends for them).
 static void WriteBlend(ShaderCode& out, const pixel_shader_uid_data* uid_data)
 {
   if (uid_data->blend_enable)

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1501,7 +1501,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     // out.Write(", int3(0,0,0), int3(255,255,255))");
     out.Write(", int3(0,0,0))");
   else
-    out.Write(", int3(-2550,-2550,2-550), int3(2550,2550,2550))");
+    out.Write(", int3(-2550,-2550,-2550), int3(2550,2550,2550))");
   out.Write(";\n");
 
   out.Write("\t// alpha combine\n");

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -993,7 +993,8 @@ ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& hos
 
   out.Write("\tDolphinFragmentOutput frag_output;\n");
   out.Write("\tprocess_fragment(frag_input, frag_output);\n");
-  out.Write("\tivec4 prev = frag_output.main & 255;\n");
+  // out.Write("\tivec4 prev = frag_output.main & 255;\n");
+  out.Write("\tivec4 prev = frag_output.main;\n");
 
   // NOTE: Fragment may not be discarded if alpha test always fails and early depth test is enabled
   // (in this case we need to write a depth value if depth test passes regardless of the alpha
@@ -1454,8 +1455,11 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   }
   out.Write("\ttevin_d = int4({}, {});\n", tev_c_input_table[cc.d], tev_a_input_table[ac.d]);
 
-  out.Write("\t// color combine\n");
-  out.Write("\t{} = clamp(", tev_c_output_table[cc.dest]);
+  out.Write("\t// color combine (unclamp)?\n");
+  if (cc.clamp)
+    out.Write("\t{} = max(", tev_c_output_table[cc.dest]);
+  else
+    out.Write("\t{} = clamp(", tev_c_output_table[cc.dest]);
   if (cc.bias != TevBias::Compare)
   {
     WriteTevRegular(out, "rgb", cc.bias, cc.op, cc.clamp, cc.scale);
@@ -1482,7 +1486,8 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
       out.Write("   tevin_d.rgb + {}", tev_rgb_comparison_gt[cc.compare_mode]);
   }
   if (cc.clamp)
-    out.Write(", int3(0,0,0), int3(255,255,255))");
+    // out.Write(", int3(0,0,0), int3(255,255,255))");
+    out.Write(", int3(0,0,0))");
   else
     out.Write(", int3(-1024,-1024,-1024), int3(1023,1023,1023))");
   out.Write(";\n");

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1448,10 +1448,22 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
   {
     out.Write("\ttevin_a = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.a],
               tev_a_input_table[ac.a]);
-    out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
-              tev_a_input_table[ac.b]);
-    out.Write("\ttevin_c = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.c],
-              tev_a_input_table[ac.c]);
+    if (cc.b == TevColorArg::PrevColor)
+      out.Write(
+          "\ttevin_b = int4(min(prev.rgb, int3(255,255,255)), {})&int4(255, 255, 255, 255);\n",
+          tev_a_input_table[ac.b]);
+    else
+      out.Write("\ttevin_b = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.b],
+                tev_a_input_table[ac.b]);
+
+    if (cc.c == TevColorArg::PrevColor)
+      out.Write(
+          "\ttevin_c = int4(min(prev.rgb, int3(255,255,255)), {})&int4(255, 255, 255, 255);\n",
+          tev_a_input_table[ac.c]);
+
+    else
+      out.Write("\ttevin_c = int4({}, {})&int4(255, 255, 255, 255);\n", tev_c_input_table[cc.c],
+                tev_a_input_table[ac.c]);
   }
   out.Write("\ttevin_d = int4({}, {});\n", tev_c_input_table[cc.d], tev_a_input_table[ac.d]);
 
@@ -1489,7 +1501,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
     // out.Write(", int3(0,0,0), int3(255,255,255))");
     out.Write(", int3(0,0,0))");
   else
-    out.Write(", int3(-1024,-1024,-1024), int3(1023,1023,1023))");
+    out.Write(", int3(-2550,-2550,2-550), int3(2550,2550,2550))");
   out.Write(";\n");
 
   out.Write("\t// alpha combine\n");

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -61,6 +61,7 @@ struct pixel_shader_uid_data
   u32 emulate_logic_op_with_blend : 1;        // Only used with logic op blend emulation
   u32 logic_op_enable : 1;                    // Only used with shader_framebuffer_fetch logic ops
   u32 logic_op_mode : 4;  // Only used with shader_framebuffer_fetch logic ops and blend emulation
+  u32 force_clamp_color : 1;  // Useful to clamp rgb if HDR is enabled and HW blend uses INVSRCCLR
 
   u32 texMtxInfo_n_projection : 8;  // 8x1 bit
   u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -635,8 +635,10 @@ std::string PostProcessing::GetUniformBufferHeader(bool user_post_process) const
   ss << "  float sdr_display_custom_gamma;\n";
   ss << "  int linear_space_output;\n";
   ss << "  int hdr_output;\n";
+  ss << "  int hdr_render;\n";
   ss << "  float hdr_paper_white_nits;\n";
   ss << "  float hdr_sdr_white_nits;\n";
+  ss << "  float peak_white_nits;\n";
 
   if (user_post_process)
   {
@@ -854,8 +856,10 @@ struct BuiltinUniforms
   float sdr_display_custom_gamma;
   s32 linear_space_output;
   s32 hdr_output;
+  s32 hdr_render;
   float hdr_paper_white_nits;
   float hdr_sdr_white_nits;
+  float peak_white_nits;
 };
 
 size_t PostProcessing::CalculateUniformsSize(bool user_post_process) const
@@ -909,9 +913,11 @@ void PostProcessing::FillUniformBuffer(const MathUtil::Rectangle<int>& src,
   builtin_uniforms.linear_space_output = m_framebuffer_format == AbstractTextureFormat::RGBA16F;
   // Implies output values can be beyond the 0-1 range
   builtin_uniforms.hdr_output = m_framebuffer_format == AbstractTextureFormat::RGBA16F;
+  builtin_uniforms.hdr_render = g_ActiveConfig.bHDRRender;
   builtin_uniforms.hdr_paper_white_nits = g_ActiveConfig.color_correction.fHDRPaperWhiteNits;
   // A value of 1 1 1 usually matches 80 nits in HDR
   builtin_uniforms.hdr_sdr_white_nits = 80.f;
+  builtin_uniforms.peak_white_nits = builtin_uniforms.hdr_output ? 1000.f : builtin_uniforms.hdr_sdr_white_nits; // TODO: merge PR to detect peak brightness
 
   std::memcpy(buffer, &builtin_uniforms, sizeof(builtin_uniforms));
   buffer += sizeof(builtin_uniforms);

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -916,9 +916,10 @@ void PostProcessing::FillUniformBuffer(const MathUtil::Rectangle<int>& src,
   builtin_uniforms.hdr_output = m_framebuffer_format == AbstractTextureFormat::RGBA16F;
   builtin_uniforms.hdr_render = g_ActiveConfig.bHDRRender;
   builtin_uniforms.hdr_paper_white_nits = g_ActiveConfig.color_correction.fHDRPaperWhiteNits;
-  // A value of 1 1 1 usually matches 80 nits in HDR
+  // A value of 1 1 1 usually matches 80 nits (sRGB standard) in HDR
   builtin_uniforms.hdr_sdr_white_nits = 80.f;
-  builtin_uniforms.peak_white_nits = builtin_uniforms.hdr_output ? 1000.f : builtin_uniforms.hdr_sdr_white_nits; // TODO: merge PR to detect peak brightness
+  builtin_uniforms.peak_white_nits = builtin_uniforms.hdr_output
+    ? g_backend_info.hdr_peak_white_nits : builtin_uniforms.hdr_sdr_white_nits;
 
   std::memcpy(buffer, &builtin_uniforms, sizeof(builtin_uniforms));
   buffer += sizeof(builtin_uniforms);

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -495,8 +495,9 @@ void PostProcessing::BlitFromTexture(const MathUtil::Rectangle<int>& dst,
   // (it might not be gamma corrected).
   const bool needs_resampling =
       g_ActiveConfig.output_resampling_mode > OutputResamplingMode::Default;
+  const bool needs_tonemap = g_ActiveConfig.bHDRRender;
   const bool needs_intermediary_buffer = NeedsIntermediaryBuffer();
-  const bool needs_default_pipeline = needs_color_correction || needs_resampling;
+  const bool needs_default_pipeline = needs_color_correction || needs_resampling || needs_tonemap;
   const AbstractPipeline* final_pipeline = m_pipeline.get();
   std::vector<u8>* uniform_staging_buffer = &m_default_uniform_staging_buffer;
   bool default_uniform_staging_buffer = true;

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -1312,7 +1312,7 @@ const AbstractPipeline* ShaderCache::GetEFBCopyToRAMPipeline(const EFBCopyParams
   config.rasterization_state = RenderState::GetNoCullRasterizationState(PrimitiveType::Triangles);
   config.depth_state = RenderState::GetNoDepthTestingDepthState();
   config.blending_state = RenderState::GetNoBlendingBlendState();
-  config.framebuffer_state = RenderState::GetColorFramebufferState(AbstractTextureFormat::BGRA8);
+  config.framebuffer_state = RenderState::GetColorFramebufferState(AbstractTextureFormat::BGRA8); // TODO: HDR?
   config.usage = AbstractPipelineUsage::Utility;
   auto iiter = m_efb_copy_to_ram_pipelines.emplace(uid, g_gfx->CreatePipeline(config));
   return iiter.first->second.get();

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -45,6 +45,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.backend_dynamic_vertex_loader = g_backend_info.bSupportsDynamicVertexLoader;
   bits.backend_vs_point_line_expand = g_ActiveConfig.UseVSForLinePointExpand();
   bits.backend_gl_layer_in_fs = g_backend_info.bSupportsGLLayerInFS;
+  bits.hdr = g_ActiveConfig.bHDRRender;
   return bits;
 }
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -179,6 +179,7 @@ union ShaderHostConfig
   BitField<27, 1, bool, u32> backend_dynamic_vertex_loader;
   BitField<28, 1, bool, u32> backend_vs_point_line_expand;
   BitField<29, 1, bool, u32> backend_gl_layer_in_fs;
+  BitField<30, 1, bool, u32> hdr;
 
   static ShaderHostConfig GetCurrent();
 };

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -41,8 +41,7 @@
 #include "VideoCommon/Assets/TextureAssetUtils.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/FramebufferManager.h"
-#include "VideoCommon/GraphicsModSystem/Runtime/FBInfo.h"
-#include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionData.h"
+#include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModBackend.h"
 #include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.h"
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/PixelShaderManager.h"
@@ -136,6 +135,31 @@ void TextureCacheBase::Invalidate()
 {
   FlushEFBCopies();
   TMEM::InvalidateAll();
+
+  if (g_ActiveConfig.bGraphicMods)
+  {
+    auto& system = Core::System::GetInstance();
+    auto& mod_manager = system.GetGraphicsModManager();
+    for (auto& tex : m_textures_by_address)
+    {
+      const auto& entry = tex.second;
+      if (entry->is_efb_copy)
+      {
+        mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::EFB,
+                                                 entry->texture_info_name);
+      }
+      else if (entry->is_xfb_copy)
+      {
+        mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::XFB,
+                                                 entry->texture_info_name);
+      }
+      else
+      {
+        mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::Normal,
+                                                 entry->texture_info_name);
+      }
+    }
+  }
 
   for (auto& bind : m_bound_textures)
     bind.reset();
@@ -401,7 +425,7 @@ void TextureCacheBase::ScaleTextureCacheEntryTo(RcTcacheEntry& entry, u32 new_wi
   }
 
   const TextureConfig newconfig(new_width, new_height, 1, entry->GetNumLayers(), 1,
-                                AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget,
+                                FramebufferManager::GetEFBColorFormat(), AbstractTextureFlag_RenderTarget,
                                 AbstractTextureType::Texture_2DArray);
   std::optional<TexPoolEntry> new_texture = AllocateTexture(newconfig);
   if (!new_texture)
@@ -1282,16 +1306,21 @@ TCacheEntry* TextureCacheBase::LoadImpl(u32 stage, bool force_reload)
     return nullptr;
 
   entry->frameCount = FRAMECOUNT_INVALID;
-  if (entry->texture_info_name.empty() && g_ActiveConfig.bGraphicMods)
+  if (g_ActiveConfig.bGraphicMods)
   {
-    entry->texture_info_name = texture_info.CalculateTextureName().GetFullName();
-
-    GraphicsModActionData::TextureLoad texture_load{entry->texture_info_name};
-    for (const auto& action :
-         g_graphics_mod_manager->GetTextureLoadActions(entry->texture_info_name))
+    if (entry->texture_info_name.empty())
     {
-      action->OnTextureLoad(&texture_load);
+      entry->texture_info_name = texture_info.CalculateTextureName().GetFullName();
     }
+
+    GraphicsModSystem::TextureView texture;
+    texture.hash_name = entry->texture_info_name;
+    texture.texture_data = entry->texture.get();
+    texture.texture_type = GraphicsModSystem::TextureType::Normal;
+    texture.unit = texture_info.GetStage();
+    auto& system = Core::System::GetInstance();
+    auto& mod_manager = system.GetGraphicsModManager();
+    mod_manager.GetBackend().OnTextureLoad(texture);
   }
   m_bound_textures[texture_info.GetStage()] = entry;
 
@@ -1583,28 +1612,25 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     }
   }
 
-  std::string texture_name = "";
-
-  if (g_ActiveConfig.bGraphicMods)
-  {
-    u32 height = texture_info.GetRawHeight();
-    u32 width = texture_info.GetRawWidth();
-    texture_name = texture_info.CalculateTextureName().GetFullName();
-    GraphicsModActionData::TextureCreate texture_create{texture_name, width, height, nullptr,
-                                                        nullptr};
-    for (const auto& action : g_graphics_mod_manager->GetTextureCreateActions(texture_name))
-    {
-      action->OnTextureCreate(&texture_create);
-    }
-  }
-
   auto entry =
       CreateTextureEntry(TextureCreationInfo{base_hash, full_hash, bytes_per_block, palette_size},
                          texture_info, textureCacheSafetyColorSampleSize, custom_texture_data.get(),
                          has_arbitrary_mipmaps, skip_texture_dump);
   entry->hires_texture = std::move(hires_texture);
   entry->last_load_time = load_time;
-  entry->texture_info_name = std::move(texture_name);
+  if (g_ActiveConfig.bGraphicMods)
+  {
+    entry->texture_info_name = texture_info.CalculateTextureName().GetFullName();
+
+    GraphicsModSystem::TextureView texture;
+    texture.hash_name = entry->texture_info_name;
+    texture.texture_data = entry->texture.get();
+    texture.texture_type = GraphicsModSystem::TextureType::Normal;
+    texture.unit = texture_info.GetStage();
+    auto& system = Core::System::GetInstance();
+    auto& mod_manager = system.GetGraphicsModManager();
+    mod_manager.GetBackend().OnTextureCreate(texture);
+  }
   return entry;
 }
 
@@ -1722,8 +1748,6 @@ RcTcacheEntry TextureCacheBase::CreateTextureEntry(
 
     for (const auto& mip_level : texture_info.GetMipMapLevels())
     {
-      if (no_mips)
-        break;
       if (!mip_level.IsDataValid())
       {
         ERROR_LOG_FMT(VIDEO, "Trying to use an invalid mipmap address {:#010x}",
@@ -1846,9 +1870,10 @@ RcTcacheEntry TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height
   }
 
   // Create a new VRAM texture, and fill it with the data from guest RAM.
-  entry = AllocateCacheEntry(TextureConfig(width, height, 1, 1, 1, AbstractTextureFormat::RGBA8,
-                                           AbstractTextureFlag_RenderTarget,
-                                           AbstractTextureType::Texture_2DArray));
+  entry = AllocateCacheEntry(TextureConfig(width, height, 1, 1, 1,
+                                            FramebufferManager::GetEFBColorFormat(),
+                                            AbstractTextureFlag_RenderTarget,
+                                            AbstractTextureType::Texture_2DArray));
 
   entry->SetGeneralParameters(address, total_size,
                               TextureAndTLUTFormat(TextureFormat::XFB, TLUTFormat::IA8), true);
@@ -2248,36 +2273,6 @@ void TextureCacheBase::CopyRenderTargetToTexture(
     return;
   }
 
-  if (g_ActiveConfig.bGraphicMods)
-  {
-    FBInfo info;
-    info.m_width = tex_w;
-    info.m_height = tex_h;
-    info.m_texture_format = baseFormat;
-    if (is_xfb_copy)
-    {
-      for (const auto& action : g_graphics_mod_manager->GetXFBActions(info))
-      {
-        action->BeforeXFB();
-      }
-    }
-    else
-    {
-      bool skip = false;
-      GraphicsModActionData::PreEFB efb{tex_w, tex_h, &skip, &scaled_tex_w, &scaled_tex_h};
-      for (const auto& action : g_graphics_mod_manager->GetEFBActions(info))
-      {
-        action->BeforeEFB(&efb);
-      }
-      if (skip == true)
-      {
-        if (copy_to_ram)
-          UninitializeEFBMemory(dst, dstStride, bytes_per_row, num_blocks_y);
-        return;
-      }
-    }
-  }
-
   if (dstStride < bytes_per_row)
   {
     // This kind of efb copy results in a scrambled image.
@@ -2305,8 +2300,9 @@ void TextureCacheBase::CopyRenderTargetToTexture(
   {
     // create the texture
     const TextureConfig config(scaled_tex_w, scaled_tex_h, 1, g_framebuffer_manager->GetEFBLayers(),
-                               1, AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget,
-                               AbstractTextureType::Texture_2DArray);
+                                1, FramebufferManager::GetEFBColorFormat(),
+                                AbstractTextureFlag_RenderTarget,
+                                AbstractTextureType::Texture_2DArray);
     entry = AllocateCacheEntry(config);
     if (entry)
     {
@@ -2329,29 +2325,9 @@ void TextureCacheBase::CopyRenderTargetToTexture(
                           isIntensity, gamma, clamp_top, clamp_bottom,
                           GetVRAMCopyFilterCoefficients(filter_coefficients));
 
-      if (g_ActiveConfig.bGraphicMods)
-      {
-        FBInfo info;
-        info.m_width = tex_w;
-        info.m_height = tex_h;
-        info.m_texture_format = baseFormat;
-        if (!is_xfb_copy)
-        {
-          GraphicsModActionData::PostEFB efb;
-          for (const auto& action : g_graphics_mod_manager->GetEFBActions(info))
-          {
-            action->AfterEFB(&efb);
-            if (efb.material)
-            {
-              ApplyMaterialToCacheEntry(*efb.material, entry.get());
-            }
-          }
-        }
-      }
-
       if (is_xfb_copy && (g_ActiveConfig.bDumpXFBTarget || g_ActiveConfig.bGraphicMods))
       {
-        const std::string id = fmt::format("{}x{}", tex_w, tex_h);
+        const std::string id = fmt::format("n{:06}_{}x{}", xfb_count++, tex_w, tex_h);
         if (g_ActiveConfig.bGraphicMods)
         {
           entry->texture_info_name = fmt::format("{}_{}", XFB_DUMP_PREFIX, id);
@@ -2359,9 +2335,8 @@ void TextureCacheBase::CopyRenderTargetToTexture(
 
         if (g_ActiveConfig.bDumpXFBTarget)
         {
-          entry->texture->Save(fmt::format("{}{}_n{:06}_{}.png",
-                                           File::GetUserPath(D_DUMPTEXTURES_IDX), XFB_DUMP_PREFIX,
-                                           xfb_count++, id),
+          entry->texture->Save(fmt::format("{}{}_{}.png", File::GetUserPath(D_DUMPTEXTURES_IDX),
+                                           XFB_DUMP_PREFIX, id),
                                0);
         }
       }
@@ -2381,6 +2356,23 @@ void TextureCacheBase::CopyRenderTargetToTexture(
                                            efb_count++, id),
                                0);
         }
+      }
+
+      if (g_ActiveConfig.bGraphicMods)
+      {
+        GraphicsModSystem::TextureView texture;
+        texture.hash_name = entry->texture_info_name;
+        texture.texture_data = entry->texture.get();
+        if (is_xfb_copy)
+        {
+          texture.texture_type = GraphicsModSystem::TextureType::XFB;
+        }
+        else
+        {
+          texture.texture_type = GraphicsModSystem::TextureType::EFB;
+        }
+        auto& mod_manager = system.GetGraphicsModManager();
+        mod_manager.GetBackend().OnTextureCreate(texture);
       }
     }
   }
@@ -2427,6 +2419,37 @@ void TextureCacheBase::CopyRenderTargetToTexture(
       UninitializeEFBMemory(dst, dstStride, bytes_per_row, num_blocks_y);
     }
   }
+
+  InvalideOverlappingTextures(dstStride, dstAddr, bytes_per_row, num_blocks_y, copy_to_vram,
+                              copy_to_ram);
+
+  if (OpcodeDecoder::g_record_fifo_data)
+  {
+    // Mark the memory behind this efb copy as dynamicly generated for the Fifo log
+    u32 address = dstAddr;
+    for (u32 i = 0; i < num_blocks_y; i++)
+    {
+      Core::System::GetInstance().GetFifoRecorder().UseMemory(address, bytes_per_row,
+                                                              MemoryUpdate::Type::TextureMap, true);
+      address += dstStride;
+    }
+  }
+
+  // Even if the copy is deferred, still compute the hash. This way if the copy is used as a texture
+  // in a subsequent draw before it is flushed, it will have the same hash.
+  if (entry)
+  {
+    const u64 hash = entry->CalculateHash();
+    entry->SetHashes(hash, hash);
+    m_textures_by_address.emplace(dstAddr, std::move(entry));
+  }
+}
+
+void TextureCacheBase::InvalideOverlappingTextures(u32 dstStride, u32 dstAddr, u32 bytes_per_row,
+                                                   u32 num_blocks_y, bool copy_to_vram,
+                                                   bool copy_to_ram)
+{
+  const u32 covered_range = num_blocks_y * dstStride;
 
   // Invalidate all textures, if they are either fully overwritten by our efb copy, or if they
   // have a different stride than our efb copy. Partly overwritten textures with the same stride
@@ -2489,27 +2512,6 @@ void TextureCacheBase::CopyRenderTargetToTexture(
       }
     }
     ++iter.first;
-  }
-
-  if (OpcodeDecoder::g_record_fifo_data)
-  {
-    // Mark the memory behind this efb copy as dynamically generated for the Fifo log
-    u32 address = dstAddr;
-    for (u32 i = 0; i < num_blocks_y; i++)
-    {
-      Core::System::GetInstance().GetFifoRecorder().UseMemory(address, bytes_per_row,
-                                                              MemoryUpdate::Type::TextureMap, true);
-      address += dstStride;
-    }
-  }
-
-  // Even if the copy is deferred, still compute the hash. This way if the copy is used as a texture
-  // in a subsequent draw before it is flushed, it will have the same hash.
-  if (entry)
-  {
-    const u64 hash = entry->CalculateHash();
-    entry->SetHashes(hash, hash);
-    m_textures_by_address.emplace(dstAddr, std::move(entry));
   }
 }
 
@@ -2760,6 +2762,30 @@ TextureCacheBase::InvalidateTexture(TexAddrCache::iterator iter, bool discard_pe
     return m_textures_by_address.end();
 
   RcTcacheEntry& entry = iter->second;
+
+  if (g_ActiveConfig.bGraphicMods)
+  {
+    auto& system = Core::System::GetInstance();
+    auto& mod_manager = system.GetGraphicsModManager();
+    if (entry->is_efb_copy)
+    {
+      if (entry->pending_efb_copy && discard_pending_efb_copy)
+      {
+        mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::EFB,
+                                                 entry->texture_info_name);
+      }
+    }
+    else if (entry->is_xfb_copy)
+    {
+      mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::XFB,
+                                               entry->texture_info_name);
+    }
+    else
+    {
+      mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::Normal,
+                                               entry->texture_info_name);
+    }
+  }
 
   if (entry->textures_by_hash_iter != m_textures_by_hash.end())
   {
@@ -3053,110 +3079,6 @@ bool TextureCacheBase::DecodeTextureOnGPU(RcTcacheEntry& entry, u32 dst_level, c
                                            dst_level);
   entry->texture->FinishedRendering();
   return true;
-}
-
-void TextureCacheBase::ApplyMaterialToCacheEntry(const VideoCommon::MaterialResource& material,
-                                                 TCacheEntry* entry)
-{
-  const auto material_data = material.GetData();
-  if (!material_data) [[unlikely]]
-    return;
-
-  // Make a copy, we can't write to our texture and use its framebuffer
-  // at the same time
-  auto new_entry = AllocateCacheEntry(entry->texture->GetConfig());
-  new_entry->SetGeneralParameters(entry->addr, entry->size_in_bytes, entry->format,
-                                  entry->should_force_safe_hashing);
-  new_entry->SetDimensions(entry->native_width, entry->native_height, 1);
-  new_entry->SetEfbCopy(entry->memory_stride);
-  new_entry->may_have_overlapping_textures = false;
-  new_entry->frameCount = FRAMECOUNT_INVALID;
-
-  g_gfx->BeginUtilityDrawing();
-  entry->texture->FinishedRendering();
-
-  const auto custom_uniforms = material_data->GetUniforms();
-
-  // Set up uniforms.
-  // TODO: this struct should be shared with post processing
-  struct Uniforms
-  {
-    std::array<float, 4> source_resolution;
-    std::array<float, 4> target_resolution;
-    std::array<float, 4> window_resolution;
-    std::array<float, 4> source_rectangle;
-    s32 source_layer;
-    s32 source_layer_pad[3];
-    u32 time;
-    u32 time_pad[3];
-    s32 graphics_api;
-    s32 graphics_api_pad[3];
-    u32 efb_scale;
-    u32 efb_scale_pad[3];
-  } uniforms;
-
-  const float rcp_src_width = 1.0f / entry->texture->GetWidth();
-  const float rcp_src_height = 1.0f / entry->texture->GetHeight();
-
-  uniforms.source_resolution = {static_cast<float>(entry->texture->GetWidth()),
-                                static_cast<float>(entry->texture->GetHeight()), rcp_src_width,
-                                rcp_src_height};
-
-  // The target resolution is the same here, since we're
-  // injecting into the texture
-  uniforms.target_resolution = uniforms.source_resolution;
-
-  const auto present_rect = g_presenter->GetTargetRectangle();
-  uniforms.window_resolution = {static_cast<float>(present_rect.GetWidth()),
-                                static_cast<float>(present_rect.GetHeight()),
-                                1.0f / static_cast<float>(present_rect.GetWidth()),
-                                1.0f / static_cast<float>(present_rect.GetHeight())};
-
-  uniforms.source_rectangle = {0, 0, 1, 1};
-  uniforms.source_layer = 0;
-  uniforms.time = 0;
-  uniforms.graphics_api = static_cast<s32>(g_backend_info.api_type);
-  uniforms.efb_scale = g_framebuffer_manager->GetEFBScale();
-
-  Common::UniqueBuffer<u8> uniform_buffer(custom_uniforms.size() + sizeof(uniforms));
-  std::memcpy(uniform_buffer.data(), &uniforms, sizeof(uniforms));
-  std::memcpy(uniform_buffer.data() + sizeof(uniforms), custom_uniforms.data(),
-              custom_uniforms.size());
-  g_vertex_manager->UploadUtilityUniforms(uniform_buffer.data(),
-                                          static_cast<u32>(uniform_buffer.size()));
-
-  // Set framebuffer and viewport based on new entry
-  g_gfx->SetAndDiscardFramebuffer(new_entry->framebuffer.get());
-  g_gfx->SetViewportAndScissor(new_entry->framebuffer->GetRect());
-  g_gfx->SetPipeline(material_data->GetPipeline());
-
-  g_gfx->SetTexture(0, entry->texture.get());
-  g_gfx->SetSamplerState(0, RenderState::GetPointSamplerState());
-
-  for (const auto texture : material_data->GetTextures())
-  {
-    g_gfx->SetTexture(texture.sampler_index, texture.texture);
-    g_gfx->SetSamplerState(texture.sampler_index, texture.sampler);
-  }
-
-  g_gfx->Draw(0, 3);
-  g_gfx->EndUtilityDrawing();
-
-  // Finish rendering new entry
-  new_entry->texture->FinishedRendering();
-
-  // Swap new entry and existing entry
-  std::swap(entry->texture, new_entry->texture);
-  std::swap(entry->framebuffer, new_entry->framebuffer);
-
-  // Return old entry to pool for use in another pass
-  // or future functionality
-  ReleaseToPool(new_entry.get());
-
-  if (auto* const next_material = material_data->GetNextMaterial(); next_material)
-  {
-    ApplyMaterialToCacheEntry(*next_material, entry);
-  }
 }
 
 u32 TCacheEntry::BytesPerRow() const

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2392,7 +2392,8 @@ void TextureCacheBase::CopyRenderTargetToTexture(
     PixelFormat srcFormat = bpmem.zcontrol.pixel_format;
     EFBCopyParams format(srcFormat, dstFormat, is_depth_copy, isIntensity,
                          AllCopyFilterCoefsNeeded(coefficients),
-                         CopyFilterCanOverflow(coefficients), gamma != 1.0);
+                         CopyFilterCanOverflow(coefficients), gamma != 1.0,
+                         g_ActiveConfig.bHDRRender);
 
     std::unique_ptr<AbstractStagingTexture> staging_texture = GetEFBCopyStagingTexture();
     if (staging_texture)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -41,7 +41,8 @@
 #include "VideoCommon/Assets/TextureAssetUtils.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/FramebufferManager.h"
-#include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModBackend.h"
+#include "VideoCommon/GraphicsModSystem/Runtime/FBInfo.h"
+#include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModActionData.h"
 #include "VideoCommon/GraphicsModSystem/Runtime/GraphicsModManager.h"
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/PixelShaderManager.h"
@@ -135,31 +136,6 @@ void TextureCacheBase::Invalidate()
 {
   FlushEFBCopies();
   TMEM::InvalidateAll();
-
-  if (g_ActiveConfig.bGraphicMods)
-  {
-    auto& system = Core::System::GetInstance();
-    auto& mod_manager = system.GetGraphicsModManager();
-    for (auto& tex : m_textures_by_address)
-    {
-      const auto& entry = tex.second;
-      if (entry->is_efb_copy)
-      {
-        mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::EFB,
-                                                 entry->texture_info_name);
-      }
-      else if (entry->is_xfb_copy)
-      {
-        mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::XFB,
-                                                 entry->texture_info_name);
-      }
-      else
-      {
-        mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::Normal,
-                                                 entry->texture_info_name);
-      }
-    }
-  }
 
   for (auto& bind : m_bound_textures)
     bind.reset();
@@ -425,7 +401,7 @@ void TextureCacheBase::ScaleTextureCacheEntryTo(RcTcacheEntry& entry, u32 new_wi
   }
 
   const TextureConfig newconfig(new_width, new_height, 1, entry->GetNumLayers(), 1,
-                                FramebufferManager::GetEFBColorFormat(), AbstractTextureFlag_RenderTarget,
+                                AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget,
                                 AbstractTextureType::Texture_2DArray);
   std::optional<TexPoolEntry> new_texture = AllocateTexture(newconfig);
   if (!new_texture)
@@ -1306,21 +1282,16 @@ TCacheEntry* TextureCacheBase::LoadImpl(u32 stage, bool force_reload)
     return nullptr;
 
   entry->frameCount = FRAMECOUNT_INVALID;
-  if (g_ActiveConfig.bGraphicMods)
+  if (entry->texture_info_name.empty() && g_ActiveConfig.bGraphicMods)
   {
-    if (entry->texture_info_name.empty())
-    {
-      entry->texture_info_name = texture_info.CalculateTextureName().GetFullName();
-    }
+    entry->texture_info_name = texture_info.CalculateTextureName().GetFullName();
 
-    GraphicsModSystem::TextureView texture;
-    texture.hash_name = entry->texture_info_name;
-    texture.texture_data = entry->texture.get();
-    texture.texture_type = GraphicsModSystem::TextureType::Normal;
-    texture.unit = texture_info.GetStage();
-    auto& system = Core::System::GetInstance();
-    auto& mod_manager = system.GetGraphicsModManager();
-    mod_manager.GetBackend().OnTextureLoad(texture);
+    GraphicsModActionData::TextureLoad texture_load{entry->texture_info_name};
+    for (const auto& action :
+         g_graphics_mod_manager->GetTextureLoadActions(entry->texture_info_name))
+    {
+      action->OnTextureLoad(&texture_load);
+    }
   }
   m_bound_textures[texture_info.GetStage()] = entry;
 
@@ -1612,25 +1583,28 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     }
   }
 
+  std::string texture_name = "";
+
+  if (g_ActiveConfig.bGraphicMods)
+  {
+    u32 height = texture_info.GetRawHeight();
+    u32 width = texture_info.GetRawWidth();
+    texture_name = texture_info.CalculateTextureName().GetFullName();
+    GraphicsModActionData::TextureCreate texture_create{texture_name, width, height, nullptr,
+                                                        nullptr};
+    for (const auto& action : g_graphics_mod_manager->GetTextureCreateActions(texture_name))
+    {
+      action->OnTextureCreate(&texture_create);
+    }
+  }
+
   auto entry =
       CreateTextureEntry(TextureCreationInfo{base_hash, full_hash, bytes_per_block, palette_size},
                          texture_info, textureCacheSafetyColorSampleSize, custom_texture_data.get(),
                          has_arbitrary_mipmaps, skip_texture_dump);
   entry->hires_texture = std::move(hires_texture);
   entry->last_load_time = load_time;
-  if (g_ActiveConfig.bGraphicMods)
-  {
-    entry->texture_info_name = texture_info.CalculateTextureName().GetFullName();
-
-    GraphicsModSystem::TextureView texture;
-    texture.hash_name = entry->texture_info_name;
-    texture.texture_data = entry->texture.get();
-    texture.texture_type = GraphicsModSystem::TextureType::Normal;
-    texture.unit = texture_info.GetStage();
-    auto& system = Core::System::GetInstance();
-    auto& mod_manager = system.GetGraphicsModManager();
-    mod_manager.GetBackend().OnTextureCreate(texture);
-  }
+  entry->texture_info_name = std::move(texture_name);
   return entry;
 }
 
@@ -1748,6 +1722,8 @@ RcTcacheEntry TextureCacheBase::CreateTextureEntry(
 
     for (const auto& mip_level : texture_info.GetMipMapLevels())
     {
+      if (no_mips)
+        break;
       if (!mip_level.IsDataValid())
       {
         ERROR_LOG_FMT(VIDEO, "Trying to use an invalid mipmap address {:#010x}",
@@ -1870,10 +1846,9 @@ RcTcacheEntry TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height
   }
 
   // Create a new VRAM texture, and fill it with the data from guest RAM.
-  entry = AllocateCacheEntry(TextureConfig(width, height, 1, 1, 1,
-                                            FramebufferManager::GetEFBColorFormat(),
-                                            AbstractTextureFlag_RenderTarget,
-                                            AbstractTextureType::Texture_2DArray));
+  entry = AllocateCacheEntry(TextureConfig(width, height, 1, 1, 1, AbstractTextureFormat::RGBA8,
+                                           AbstractTextureFlag_RenderTarget,
+                                           AbstractTextureType::Texture_2DArray));
 
   entry->SetGeneralParameters(address, total_size,
                               TextureAndTLUTFormat(TextureFormat::XFB, TLUTFormat::IA8), true);
@@ -2273,6 +2248,36 @@ void TextureCacheBase::CopyRenderTargetToTexture(
     return;
   }
 
+  if (g_ActiveConfig.bGraphicMods)
+  {
+    FBInfo info;
+    info.m_width = tex_w;
+    info.m_height = tex_h;
+    info.m_texture_format = baseFormat;
+    if (is_xfb_copy)
+    {
+      for (const auto& action : g_graphics_mod_manager->GetXFBActions(info))
+      {
+        action->BeforeXFB();
+      }
+    }
+    else
+    {
+      bool skip = false;
+      GraphicsModActionData::PreEFB efb{tex_w, tex_h, &skip, &scaled_tex_w, &scaled_tex_h};
+      for (const auto& action : g_graphics_mod_manager->GetEFBActions(info))
+      {
+        action->BeforeEFB(&efb);
+      }
+      if (skip == true)
+      {
+        if (copy_to_ram)
+          UninitializeEFBMemory(dst, dstStride, bytes_per_row, num_blocks_y);
+        return;
+      }
+    }
+  }
+
   if (dstStride < bytes_per_row)
   {
     // This kind of efb copy results in a scrambled image.
@@ -2300,9 +2305,8 @@ void TextureCacheBase::CopyRenderTargetToTexture(
   {
     // create the texture
     const TextureConfig config(scaled_tex_w, scaled_tex_h, 1, g_framebuffer_manager->GetEFBLayers(),
-                                1, FramebufferManager::GetEFBColorFormat(),
-                                AbstractTextureFlag_RenderTarget,
-                                AbstractTextureType::Texture_2DArray);
+                               1, AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget,
+                               AbstractTextureType::Texture_2DArray);
     entry = AllocateCacheEntry(config);
     if (entry)
     {
@@ -2325,9 +2329,29 @@ void TextureCacheBase::CopyRenderTargetToTexture(
                           isIntensity, gamma, clamp_top, clamp_bottom,
                           GetVRAMCopyFilterCoefficients(filter_coefficients));
 
+      if (g_ActiveConfig.bGraphicMods)
+      {
+        FBInfo info;
+        info.m_width = tex_w;
+        info.m_height = tex_h;
+        info.m_texture_format = baseFormat;
+        if (!is_xfb_copy)
+        {
+          GraphicsModActionData::PostEFB efb;
+          for (const auto& action : g_graphics_mod_manager->GetEFBActions(info))
+          {
+            action->AfterEFB(&efb);
+            if (efb.material)
+            {
+              ApplyMaterialToCacheEntry(*efb.material, entry.get());
+            }
+          }
+        }
+      }
+
       if (is_xfb_copy && (g_ActiveConfig.bDumpXFBTarget || g_ActiveConfig.bGraphicMods))
       {
-        const std::string id = fmt::format("n{:06}_{}x{}", xfb_count++, tex_w, tex_h);
+        const std::string id = fmt::format("{}x{}", tex_w, tex_h);
         if (g_ActiveConfig.bGraphicMods)
         {
           entry->texture_info_name = fmt::format("{}_{}", XFB_DUMP_PREFIX, id);
@@ -2335,8 +2359,9 @@ void TextureCacheBase::CopyRenderTargetToTexture(
 
         if (g_ActiveConfig.bDumpXFBTarget)
         {
-          entry->texture->Save(fmt::format("{}{}_{}.png", File::GetUserPath(D_DUMPTEXTURES_IDX),
-                                           XFB_DUMP_PREFIX, id),
+          entry->texture->Save(fmt::format("{}{}_n{:06}_{}.png",
+                                           File::GetUserPath(D_DUMPTEXTURES_IDX), XFB_DUMP_PREFIX,
+                                           xfb_count++, id),
                                0);
         }
       }
@@ -2356,23 +2381,6 @@ void TextureCacheBase::CopyRenderTargetToTexture(
                                            efb_count++, id),
                                0);
         }
-      }
-
-      if (g_ActiveConfig.bGraphicMods)
-      {
-        GraphicsModSystem::TextureView texture;
-        texture.hash_name = entry->texture_info_name;
-        texture.texture_data = entry->texture.get();
-        if (is_xfb_copy)
-        {
-          texture.texture_type = GraphicsModSystem::TextureType::XFB;
-        }
-        else
-        {
-          texture.texture_type = GraphicsModSystem::TextureType::EFB;
-        }
-        auto& mod_manager = system.GetGraphicsModManager();
-        mod_manager.GetBackend().OnTextureCreate(texture);
       }
     }
   }
@@ -2419,37 +2427,6 @@ void TextureCacheBase::CopyRenderTargetToTexture(
       UninitializeEFBMemory(dst, dstStride, bytes_per_row, num_blocks_y);
     }
   }
-
-  InvalideOverlappingTextures(dstStride, dstAddr, bytes_per_row, num_blocks_y, copy_to_vram,
-                              copy_to_ram);
-
-  if (OpcodeDecoder::g_record_fifo_data)
-  {
-    // Mark the memory behind this efb copy as dynamicly generated for the Fifo log
-    u32 address = dstAddr;
-    for (u32 i = 0; i < num_blocks_y; i++)
-    {
-      Core::System::GetInstance().GetFifoRecorder().UseMemory(address, bytes_per_row,
-                                                              MemoryUpdate::Type::TextureMap, true);
-      address += dstStride;
-    }
-  }
-
-  // Even if the copy is deferred, still compute the hash. This way if the copy is used as a texture
-  // in a subsequent draw before it is flushed, it will have the same hash.
-  if (entry)
-  {
-    const u64 hash = entry->CalculateHash();
-    entry->SetHashes(hash, hash);
-    m_textures_by_address.emplace(dstAddr, std::move(entry));
-  }
-}
-
-void TextureCacheBase::InvalideOverlappingTextures(u32 dstStride, u32 dstAddr, u32 bytes_per_row,
-                                                   u32 num_blocks_y, bool copy_to_vram,
-                                                   bool copy_to_ram)
-{
-  const u32 covered_range = num_blocks_y * dstStride;
 
   // Invalidate all textures, if they are either fully overwritten by our efb copy, or if they
   // have a different stride than our efb copy. Partly overwritten textures with the same stride
@@ -2512,6 +2489,27 @@ void TextureCacheBase::InvalideOverlappingTextures(u32 dstStride, u32 dstAddr, u
       }
     }
     ++iter.first;
+  }
+
+  if (OpcodeDecoder::g_record_fifo_data)
+  {
+    // Mark the memory behind this efb copy as dynamically generated for the Fifo log
+    u32 address = dstAddr;
+    for (u32 i = 0; i < num_blocks_y; i++)
+    {
+      Core::System::GetInstance().GetFifoRecorder().UseMemory(address, bytes_per_row,
+                                                              MemoryUpdate::Type::TextureMap, true);
+      address += dstStride;
+    }
+  }
+
+  // Even if the copy is deferred, still compute the hash. This way if the copy is used as a texture
+  // in a subsequent draw before it is flushed, it will have the same hash.
+  if (entry)
+  {
+    const u64 hash = entry->CalculateHash();
+    entry->SetHashes(hash, hash);
+    m_textures_by_address.emplace(dstAddr, std::move(entry));
   }
 }
 
@@ -2762,30 +2760,6 @@ TextureCacheBase::InvalidateTexture(TexAddrCache::iterator iter, bool discard_pe
     return m_textures_by_address.end();
 
   RcTcacheEntry& entry = iter->second;
-
-  if (g_ActiveConfig.bGraphicMods)
-  {
-    auto& system = Core::System::GetInstance();
-    auto& mod_manager = system.GetGraphicsModManager();
-    if (entry->is_efb_copy)
-    {
-      if (entry->pending_efb_copy && discard_pending_efb_copy)
-      {
-        mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::EFB,
-                                                 entry->texture_info_name);
-      }
-    }
-    else if (entry->is_xfb_copy)
-    {
-      mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::XFB,
-                                               entry->texture_info_name);
-    }
-    else
-    {
-      mod_manager.GetBackend().OnTextureUnload(GraphicsModSystem::TextureType::Normal,
-                                               entry->texture_info_name);
-    }
-  }
 
   if (entry->textures_by_hash_iter != m_textures_by_hash.end())
   {
@@ -3079,6 +3053,110 @@ bool TextureCacheBase::DecodeTextureOnGPU(RcTcacheEntry& entry, u32 dst_level, c
                                            dst_level);
   entry->texture->FinishedRendering();
   return true;
+}
+
+void TextureCacheBase::ApplyMaterialToCacheEntry(const VideoCommon::MaterialResource& material,
+                                                 TCacheEntry* entry)
+{
+  const auto material_data = material.GetData();
+  if (!material_data) [[unlikely]]
+    return;
+
+  // Make a copy, we can't write to our texture and use its framebuffer
+  // at the same time
+  auto new_entry = AllocateCacheEntry(entry->texture->GetConfig());
+  new_entry->SetGeneralParameters(entry->addr, entry->size_in_bytes, entry->format,
+                                  entry->should_force_safe_hashing);
+  new_entry->SetDimensions(entry->native_width, entry->native_height, 1);
+  new_entry->SetEfbCopy(entry->memory_stride);
+  new_entry->may_have_overlapping_textures = false;
+  new_entry->frameCount = FRAMECOUNT_INVALID;
+
+  g_gfx->BeginUtilityDrawing();
+  entry->texture->FinishedRendering();
+
+  const auto custom_uniforms = material_data->GetUniforms();
+
+  // Set up uniforms.
+  // TODO: this struct should be shared with post processing
+  struct Uniforms
+  {
+    std::array<float, 4> source_resolution;
+    std::array<float, 4> target_resolution;
+    std::array<float, 4> window_resolution;
+    std::array<float, 4> source_rectangle;
+    s32 source_layer;
+    s32 source_layer_pad[3];
+    u32 time;
+    u32 time_pad[3];
+    s32 graphics_api;
+    s32 graphics_api_pad[3];
+    u32 efb_scale;
+    u32 efb_scale_pad[3];
+  } uniforms;
+
+  const float rcp_src_width = 1.0f / entry->texture->GetWidth();
+  const float rcp_src_height = 1.0f / entry->texture->GetHeight();
+
+  uniforms.source_resolution = {static_cast<float>(entry->texture->GetWidth()),
+                                static_cast<float>(entry->texture->GetHeight()), rcp_src_width,
+                                rcp_src_height};
+
+  // The target resolution is the same here, since we're
+  // injecting into the texture
+  uniforms.target_resolution = uniforms.source_resolution;
+
+  const auto present_rect = g_presenter->GetTargetRectangle();
+  uniforms.window_resolution = {static_cast<float>(present_rect.GetWidth()),
+                                static_cast<float>(present_rect.GetHeight()),
+                                1.0f / static_cast<float>(present_rect.GetWidth()),
+                                1.0f / static_cast<float>(present_rect.GetHeight())};
+
+  uniforms.source_rectangle = {0, 0, 1, 1};
+  uniforms.source_layer = 0;
+  uniforms.time = 0;
+  uniforms.graphics_api = static_cast<s32>(g_backend_info.api_type);
+  uniforms.efb_scale = g_framebuffer_manager->GetEFBScale();
+
+  Common::UniqueBuffer<u8> uniform_buffer(custom_uniforms.size() + sizeof(uniforms));
+  std::memcpy(uniform_buffer.data(), &uniforms, sizeof(uniforms));
+  std::memcpy(uniform_buffer.data() + sizeof(uniforms), custom_uniforms.data(),
+              custom_uniforms.size());
+  g_vertex_manager->UploadUtilityUniforms(uniform_buffer.data(),
+                                          static_cast<u32>(uniform_buffer.size()));
+
+  // Set framebuffer and viewport based on new entry
+  g_gfx->SetAndDiscardFramebuffer(new_entry->framebuffer.get());
+  g_gfx->SetViewportAndScissor(new_entry->framebuffer->GetRect());
+  g_gfx->SetPipeline(material_data->GetPipeline());
+
+  g_gfx->SetTexture(0, entry->texture.get());
+  g_gfx->SetSamplerState(0, RenderState::GetPointSamplerState());
+
+  for (const auto texture : material_data->GetTextures())
+  {
+    g_gfx->SetTexture(texture.sampler_index, texture.texture);
+    g_gfx->SetSamplerState(texture.sampler_index, texture.sampler);
+  }
+
+  g_gfx->Draw(0, 3);
+  g_gfx->EndUtilityDrawing();
+
+  // Finish rendering new entry
+  new_entry->texture->FinishedRendering();
+
+  // Swap new entry and existing entry
+  std::swap(entry->texture, new_entry->texture);
+  std::swap(entry->framebuffer, new_entry->framebuffer);
+
+  // Return old entry to pool for use in another pass
+  // or future functionality
+  ReleaseToPool(new_entry.get());
+
+  if (auto* const next_material = material_data->GetNextMaterial(); next_material)
+  {
+    ApplyMaterialToCacheEntry(*next_material, entry);
+  }
 }
 
 u32 TCacheEntry::BytesPerRow() const

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2814,7 +2814,7 @@ void TextureCacheBase::ReleaseToPool(TCacheEntry* entry)
 bool TextureCacheBase::CreateUtilityTextures()
 {
   constexpr TextureConfig encoding_texture_config(
-      EFB_WIDTH * 4, 1024, 1, 1, 1, AbstractTextureFormat::BGRA8, AbstractTextureFlag_RenderTarget,
+      EFB_WIDTH * 4, 1024, 1, 1, 1, AbstractTextureFormat::BGRA8, AbstractTextureFlag_RenderTarget, // TODO: HDR? And below too?
       AbstractTextureType::Texture_2DArray);
   m_efb_encoding_texture = g_gfx->CreateTexture(encoding_texture_config, "EFB encoding texture");
   if (!m_efb_encoding_texture)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -401,7 +401,7 @@ void TextureCacheBase::ScaleTextureCacheEntryTo(RcTcacheEntry& entry, u32 new_wi
   }
 
   const TextureConfig newconfig(new_width, new_height, 1, entry->GetNumLayers(), 1,
-                                AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget,
+                                FramebufferManager::GetEFBColorFormat(), AbstractTextureFlag_RenderTarget,
                                 AbstractTextureType::Texture_2DArray);
   std::optional<TexPoolEntry> new_texture = AllocateTexture(newconfig);
   if (!new_texture)
@@ -1846,7 +1846,7 @@ RcTcacheEntry TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height
   }
 
   // Create a new VRAM texture, and fill it with the data from guest RAM.
-  entry = AllocateCacheEntry(TextureConfig(width, height, 1, 1, 1, AbstractTextureFormat::RGBA8,
+  entry = AllocateCacheEntry(TextureConfig(width, height, 1, 1, 1, FramebufferManager::GetEFBColorFormat(),
                                            AbstractTextureFlag_RenderTarget,
                                            AbstractTextureType::Texture_2DArray));
 
@@ -2305,7 +2305,8 @@ void TextureCacheBase::CopyRenderTargetToTexture(
   {
     // create the texture
     const TextureConfig config(scaled_tex_w, scaled_tex_h, 1, g_framebuffer_manager->GetEFBLayers(),
-                               1, AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget,
+                               1, FramebufferManager::GetEFBColorFormat(),
+                               AbstractTextureFlag_RenderTarget,
                                AbstractTextureType::Texture_2DArray);
     entry = AllocateCacheEntry(config);
     if (entry)

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -73,10 +73,11 @@ struct EFBCopyParams
 {
   EFBCopyParams(PixelFormat efb_format_, EFBCopyFormat copy_format_, bool depth_, bool yuv_,
                 bool all_copy_filter_coefs_needed_, bool copy_filter_can_overflow_,
-                bool apply_gamma_)
+                bool apply_gamma_, bool hdr_)
       : efb_format(efb_format_), copy_format(copy_format_), depth(depth_), yuv(yuv_),
         all_copy_filter_coefs_needed(all_copy_filter_coefs_needed_),
-        copy_filter_can_overflow(copy_filter_can_overflow_), apply_gamma(apply_gamma_)
+        copy_filter_can_overflow(copy_filter_can_overflow_), apply_gamma(apply_gamma_),
+        hdr(hdr_)
   {
   }
 
@@ -84,9 +85,9 @@ struct EFBCopyParams
   {
     return std::tie(efb_format, copy_format, depth, yuv, all_copy_filter_coefs_needed,
                     copy_filter_can_overflow,
-                    apply_gamma) < std::tie(rhs.efb_format, rhs.copy_format, rhs.depth, rhs.yuv,
-                                            rhs.all_copy_filter_coefs_needed,
-                                            rhs.copy_filter_can_overflow, rhs.apply_gamma);
+                    apply_gamma, hdr) < std::tie(rhs.efb_format, rhs.copy_format, rhs.depth,
+                                            rhs.yuv, rhs.all_copy_filter_coefs_needed,
+                                            rhs.copy_filter_can_overflow, rhs.apply_gamma, rhs.hdr);
   }
 
   PixelFormat efb_format;
@@ -96,6 +97,7 @@ struct EFBCopyParams
   bool all_copy_filter_coefs_needed;
   bool copy_filter_can_overflow;
   bool apply_gamma;
+  bool hdr;
 };
 
 template <>
@@ -112,9 +114,9 @@ struct fmt::formatter<EFBCopyParams>
       copy_format = fmt::to_string(uid.copy_format);
     return fmt::format_to(ctx.out(),
                           "format: {}, copy format: {}, depth: {}, yuv: {}, apply_gamma: {}, "
-                          "all_copy_filter_coefs_needed: {}, copy_filter_can_overflow: {}",
+                          "all_copy_filter_coefs_needed: {}, copy_filter_can_overflow: {}, hdr: {}",
                           uid.efb_format, copy_format, uid.depth, uid.yuv, uid.apply_gamma,
-                          uid.all_copy_filter_coefs_needed, uid.copy_filter_can_overflow);
+                          uid.all_copy_filter_coefs_needed, uid.copy_filter_can_overflow, uid.hdr);
   }
 };
 

--- a/Source/Core/VideoCommon/TextureConfig.h
+++ b/Source/Core/VideoCommon/TextureConfig.h
@@ -74,7 +74,7 @@ struct TextureConfig
   u32 levels = 1;
   u32 layers = 1;
   u32 samples = 1;
-  AbstractTextureFormat format = AbstractTextureFormat::RGBA8;
+  AbstractTextureFormat format = AbstractTextureFormat::BGRA8;  // Do not rely on this default!
   u32 flags = 0;
   AbstractTextureType type = AbstractTextureType::Texture_2DArray;
 };

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -136,6 +136,7 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
     code.Write("  return uint4(tex_sample * 255.0);\n"
                "}}\n");
   }
+
   // The copy filter applies to both color and depth copies. This has been verified on hardware.
   // The filter is only applied to the RGB channels, the alpha channel is left intact.
   code.Write("float4 SampleEFB(float2 uv, float2 pixel_size, int x_offset)\n"
@@ -162,7 +163,7 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
     code.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  // code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (params.apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -159,12 +159,18 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
              "  // that sum to 64 result in no change in brightness\n"
              "  uint4 texcol_raw = uint4(combined_rows.rgb >> 6, current_row.a);\n");
 
-  if (params.copy_filter_can_overflow)
+  // TODO: HDR needed for XFB? Maybe not
+  bool skip_clamp = !params.depth && params.hdr && params.efb_format == PixelFormat::RGB8_Z24 &&
+      (params.copy_format == EFBCopyFormat::RGBA8 || params.copy_format == EFBCopyFormat::XFB);
+
+  if (params.copy_filter_can_overflow && !skip_clamp)
     code.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  code.Write("  texcol_raw = min(texcol_raw, uint4(2550, 2550, 2550, 255));\n"); // TODO: HDR branch (which also implies re-triggering shaders compilation)!
-  //code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  if (skip_clamp)
+    code.Write("  texcol_raw = min(texcol_raw, uint4(2550, 2550, 2550, 255));\n");
+  else
+    code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (params.apply_gamma)
   {
@@ -172,6 +178,7 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
                "                     float4(gamma_rcp, gamma_rcp, gamma_rcp, 1.0)) * 255.0));\n");
   }
 
+  // TODO: add support for HDR? Does it work already? There's other similar places too
   if (params.yuv)
   {
     code.Write("  // Intensity/YUV format conversion constants determined by hardware testing\n"

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -807,6 +807,7 @@ static const std::map<TextureFormat, DecodingShaderInfo> s_decoding_shader_info{
       }
 
       )"}},
+    // TODO: HDR?
     {TextureFormat::RGBA8,
      {TEXEL_BUFFER_FORMAT_R16_UINT, 0, 8, 8, false,
       R"(

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -78,7 +78,8 @@ static void WriteHeader(ShaderCode& code, APIType api_type)
   // Alpha channel in the copy is set to 1 the EFB format does not have an alpha channel.
   code.Write("float4 RGBA8ToRGB8(float4 src)\n"
              "{{\n"
-             "  return float4(src.xyz, 1.0);\n"
+             // Force rounding to support FLOAT textures
+             "  return float4(roundEven(src.xyz * 255.0) / 255.0, 1.0);\n"
              "}}\n"
 
              "float4 RGBA8ToRGBA6(float4 src)\n"

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -163,7 +163,8 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
     code.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  // code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  code.Write("  texcol_raw = min(texcol_raw, uint4(2550, 2550, 2550, 255));\n"); // TODO: HDR branch (which also implies re-triggering shaders compilation)!
+  //code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (params.apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -163,7 +163,7 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
     code.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  // code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (params.apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -136,7 +136,6 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
     code.Write("  return uint4(tex_sample * 255.0);\n"
                "}}\n");
   }
-
   // The copy filter applies to both color and depth copies. This has been verified on hardware.
   // The filter is only applied to the RGB channels, the alpha channel is left intact.
   code.Write("float4 SampleEFB(float2 uv, float2 pixel_size, int x_offset)\n"
@@ -163,7 +162,7 @@ static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, A
     code.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  // code.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (params.apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -161,7 +161,7 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
     out.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  // out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (uid_data->apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -161,7 +161,8 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
     out.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+
+  // out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (uid_data->apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -48,6 +48,7 @@ TCShaderUid GetShaderUid(EFBCopyFormat dst_format, bool is_depth_copy, bool is_i
   uid_data->copy_filter_can_overflow = TextureCacheBase::CopyFilterCanOverflow(filter_coefficients);
   // If the gamma is needed, then include that too.
   uid_data->apply_gamma = gamma_rcp != 1.0f;
+  uid_data->hdr = g_ActiveConfig.bHDRRender; // TODO: do we need to force a shader refresh if this changes?
 
   return out;
 }
@@ -157,12 +158,16 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
             "  uint4 texcol_raw = uint4(combined_rows.rgb >> 6, {});\n",
             uid_data->efb_has_alpha ? "current_row.a" : "255");
 
-  if (uid_data->copy_filter_can_overflow)
+  bool skip_clamp = !uid_data->is_depth_copy && uid_data->hdr;
+
+  if (uid_data->copy_filter_can_overflow && !skip_clamp)
     out.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  out.Write("  texcol_raw = min(texcol_raw, uint4(2550, 2550, 2550, 255));\n"); // TODO: HDR branch (which also implies re-triggering shaders compilation)!
-  //out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  if (skip_clamp)
+    out.Write("  texcol_raw = min(texcol_raw, uint4(2550, 2550, 2550, 255));\n");
+  else
+    out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (uid_data->apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -119,7 +119,7 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
   }
   else
   {
-    out.Write("  return uint4(tex_sample * 255.0);\n"
+    out.Write("  return uint4(tex_sample * 255.0 + 0.5);\n"
               "}}\n");
   }
 

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -161,8 +161,8 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
     out.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-
-  // out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  out.Write("  texcol_raw = min(texcol_raw, uint4(2550, 2550, 2550, 255));\n"); // TODO: HDR branch (which also implies re-triggering shaders compilation)!
+  //out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (uid_data->apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -161,7 +161,7 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
     out.Write("  texcol_raw &= 0x1ffu;\n");
   // Note that overflow occurs when the sum of values is >= 128, but this max situation can be hit
   // on >= 64, so we always include it.
-  out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
+  // out.Write("  texcol_raw = min(texcol_raw, uint4(255, 255, 255, 255));\n");
 
   if (uid_data->apply_gamma)
   {

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.h
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.h
@@ -28,6 +28,7 @@ struct UidData
   u32 all_copy_filter_coefs_needed : 1;
   u32 copy_filter_can_overflow : 1;
   u32 apply_gamma : 1;
+  u32 hdr : 1;
 };
 #pragma pack()
 
@@ -57,9 +58,9 @@ struct fmt::formatter<TextureConversionShaderGen::UidData>
     return fmt::format_to(ctx.out(),
                           "dst_format: {}, efb_has_alpha: {}, is_depth_copy: {}, is_intensity: {}, "
                           "scale_by_half: {}, all_copy_filter_coefs_needed: {}, "
-                          "copy_filter_can_overflow: {}, apply_gamma: {}",
+                          "copy_filter_can_overflow: {}, apply_gamma: {}, hdr: {}",
                           dst_format, uid.efb_has_alpha, uid.is_depth_copy, uid.is_intensity,
                           uid.scale_by_half, uid.all_copy_filter_coefs_needed,
-                          uid.copy_filter_can_overflow, uid.apply_gamma);
+                          uid.copy_filter_can_overflow, uid.apply_gamma, uid.hdr);
   }
 };

--- a/Source/Core/VideoCommon/UberShaderCommon.cpp
+++ b/Source/Core/VideoCommon/UberShaderCommon.cpp
@@ -146,10 +146,10 @@ void WriteVertexLighting(ShaderCode& out, APIType api_type, std::string_view wor
             "  }}\n"
             "\n");
 
-  out.Write("  lacc = clamp(lacc, 0, 255);\n"
+  out.Write("  lacc = clamp(lacc, 0, 2550);\n"
             "\n"
             "  // Hopefully GPUs that can support dynamic indexing will optimize this.\n"
-            "  float4 lit_color = float4((mat * (lacc + (lacc >> 7))) >> 8) / 255.0;\n"
+            "  float4 lit_color = float4((mat * ((lacc * 256 + 127) / 255)) >> 8) / 255.0;\n"
             "  switch (chan) {{\n"
             "  case 0u: {} = lit_color; break;\n",
             out_color_0_var);

--- a/Source/Core/VideoCommon/UberShaderCommon.cpp
+++ b/Source/Core/VideoCommon/UberShaderCommon.cpp
@@ -146,7 +146,7 @@ void WriteVertexLighting(ShaderCode& out, APIType api_type, std::string_view wor
             "  }}\n"
             "\n");
 
-  out.Write("  lacc = clamp(lacc, 0, 2550);\n"
+  out.Write("  lacc = clamp(lacc, int4(0, 0, 0, 0), int4(2550, 2550, 2550, 255));\n"
             "\n"
             "  // Hopefully GPUs that can support dynamic indexing will optimize this.\n"
             "  float4 lit_color = float4((mat * ((lacc * 256 + 127) / 255)) >> 8) / 255.0;\n"

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -811,15 +811,16 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
   out.Write("      uint color_dest = {};\n",
             BitfieldExtract<&TevStageCombiner::ColorCombiner::dest>("ss.cc"));
 
+  // TODO: either implement HDR here too or let it not work
   out.Write(
       "      uint color_compare_op = color_scale << 1 | uint(color_op);\n"
       "\n"
       "      int3 color_A = selectColorInput(s, ss, {0}colors_0, {0}colors_1, color_a) & "
-      "int3(255, 255, 255);\n"
+      "int3(2550, 2550, 2550);\n"
       "      int3 color_B = selectColorInput(s, ss, {0}colors_0, {0}colors_1, color_b) & "
-      "int3(255, 255, 255);\n"
+      "int3(2550, 2550, 2550);\n"
       "      int3 color_C = selectColorInput(s, ss, {0}colors_0, {0}colors_1, color_c) & "
-      "int3(255, 255, 255);\n"
+      "int3(2550, 2550, 2550);\n"
       "      int3 color_D = selectColorInput(s, ss, {0}colors_0, {0}colors_1, color_d);  // 10 "
       "bits + sign\n"
       "\n",  // TODO: do we need to sign extend?
@@ -851,7 +852,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
       "\n"
       "      // Clamp result\n"
       "      if (color_clamp)\n"
-      "        color = clamp(color, 0, 255);\n"
+      "        color = clamp(color, 0, 2550);\n"
       "      else\n"
       "        color = clamp(color, -1024, 1023);\n"
       "\n"
@@ -937,7 +938,7 @@ ShaderCode GenPixelShader(APIType api_type, const ShaderHostConfig& host_config,
       "  TevResult.w = getTevReg(s, {}).w;\n",
       BitfieldExtract<&TevStageCombiner::AlphaCombiner::dest>("bpmem_combiners(num_stages).y"));
 
-  out.Write("  TevResult &= 255;\n\n");
+  out.Write("  TevResult &= 2550;\n\n");
 
   if (host_config.fast_depth_calc)
   {

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -349,7 +349,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
 {
   ShaderCode out;
 
-  const bool per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
+  const bool per_pixel_lighting = host_config.per_pixel_lighting;
   const bool msaa = host_config.msaa;
   const bool ssaa = host_config.ssaa;
   const bool vertex_rounding = host_config.vertex_rounding;

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -392,7 +392,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   out.Write("}};\n\n");
 
   WriteIsNanHeader(out, api_type);
-  GenerateLightingShaderHeader(out, uid_data->lighting);
+  GenerateLightingShaderHeader(out, host_config, uid_data->lighting);
 
   if (uid_data->vs_expand == VSExpand::None)
   {

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -370,7 +370,7 @@ void CheckForConfigChanges()
 
   // Framebuffer changed?
   if (changed_bits & (CONFIG_CHANGE_BIT_MULTISAMPLES | CONFIG_CHANGE_BIT_STEREO_MODE |
-                      CONFIG_CHANGE_BIT_TARGET_SIZE | CONFIG_CHANGE_BIT_HDR_RENDER))
+                      CONFIG_CHANGE_BIT_TARGET_SIZE | CONFIG_CHANGE_BIT_HDR_OUTPUT))
   {
     g_framebuffer_manager->RecreateEFBFramebuffer(g_ActiveConfig.iEFBScale);
   }
@@ -384,7 +384,7 @@ void CheckForConfigChanges()
 
   // Reload shaders if host config has changed.
   if (changed_bits & (CONFIG_CHANGE_BIT_HOST_CONFIG | CONFIG_CHANGE_BIT_MULTISAMPLES |
-                      CONFIG_CHANGE_BIT_HDR_OUTPUT))
+                      CONFIG_CHANGE_BIT_HDR_RENDER))
   {
     OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
     g_gfx->WaitForGPUIdle();

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -150,7 +150,8 @@ void VideoConfig::Refresh()
   bArbitraryMipmapDetection = Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
   fArbitraryMipmapDetectionThreshold =
       Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD);
-  bHDR = Config::Get(Config::GFX_ENHANCE_HDR_OUTPUT);
+  bHDRRender = Config::Get(Config::GFX_ENHANCE_HDR_RENDER);
+  bHDROutput = Config::Get(Config::GFX_ENHANCE_HDR_OUTPUT);
 
   color_correction.bCorrectColorSpace = Config::Get(Config::GFX_CC_CORRECT_COLOR_SPACE);
   color_correction.game_color_space = Config::Get(Config::GFX_CC_GAME_COLOR_SPACE);
@@ -302,7 +303,8 @@ void CheckForConfigChanges()
   const AspectMode old_suggested_aspect_mode = g_ActiveConfig.suggested_aspect_mode;
   const bool old_widescreen_hack = g_ActiveConfig.bWidescreenHack;
   const auto old_post_processing_shader = g_ActiveConfig.sPostProcessingShader;
-  const auto old_hdr = g_ActiveConfig.bHDR;
+  const auto old_hdr_render = g_ActiveConfig.bHDRRender;
+  const auto old_hdr_output = g_ActiveConfig.bHDROutput;
 
   UpdateActiveConfig();
   g_vertex_manager->OnConfigChange();
@@ -355,8 +357,10 @@ void CheckForConfigChanges()
     changed_bits |= CONFIG_CHANGE_BIT_ASPECT_RATIO;
   if (old_post_processing_shader != g_ActiveConfig.sPostProcessingShader)
     changed_bits |= CONFIG_CHANGE_BIT_POST_PROCESSING_SHADER;
-  if (old_hdr != g_ActiveConfig.bHDR)
-    changed_bits |= CONFIG_CHANGE_BIT_HDR;
+  if (old_hdr_render != g_ActiveConfig.bHDRRender)
+    changed_bits |= CONFIG_CHANGE_BIT_HDR_RENDER;
+  if (old_hdr_output != g_ActiveConfig.bHDROutput)
+    changed_bits |= CONFIG_CHANGE_BIT_HDR_OUTPUT;
 
   // No changes?
   if (changed_bits == 0)
@@ -366,7 +370,7 @@ void CheckForConfigChanges()
 
   // Framebuffer changed?
   if (changed_bits & (CONFIG_CHANGE_BIT_MULTISAMPLES | CONFIG_CHANGE_BIT_STEREO_MODE |
-                      CONFIG_CHANGE_BIT_TARGET_SIZE | CONFIG_CHANGE_BIT_HDR))
+                      CONFIG_CHANGE_BIT_TARGET_SIZE | CONFIG_CHANGE_BIT_HDR_RENDER))
   {
     g_framebuffer_manager->RecreateEFBFramebuffer(g_ActiveConfig.iEFBScale);
   }
@@ -379,13 +383,14 @@ void CheckForConfigChanges()
   }
 
   // Reload shaders if host config has changed.
-  if (changed_bits & (CONFIG_CHANGE_BIT_HOST_CONFIG | CONFIG_CHANGE_BIT_MULTISAMPLES))
+  if (changed_bits & (CONFIG_CHANGE_BIT_HOST_CONFIG | CONFIG_CHANGE_BIT_MULTISAMPLES |
+                      CONFIG_CHANGE_BIT_HDR_OUTPUT))
   {
     OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
     g_gfx->WaitForGPUIdle();
     g_vertex_manager->InvalidatePipelineObject();
     g_vertex_manager->NotifyCustomShaderCacheOfHostChange(new_host_config);
-    g_shader_cache->SetHostConfig(new_host_config);
+    g_shader_cache->SetHostConfig(new_host_config); // TODO: is this actually necessary when we toggle HDR render in the menu? Other changes the influence shaders aren't immediately applied it seems
     g_shader_cache->Reload();
     g_framebuffer_manager->RecompileShaders();
   }

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -370,7 +370,8 @@ void CheckForConfigChanges()
 
   // Framebuffer changed?
   if (changed_bits & (CONFIG_CHANGE_BIT_MULTISAMPLES | CONFIG_CHANGE_BIT_STEREO_MODE |
-                      CONFIG_CHANGE_BIT_TARGET_SIZE | CONFIG_CHANGE_BIT_HDR_OUTPUT))
+                      CONFIG_CHANGE_BIT_TARGET_SIZE | CONFIG_CHANGE_BIT_HDR_RENDER |
+                      CONFIG_CHANGE_BIT_HDR_OUTPUT))
   {
     g_framebuffer_manager->RecreateEFBFramebuffer(g_ActiveConfig.iEFBScale);
   }
@@ -383,14 +384,13 @@ void CheckForConfigChanges()
   }
 
   // Reload shaders if host config has changed.
-  if (changed_bits & (CONFIG_CHANGE_BIT_HOST_CONFIG | CONFIG_CHANGE_BIT_MULTISAMPLES |
-                      CONFIG_CHANGE_BIT_HDR_RENDER))
+  if (changed_bits & (CONFIG_CHANGE_BIT_HOST_CONFIG | CONFIG_CHANGE_BIT_MULTISAMPLES))
   {
     OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
     g_gfx->WaitForGPUIdle();
     g_vertex_manager->InvalidatePipelineObject();
     g_vertex_manager->NotifyCustomShaderCacheOfHostChange(new_host_config);
-    g_shader_cache->SetHostConfig(new_host_config); // TODO: is this actually necessary when we toggle HDR render in the menu? Other changes the influence shaders aren't immediately applied it seems
+    g_shader_cache->SetHostConfig(new_host_config);
     g_shader_cache->Reload();
     g_framebuffer_manager->RecompileShaders();
   }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -120,7 +120,8 @@ enum ConfigChangeBits : u32
   CONFIG_CHANGE_BIT_BBOX = (1 << 7),
   CONFIG_CHANGE_BIT_ASPECT_RATIO = (1 << 8),
   CONFIG_CHANGE_BIT_POST_PROCESSING_SHADER = (1 << 9),
-  CONFIG_CHANGE_BIT_HDR = (1 << 10),
+  CONFIG_CHANGE_BIT_HDR_RENDER = (1 << 10),
+  CONFIG_CHANGE_BIT_HDR_OUTPUT = (1 << 11),
 };
 
 // Static config per API
@@ -221,7 +222,8 @@ struct VideoConfig final
   bool bDisableCopyFilter = false;
   bool bArbitraryMipmapDetection = false;
   float fArbitraryMipmapDetectionThreshold = 0;
-  bool bHDR = false;
+  bool bHDRRender = false;
+  bool bHDROutput = false;
 
   // Color Correction
   struct

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -224,7 +224,7 @@ struct VideoConfig final
   bool bArbitraryMipmapDetection = false;
   float fArbitraryMipmapDetectionThreshold = 0;
   bool bHDRRender = false;
-  bool bHDROutput = false;
+  bool bHDROutput = false;  // Just a request flag, only engaged if supported
 
   // Color Correction
   struct

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -181,6 +181,7 @@ struct BackendInfo
   bool bSupportsVSLinePointExpand = false;
   bool bSupportsGLLayerInFS = true;
   bool bSupportsHDROutput = false;
+  float hdr_peak_white_nits = 1000.f;  // Default to a sensible value
   bool bSupportsUnrestrictedDepthRange = false;
 };
 


### PR DESCRIPTION
PR is functional already.

Missing:
- better heuristics for the tev stages, deciding when and when not to clamp each input/output
- inv dest HW blends need to be pre-clamped if the dest is HDR, otherwise colors flip

HDR vs SDR
<img width="1809" height="984" alt="Dolphin_2026-04-12_03-42-58_783" src="https://github.com/user-attachments/assets/824bf8f0-d049-4772-b67c-5d00b2f73dc9" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c7a07a27-f03b-4752-8e5b-567885b22c96" />

OG branch: https://github.com/Filoppi/dolphin/tree/hdr-rendering