### PR TITLE
DolphinQt: Remove the "supported Bluetooth device could not be found" label from ControllersPane.

### DIFF
--- a/Source/Core/DolphinQt/Config/ControllersPane.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersPane.cpp
@@ -14,13 +14,6 @@ ControllersPane::ControllersPane()
   CreateMainLayout();
 }
 
-void ControllersPane::showEvent(QShowEvent* event)
-{
-  QWidget::showEvent(event);
-
-  m_wiimote_controllers->UpdateBluetoothAvailableStatus();
-}
-
 void ControllersPane::CreateMainLayout()
 {
   auto* const layout = new QVBoxLayout{this};

--- a/Source/Core/DolphinQt/Config/ControllersPane.h
+++ b/Source/Core/DolphinQt/Config/ControllersPane.h
@@ -13,9 +13,6 @@ class ControllersPane final : public QWidget
 public:
   ControllersPane();
 
-protected:
-  void showEvent(QShowEvent* event) override;
-
 private:
   void CreateMainLayout();
 

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -66,11 +66,6 @@ WiimoteControllersWidget::~WiimoteControllersWidget()
   m_bluetooth_adapter_refresh_thread.WaitForCompletion();
 }
 
-void WiimoteControllersWidget::UpdateBluetoothAvailableStatus()
-{
-  m_bluetooth_unavailable->setHidden(WiimoteReal::IsScannerReady());
-}
-
 void WiimoteControllersWidget::StartBluetoothAdapterRefresh()
 {
 #ifdef __LIBUSB__
@@ -284,10 +279,6 @@ void WiimoteControllersWidget::CreateLayout()
 
   m_wiimote_layout->addLayout(left_of_refresh_button_layout, continuous_scanning_row, 0, 1, 3);
   m_wiimote_layout->addWidget(m_wiimote_refresh, continuous_scanning_row, 3);
-
-  m_bluetooth_unavailable = new QLabel(tr("A supported Bluetooth device could not be found.\n"
-                                          "You must manually connect your Wii Remote."));
-  m_wiimote_layout->addWidget(m_bluetooth_unavailable, m_wiimote_layout->rowCount(), 1, 1, -1);
 
   auto* layout = new QVBoxLayout;
   layout->setContentsMargins(0, 0, 0, 0);

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -32,9 +32,7 @@ class WiimoteControllersWidget final : public QWidget
   Q_OBJECT
 public:
   explicit WiimoteControllersWidget(QWidget* parent);
-  ~WiimoteControllersWidget();
-
-  void UpdateBluetoothAvailableStatus();
+  ~WiimoteControllersWidget() override;
 
 private:
   void SaveSettings();
@@ -81,5 +79,4 @@ private:
   QCheckBox* m_wiimote_ciface;
   QToolButton* m_wiimote_refresh;
   QLabel* m_wiimote_refresh_indicator;
-  QLabel* m_bluetooth_unavailable;
 };


### PR DESCRIPTION
I believe I originally introduced this in WxWidgets in 026793fa4abfd7e2d1b6f443022e621b81bddac9 (year 2013)

This was in the days of popular alternative Bluetooth stacks from Toshiba and BlueSoleil, which dolphin was unable to control.
Users had to manually pair their remotes when not using the Microsoft Bluetooth stack.

The message was re-introduced in Qt in d18735e82ea3372d407bb313b0af65692ca5ad05 (year 2023)
<img width="295" height="41" alt="image" src="https://github.com/user-attachments/assets/a5223d6e-9de0-4dad-9ce0-efe04e878d23" />

But I think this message is unnecessary and counterproductive these days.
Windows users just use the Microsoft Bluetooth stack so the original intent of the message rarely applies.

Additionally, now that the DolphinBar and Bluetooth Passthrough exist, the message just appears and confuses anyone that doesn't also have a Bluetooth adapter controlled by Windows.

I often see users setting up Bluetooth Passthrough worried when they see this message.

This PR removes the message to stop the confusion.
Addresses https://bugs.dolphin-emu.org/issues/13245