### PR TITLE
GameSettings: Enable VertexRounding in "Shrek Smash n' Crash Racing".

### DIFF
--- a/Data/Sys/GameSettings/G4I.ini
+++ b/Data/Sys/GameSettings/G4I.ini
@@ -1,0 +1,5 @@
+# G4IP52, G4IE52 - Shrek Smash n' Crash Racing
+
+[Video_Hacks]
+# Eliminates vertical lines when in game.
+VertexRounding = True


### PR DESCRIPTION
Enable `VertexRounding` in "Shrek Smash n' Crash Racing" to eliminate vertical lines in game.

Note that turning off `EFBScaledCopy` also eliminates the vertical lines.

Fixes https://bugs.dolphin-emu.org/issues/13421