### PR TITLE
GameSettings: Disable DeferEFBCopies to fix shadows in "Disney's Hide & Sneak".

### DIFF
--- a/Data/Sys/GameSettings/GAA.ini
+++ b/Data/Sys/GameSettings/GAA.ini
@@ -1,14 +1,7 @@
 # GAAJ08 - Disney's Mickey & Minnie Trick & Chase
 
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
 [Video_Hacks]
+# Avoid broken shadows and other effects.
 EFBToTextureEnable = False
+DeferEFBCopies = False
 BBoxEnable = True

--- a/Data/Sys/GameSettings/GHV.ini
+++ b/Data/Sys/GameSettings/GHV.ini
@@ -1,14 +1,7 @@
 # GHVE08, GHVP08 - Disney's Hide & Sneak
 
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
 [Video_Hacks]
+# Avoid broken shadows and other effects.
 EFBToTextureEnable = False
+DeferEFBCopies = False
 BBoxEnable = True


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/13449