### PR TITLE
DolphinQt/Resources: ERROR_LOG instead of ASSERT when LoadNamedIcon fails.

### DIFF
--- a/Source/Core/DolphinQt/Resources.cpp
+++ b/Source/Core/DolphinQt/Resources.cpp
@@ -8,8 +8,8 @@
 #include <QImageReader>
 #include <QPixmap>
 
-#include "Common/Assert.h"
 #include "Common/FileUtil.h"
+#include "Common/Logging/Log.h"
 
 #include "Core/Config/MainSettings.h"
 
@@ -48,7 +48,10 @@ QIcon Resources::LoadNamedIcon(std::string_view name, const QString& dir)
   for (auto scale : {1, 2, 4})
     load_png(scale);
 
-  ASSERT(icon.availableSizes().size() > 0);
+  if (icon.isNull())
+  {
+    ERROR_LOG_FMT(COMMON, "LoadNamedIcon: \"{}\" could not be loaded.", name);
+  }
 
   return icon;
 }


### PR DESCRIPTION
Addresses https://bugs.dolphin-emu.org/issues/13964

<img width="779" height="153" alt="image" src="https://github.com/user-attachments/assets/c6da37e0-2e89-447c-bfec-ceb5b15b9212" />
