### PR TITLE
DolphinQt/GCMemcardManager: Set ScrollMode::ScrollPerPixel to make scrolling behavior less annoying.

### DIFF
--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -243,7 +243,6 @@ void GCMemcardManager::SetActiveSlot(Slot slot)
 
   m_active_slot = slot;
 
-  UpdateSlotTable(slot);
   UpdateActions();
 }
 

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -133,6 +133,8 @@ void GCMemcardManager::CreateWidgets()
     m_slot_create_button[slot] = new NonDefaultQPushButton(tr("&Create..."));
     m_slot_table[slot] = new QTableWidget;
     m_slot_table[slot]->setTabKeyNavigation(false);
+    m_slot_table[slot]->setHorizontalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
+    m_slot_table[slot]->setVerticalScrollMode(QAbstractItemView::ScrollMode::ScrollPerPixel);
     m_slot_stat_label[slot] = new QLabel;
 
     m_slot_table[slot]->setSelectionMode(QAbstractItemView::ExtendedSelection);


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/11361