### PR TITLE
GameSettings: EFBAccessEnable for "NFL Street 2" to fix broken custom character portraits.

### DIFF
--- a/Data/Sys/GameSettings/GN7.ini
+++ b/Data/Sys/GameSettings/GN7.ini
@@ -1,15 +1,7 @@
-# GN7E69, GN7P69 - NFL STREET 2
-
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
-[Video_Settings]
+# GN7E69, GN7P69 - NFL Street 2
 
 [Video_Hacks]
+# Avoids broken custom character portraits.
+EFBAccessEnable = True
+# Avoids stuck screens during FMVs.
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GNN.ini
+++ b/Data/Sys/GameSettings/GNN.ini
@@ -1,16 +1,8 @@
 # GNNE69, GNNP69 - NFL Street
 
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
+# Avoids stuck screens during FMVs.
 ImmediateXFBEnable = False


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/13744

Also added comments for ImmediateXFBEnable in NFL Street 1 and 2.