### PR TITLE
GameSettings: Apply settings for alternate regions of "MySims Agents".

### DIFF
--- a/Data/Sys/GameSettings/R5X.ini
+++ b/Data/Sys/GameSettings/R5X.ini
@@ -1,4 +1,4 @@
-# R6QE69 - MySims Agents
+# R5XJ13, R5XP69 - MySims Agents
 
 [Video_Hacks]
 EFBToTextureEnable = False


### PR DESCRIPTION
"MySims Agents" also uses the "R5X" game ID.
https://wiki.dolphin-emu.org/index.php?title=MySims_Agents

Fixes https://bugs.dolphin-emu.org/issues/13631

I don't know if/why `EFBToTextureEnable = False` is needed, but I've copied it from the existing "R6Q" ini file.