### PR TITLE
HacksWidget: Merge tooltips for disabled settings into balloontips

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -128,15 +128,8 @@ void HacksWidget::CreateWidgets()
 
 void HacksWidget::OnBackendChanged(const QString& backend_name)
 {
-  const bool bbox = g_backend_info.bSupportsBBox;
-  m_disable_bounding_box->setEnabled(bbox);
-
-  const QString tooltip = tr("%1 doesn't support this feature on your system.")
-                              .arg(tr(backend_name.toStdString().c_str()));
-
-  m_disable_bounding_box->setToolTip(!bbox ? tooltip : QString{});
-
   UpdateGPUTextureDecodingEnabled(backend_name);
+  UpdateBoundingBoxEnabled(backend_name);
 }
 
 void HacksWidget::ConnectWidgets()
@@ -216,10 +209,6 @@ void HacksWidget::AddDescriptions()
       "Uses a less accurate algorithm to calculate depth values.<br><br>Causes issues in a few "
       "games, but can result in a decent speed increase depending on the game and/or "
       "GPU.<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
-  static const char TR_DISABLE_BOUNDINGBOX_DESCRIPTION[] =
-      QT_TR_NOOP("Disables bounding box emulation.<br><br>This may improve GPU performance "
-                 "significantly, but some games will break.<br><br><dolphin_emphasis>If "
-                 "unsure, leave this checked.</dolphin_emphasis>");
   static const char TR_SAVE_TEXTURE_CACHE_TO_STATE_DESCRIPTION[] =
       QT_TR_NOOP("Includes the contents of the embedded frame buffer (EFB) and upscaled EFB copies "
                  "in save states. Fixes missing and/or non-upscaled textures/objects when loading "
@@ -249,7 +238,6 @@ void HacksWidget::AddDescriptions()
   m_immediate_xfb->SetDescription(tr(TR_IMMEDIATE_XFB_DESCRIPTION));
   m_skip_duplicate_xfbs->SetDescription(tr(TR_SKIP_DUPLICATE_XFBS_DESCRIPTION));
   m_fast_depth_calculation->SetDescription(tr(TR_FAST_DEPTH_CALC_DESCRIPTION));
-  m_disable_bounding_box->SetDescription(tr(TR_DISABLE_BOUNDINGBOX_DESCRIPTION));
   m_save_texture_cache_state->SetDescription(tr(TR_SAVE_TEXTURE_CACHE_TO_STATE_DESCRIPTION));
   m_vertex_rounding->SetDescription(tr(TR_VERTEX_ROUNDING_DESCRIPTION));
   m_vi_skip->SetDescription(tr(TR_VI_SKIP_DESCRIPTION));
@@ -288,6 +276,30 @@ void HacksWidget::UpdateGPUTextureDecodingEnabled(const QString& backend_name)
     m_gpu_texture_decoding->SetDescription(
         tr(TR_GPU_DECODING_DESCRIPTION) +
         tr("<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
+  }
+}
+
+void HacksWidget::UpdateBoundingBoxEnabled(const QString& backend_name)
+{
+  static const char TR_DISABLE_BOUNDINGBOX_DESCRIPTION[] =
+      QT_TR_NOOP("Disables bounding box emulation.<br><br>This may improve GPU performance "
+                 "significantly, but some games will break.<br><br>");
+
+  const bool bbox = g_backend_info.bSupportsBBox;
+  m_disable_bounding_box->setEnabled(bbox);
+
+  if (bbox)
+  {
+    m_disable_bounding_box->SetDescription(
+        tr(TR_DISABLE_BOUNDINGBOX_DESCRIPTION) +
+        tr("<dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>"));
+  }
+  else
+  {
+    m_disable_bounding_box->SetDescription(tr(TR_DISABLE_BOUNDINGBOX_DESCRIPTION) +
+                                           tr("<dolphin_emphasis>The %1 backend doesn't support "
+                                              "Bounding Box emulation.</dolphin_emphasis>")
+                                               .arg(backend_name));
   }
 }
 

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -25,10 +25,13 @@ HacksWidget::HacksWidget(GraphicsPane* gfx_pane) : m_game_layer{gfx_pane->GetCon
   ConnectWidgets();
   AddDescriptions();
 
+  const auto get_backend_name = []() { return tr(Config::Get(Config::MAIN_GFX_BACKEND).data()); };
+
   connect(gfx_pane, &GraphicsPane::BackendChanged, this, &HacksWidget::OnBackendChanged);
-  OnBackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
   connect(gfx_pane, &GraphicsPane::UpdateGPUTextureDecoding, this,
-          &HacksWidget::UpdateGPUTextureDecodingEnabled);
+          [this, get_backend_name] { UpdateGPUTextureDecodingEnabled(get_backend_name()); });
+
+  OnBackendChanged(get_backend_name());
 }
 
 void HacksWidget::CreateWidgets()
@@ -126,16 +129,14 @@ void HacksWidget::CreateWidgets()
 void HacksWidget::OnBackendChanged(const QString& backend_name)
 {
   const bool bbox = g_backend_info.bSupportsBBox;
-  const bool gpu_texture_decoding = g_backend_info.bSupportsGPUTextureDecoding;
-
-  UpdateGPUTextureDecodingEnabled();
   m_disable_bounding_box->setEnabled(bbox);
 
   const QString tooltip = tr("%1 doesn't support this feature on your system.")
                               .arg(tr(backend_name.toStdString().c_str()));
 
-  m_gpu_texture_decoding->setToolTip(!gpu_texture_decoding ? tooltip : QString{});
   m_disable_bounding_box->setToolTip(!bbox ? tooltip : QString{});
+
+  UpdateGPUTextureDecodingEnabled(backend_name);
 }
 
 void HacksWidget::ConnectWidgets()
@@ -211,12 +212,6 @@ void HacksWidget::AddDescriptions()
       "<br><br>This setting is unavailable when Immediately Present XFB or VBI Skip is "
       "enabled. In those cases, duplicate frames are never presented."
       "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
-  static const char TR_GPU_DECODING_DESCRIPTION[] = QT_TR_NOOP(
-      "Enables texture decoding using the GPU instead of the CPU.<br><br>This may result in "
-      "performance gains in some scenarios, or on systems where the CPU is the "
-      "bottleneck.<br><br>This setting is disabled when Arbitrary Mipmap Detection is "
-      "enabled.<br><br>"
-      "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static const char TR_FAST_DEPTH_CALC_DESCRIPTION[] = QT_TR_NOOP(
       "Uses a less accurate algorithm to calculate depth values.<br><br>Causes issues in a few "
       "games, but can result in a decent speed increase depending on the game and/or "
@@ -253,7 +248,6 @@ void HacksWidget::AddDescriptions()
   m_store_xfb_copies->SetDescription(tr(TR_STORE_XFB_TO_TEXTURE_DESCRIPTION));
   m_immediate_xfb->SetDescription(tr(TR_IMMEDIATE_XFB_DESCRIPTION));
   m_skip_duplicate_xfbs->SetDescription(tr(TR_SKIP_DUPLICATE_XFBS_DESCRIPTION));
-  m_gpu_texture_decoding->SetDescription(tr(TR_GPU_DECODING_DESCRIPTION));
   m_fast_depth_calculation->SetDescription(tr(TR_FAST_DEPTH_CALC_DESCRIPTION));
   m_disable_bounding_box->SetDescription(tr(TR_DISABLE_BOUNDINGBOX_DESCRIPTION));
   m_save_texture_cache_state->SetDescription(tr(TR_SAVE_TEXTURE_CACHE_TO_STATE_DESCRIPTION));
@@ -261,11 +255,40 @@ void HacksWidget::AddDescriptions()
   m_vi_skip->SetDescription(tr(TR_VI_SKIP_DESCRIPTION));
 }
 
-void HacksWidget::UpdateGPUTextureDecodingEnabled()
+void HacksWidget::UpdateGPUTextureDecodingEnabled(const QString& backend_name)
 {
-  const bool gpu_texture_decoding = g_backend_info.bSupportsGPUTextureDecoding;
-  m_gpu_texture_decoding->setEnabled(
-      gpu_texture_decoding && !Get(m_game_layer, Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION));
+  static const char TR_GPU_DECODING_DESCRIPTION[] = QT_TR_NOOP(
+      "Enables texture decoding using the GPU instead of the CPU.<br><br>This may result in "
+      "performance gains in some scenarios, or on systems where the CPU is the bottleneck."
+      "<br><br>This setting is disabled when Arbitrary Mipmap Detection is enabled.<br><br>");
+
+  const bool gpu_texture_decoding_supported = g_backend_info.bSupportsGPUTextureDecoding;
+  const bool arbitrary_mipmap_detection_enabled =
+      Get(m_game_layer, Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
+  const bool gpu_texture_decoding_enabled =
+      gpu_texture_decoding_supported && !arbitrary_mipmap_detection_enabled;
+  m_gpu_texture_decoding->setEnabled(gpu_texture_decoding_enabled);
+
+  if (!gpu_texture_decoding_supported)
+  {
+    m_gpu_texture_decoding->SetDescription(tr(TR_GPU_DECODING_DESCRIPTION) +
+                                           tr("<dolphin_emphasis>The %1 backend doesn't support "
+                                              "GPU Texture Decoding.</dolphin_emphasis>")
+                                               .arg(backend_name));
+  }
+  else if (arbitrary_mipmap_detection_enabled)
+  {
+    m_gpu_texture_decoding->SetDescription(
+        tr(TR_GPU_DECODING_DESCRIPTION) +
+        tr("<dolphin_emphasis>GPU Texture Decoding is currently disabled by Arbitrary Mipmap "
+           "Detection.</dolphin_emphasis>"));
+  }
+  else
+  {
+    m_gpu_texture_decoding->SetDescription(
+        tr(TR_GPU_DECODING_DESCRIPTION) +
+        tr("<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
+  }
 }
 
 void HacksWidget::UpdateDeferEFBCopiesEnabled()

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -28,6 +28,7 @@ private:
   void AddDescriptions();
 
   void UpdateGPUTextureDecodingEnabled(const QString& backend_name);
+  void UpdateBoundingBoxEnabled(const QString& backend_name);
   void UpdateDeferEFBCopiesEnabled();
   void UpdateSkipPresentingDuplicateFramesEnabled();
 

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -22,6 +22,14 @@ public:
   explicit HacksWidget(GraphicsPane* gfx_pane);
 
 private:
+  void CreateWidgets();
+  void ConnectWidgets();
+  void AddDescriptions();
+
+  void UpdateGPUTextureDecodingEnabled();
+  void UpdateDeferEFBCopiesEnabled();
+  void UpdateSkipPresentingDuplicateFramesEnabled();
+
   void OnBackendChanged(const QString& backend_name);
 
   // EFB
@@ -48,12 +56,4 @@ private:
   ConfigBool* m_save_texture_cache_state;
 
   Config::Layer* m_game_layer = nullptr;
-
-  void CreateWidgets();
-  void ConnectWidgets();
-  void AddDescriptions();
-
-  void UpdateGPUTextureDecodingEnabled();
-  void UpdateDeferEFBCopiesEnabled();
-  void UpdateSkipPresentingDuplicateFramesEnabled();
 };

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -9,6 +9,7 @@ class ConfigBool;
 class ConfigSlider;
 class ConfigSliderLabel;
 class GraphicsPane;
+class QString;
 
 namespace Config
 {
@@ -26,7 +27,7 @@ private:
   void ConnectWidgets();
   void AddDescriptions();
 
-  void UpdateGPUTextureDecodingEnabled();
+  void UpdateGPUTextureDecodingEnabled(const QString& backend_name);
   void UpdateDeferEFBCopiesEnabled();
   void UpdateSkipPresentingDuplicateFramesEnabled();
 


### PR DESCRIPTION
For `Disable Bounding Box`, merge the separate tooltip shown when the backend doesn't support Bounding Box into the normal tooltip.

For `GPU Texture Decoding` do the same thing, and also clarify when `Arbitrary Mipmap Detection` is currently disabling the setting.

Some images showing the `GPU Texture Decoding` changes:
|   | master | PR |
| --- | --- | ---- |
| **GPU Texture Decoding not supported** | <img width="385" height="133" alt="master_null" src="https://github.com/user-attachments/assets/f191cd98-fdee-4770-a3c0-c45a62f36fad" /> |<img width="337" height="61" alt="PR_null" src="https://github.com/user-attachments/assets/e192c51c-21d0-4204-9224-f1ba286ee7f2" /> |
| **Arbitrary Mipmap Detection enabled** | <img width="198" height="67" alt="master_arbitrary" src="https://github.com/user-attachments/assets/9667a66b-5f65-43f1-9baf-2b98cf8eec53" /> |<img width="429" height="57" alt="PR_arbitrary" src="https://github.com/user-attachments/assets/ee6a8b0b-8b4a-42f0-bc83-ad24f937fe75" /> |
| **Neither** | <img width="194" height="60" alt="PR_available" src="https://github.com/user-attachments/assets/b371fa31-6f71-4b6f-8b0b-0d179091dfdb" /> | unchanged |