### PR TITLE
GameSettings: Add CPU overclock to work around long black screen on boot in "Deadly Creatures".

### DIFF
--- a/Data/Sys/GameSettings/RDC.ini
+++ b/Data/Sys/GameSettings/RDC.ini
@@ -1,0 +1,6 @@
+# RDCE78, RDCP78 - Deadly Creatures
+
+[Core]
+# Overclock to work around long black screen on boot.
+Overclock = 1.10
+OverclockEnable = True


### PR DESCRIPTION
An "Overclock" value of at least 1.06 seems to currently work around this issue.
https://bugs.dolphin-emu.org/issues/12574

This is hacky, but it's better than having to wait over a minute for the game to boot.