### PR TITLE
GameINI: Action Replay/Gecko codes to unlock Most Wanted Black Edition and Carbon Collector's Edition in GameCube/Wii's Need for Speed

### DIFF
--- a/Data/Sys/GameSettings/GOW.ini
+++ b/Data/Sys/GameSettings/GOW.ini
@@ -1,4 +1,4 @@
-# GOWD69, GOWE69, GOWF69, GOWJ69, GOWP69 - NFS Most Wanted
+# GOWD69, GOWE69, GOWF69, GOWJ69, GOWP69 - Need for Speed: Most Wanted
 
 [Core]
 JITFollowBranch = False

--- a/Data/Sys/GameSettings/GOWE69.ini
+++ b/Data/Sys/GameSettings/GOWE69.ini
@@ -1,0 +1,6 @@
+# GOWE69 - Need for Speed: Most Wanted
+
+[Gecko]
+$Unlock Black Edition [Xanvier]
+C241EECC 00000001
+00000001 00000000

--- a/Data/Sys/GameSettings/GW5E69.ini
+++ b/Data/Sys/GameSettings/GW5E69.ini
@@ -1,0 +1,6 @@
+# GW5E69 - Need for Speed: Carbon
+
+[ActionReplay]
+$Unlock Collector's Edition
+0AB3E002 18000000
+045075B8 00000001

--- a/Data/Sys/GameSettings/RNSE69.ini
+++ b/Data/Sys/GameSettings/RNSE69.ini
@@ -1,0 +1,5 @@
+# RNSE69 - Need for Speed: Carbon
+
+[Gecko]
+$Unlock Collector's Edition [TCRF]
+006F9D5B 00000001


### PR DESCRIPTION
I fully understand that there may be concerns about merging this, but since these editions were never sold for the GameCube and/or Wii, and that [according to The Cutting Room Floor](https://tcrf.net/Need_for_Speed:_Carbon#Version_differences), all the content is present in the files of other versions as well, I decided to create this PR.

These codes unlock the Black Edition and Collector's Edition content in Most Wanted and Carbon, respectively. Screenshot of Most Wanted, showing the extra challenge unlocked with the code:
![gecko-codes-nfs](https://github.com/user-attachments/assets/7e9a536d-6484-4d70-93db-f4ed5393bf4b)

These codes are only for NTSC, apparently there are codes online for PAL versions as well, but since I don't own those I can't test the codes for it, so I decided to focus only on NTSC versions here.

~~I tested them all and the code for GameCube's Carbon didn't unlocked the extra Challenge Series, but it did unlock all the extra cars~~. The codes for Most Wanted on GameCube and Carbon on Wii unlocked everything. Source [here](https://forums.dolphin-emu.org/Thread-nfs-most-wanted-gecko-codes-and-various-hacks) (Dolphin Forums) and [here](https://tcrf.net/Need_for_Speed:_Carbon) (The Cutting Room Floor).

Edit: this also update the name of one of the games in an INI file, as per conversation in this PR.

Edit 2: I successfully ported/converted the code for Carbon on the GameCube from an PAL/GERMAN code to NTSC, now all codes unlock everything correctly in all versions (source to the original PAL/GERMAN code by Ralf [here](https://web.archive.org/web/20230427150941/https://www.gc-forever.com/forums/viewtopic.php?t=3053)).