### PR TITLE
DirectoryBlob: fix data alignment for GC/Triforce and skip Triforce DIMM memory range

### DIFF
--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -895,7 +895,8 @@ DirectoryBlobPartition::DirectoryBlobPartition(
     const std::function<void(std::vector<FSTBuilderNode>* fst_nodes, FSTBuilderNode* dol_node)>&
         fst_callback,
     DirectoryBlobReader* blob)
-    : m_wrapped_partition(partition)
+    : m_wrapped_partition(partition),
+      m_is_triforce(volume && volume->GetVolumeType() == Platform::Triforce)
 {
   std::vector<FSTBuilderNode> sys_nodes;
 
@@ -1230,6 +1231,14 @@ void DirectoryBlobPartition::WriteDirectory(std::vector<u8>* fst_data,
     }
     else
     {
+      // Skip Triforce DIMM so the file doesn't overlap with it. Any portion of
+      // a file placed in 0x1F000000-0x1F800000 would be shadowed by SRAM on the
+      // AMMediaboard and read back as DIMM contents instead of disc data.
+      if (m_is_triforce && *data_offset < 0x1F800000 && *data_offset + entry.m_size > 0x1F000000)
+      {
+        *data_offset = 0x1F800000ull;
+      }
+
       // put entry in FST
       WriteEntryData(fst_data, fst_offset, FILE_ENTRY, *name_offset, *data_offset, entry.m_size,
                      m_address_shift);
@@ -1243,8 +1252,8 @@ void DirectoryBlobPartition::WriteDirectory(std::vector<u8>* fst_data,
                        std::move(content.m_source));
       }
 
-      // 32 KiB aligned - many games are fine with less alignment, but not all
-      *data_offset = Common::AlignUp(*data_offset + entry.m_size, 0x8000ull);
+      const u64 data_alignment = m_is_triforce ? 0x20ull : 0x8000ull;
+      *data_offset = Common::AlignUp(*data_offset + entry.m_size, data_alignment);
     }
   }
 }

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -231,6 +231,7 @@ private:
 
   std::string m_root_directory;
   bool m_is_wii = false;
+  bool m_is_triforce = false;
   // GameCube has no shift, Wii has 2 bit shift
   u32 m_address_shift = 0;
 


### PR DESCRIPTION
DirectoryBlob uses [0x8000 alignment](https://github.com/dolphin-emu/dolphin/blob/6871428a81/Source/Core/DiscIO/DirectoryBlob.cpp#L1151-L1152) for file data offsets when rebuilding the FST. This is needed for Wii disc group encryption, but for GC/Triforce it just inflates the disc image.

On Triforce games with many files (MKGP2 has ~8600), the inflated offsets can land in the [DIMM memory range](https://github.com/dolphin-emu/dolphin/blob/6871428a81/Source/Core/Core/HW/DVD/AMMediaboard.cpp#L1510-L1515) (`0x1F000000-0x1F800000`). AMMediaboard Read returns SRAM data instead of disc data for those offsets, which causes the game to hang.

This changes GC/Triforce alignment to 0x20 (matching original disc layout) and, for Triforce specifically, skips the DIMM memory range when assigning data offsets as a safety net for very large mods.

Tested with MKGP2 (GNLJ) + Riivolution:
- A no-op patch (just triggering FST rebuild, no file changes) that hangs without this fix
- ~60 MB of additional `create="true"` files pushing past the DIMM range, confirming the skip works

<details>
<summary>Riivolution patches used for testing</summary>

No-op patch (reproduces the hang without this fix):
```xml
<wiidisc version="1">
  <id game="GNLJ"/>
  <options>
    <section name="Test">
      <option name="Empty patch" default="1">
        <choice name="Enabled">
          <patch id="noop"/>
        </choice>
      </option>
    </section>
  </options>
  <patch id="noop"/>
</wiidisc>
```

DIMM range skip test (60 x 1MB files to push past 0x1F000000):
```xml
<wiidisc version="1">
  <id game="GNLJ"/>
  <options>
    <section name="Test">
      <option name="Add files" default="1">
        <choice name="Enabled">
          <patch id="add_files"/>
        </choice>
      </option>
    </section>
  </options>
  <patch id="add_files">
    <file disc="/dummy_01.bin" external="/testmod/dummy_01.bin" create="true"/>
    <file disc="/dummy_02.bin" external="/testmod/dummy_02.bin" create="true"/>
    <!-- ... 60 x 1MB random files total -->
    <file disc="/dummy_60.bin" external="/testmod/dummy_60.bin" create="true"/>
  </patch>
</wiidisc>
```
</details>
