### PR TITLE
PowerPC/MMU: Change mask in DMA_LCToMemory and DMA_MemoryToLC functions to allow for a 256MiB MEM2.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -1260,7 +1260,7 @@ class SettingsFragmentPresenter(
                 R.string.main_mem2_size,
                 0,
                 64,
-                128,
+                256,
                 "MB",
                 1
             )

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -960,7 +960,7 @@ void MMU::DMA_LCToMemory(const u32 mem_address, const u32 cache_address, const u
   // TODO: This is terribly slow.
   // TODO: Refactor.
   // Avatar: The Last Airbender (GC) uses this for videos.
-  if ((mem_address & 0x0F000000) == 0x08000000)
+  if ((mem_address & 0x1F000000) == 0x08000000)
   {
     for (u32 i = 0; i < 32 * num_blocks; i += 4)
     {
@@ -972,7 +972,7 @@ void MMU::DMA_LCToMemory(const u32 mem_address, const u32 cache_address, const u
 
   // No known game uses this; here for completeness.
   // TODO: Refactor.
-  if ((mem_address & 0x0F000000) == 0x0C000000)
+  if ((mem_address & 0x1F000000) == 0x0C000000)
   {
     for (u32 i = 0; i < 32 * num_blocks; i += 4)
     {
@@ -990,7 +990,7 @@ void MMU::DMA_MemoryToLC(const u32 cache_address, const u32 mem_address, const u
 {
   // No known game uses this; here for completeness.
   // TODO: Refactor.
-  if ((mem_address & 0x0F000000) == 0x08000000)
+  if ((mem_address & 0x1F000000) == 0x08000000)
   {
     for (u32 i = 0; i < 32 * num_blocks; i += 4)
     {
@@ -1002,7 +1002,7 @@ void MMU::DMA_MemoryToLC(const u32 cache_address, const u32 mem_address, const u
 
   // No known game uses this.
   // TODO: Refactor.
-  if ((mem_address & 0x0F000000) == 0x0C000000)
+  if ((mem_address & 0x1F000000) == 0x0C000000)
   {
     for (u32 i = 0; i < 32 * num_blocks; i += 4)
     {

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -263,7 +263,7 @@ void AdvancedPane::CreateLayout()
   mem2_override_slider_layout->setContentsMargins(0, 0, 0, 0);
   ram_override_layout->addLayout(mem2_override_slider_layout);
 
-  m_mem2_override_slider = new ConfigSliderU32(64, 128, Config::MAIN_MEM2_SIZE, 0x100000);
+  m_mem2_override_slider = new ConfigSliderU32(64, 256, Config::MAIN_MEM2_SIZE, 0x100000);
   mem2_override_slider_layout->addWidget(m_mem2_override_slider);
 
   m_mem2_label =


### PR DESCRIPTION
This addresses https://bugs.dolphin-emu.org/issues/13973

It allows "Battalion Wars 2" to boot with
```ini
[Core]
MEM2Size = 0x10000000
```

My vague understanding is that high bit is used for MEM2, but I don't know if these checks are actually correct.
From the looks of things the current behavior of these functions is already questionable?

~~The UI can be adjusted later.~~
Edit: I've also adjusted the UI.