### PR TITLE
Debugger: Register Widget bug fix. Block updates when changing types

### DIFF
--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -283,12 +283,14 @@ void RegisterWidget::ShowContextMenu()
                          view_double_column})
     {
       connect(action, &QAction::triggered, [this, action] {
+        m_updating = true;
         auto col = m_table->currentItem()->column();
         for (int i = 0; i < 32; i++)
         {
           auto* update_item = static_cast<RegisterColumn*>(m_table->item(i, col));
           update_item->SetDisplay(static_cast<RegisterDisplay>(action->data().toInt()));
         }
+        m_updating = false;
       });
     }
 


### PR DESCRIPTION
When changing a column's data type view (ex: all floats) it was re-saving the register values, potentially changing them. Mostly affected normal registers when changing to float view, as round off errors would change the actual register value.