### PR TITLE
GameSettings: Apply settings required for Solitaire and Mahjong WiiWare.

### DIFF
--- a/Data/Sys/GameSettings/WMZ.ini
+++ b/Data/Sys/GameSettings/WMZ.ini
@@ -1,0 +1,7 @@
+# WMZPLN - Mahjong
+
+[Video_Hacks]
+# Avoids constant flickering.
+ImmediateXFBEnable = False
+# Required for cursor functionality.
+EFBAccessEnable = True

--- a/Data/Sys/GameSettings/WSS.ini
+++ b/Data/Sys/GameSettings/WSS.ini
@@ -1,0 +1,7 @@
+# WSSPLN - Solitaire
+
+[Video_Hacks]
+# Avoids constant flickering.
+ImmediateXFBEnable = False
+# Required for cursor functionality.
+EFBAccessEnable = True


### PR DESCRIPTION
Edit: I've also included Mahjong, another game developed by GameOn that requires the same hacks disabled.