### PR TITLE
DolphinQt: Use custom style for `QGroupBox` only with Qt 6.6.0+.

### DIFF
--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -384,6 +384,7 @@ void Settings::ApplyStyle()
     stylesheet_contents.append(QStringLiteral("%1").arg(tooltip_stylesheet));
   }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
   // For Fusion, define group box style if not already defined.
   if (style_name.compare(QStringLiteral("fusion"), Qt::CaseInsensitive) == 0 &&
       !stylesheet_contents.contains(QStringLiteral("QGroupBox")))
@@ -403,6 +404,7 @@ void Settings::ApplyStyle()
                                               " min-width: 0;"
                                               "}"));
   }
+#endif
 
   qApp->setStyleSheet(stylesheet_contents);
 }


### PR DESCRIPTION
This is a follow-up to 3e788399b6f608a270fe0 (#14153), where a custom style for `QGroupBox` widgets was introduced when the Fusion style is used.

However, it was overlooked that the custom QSS does not get along well with Qt versions older than 6.6.0; on Windows, Qt 6.5.1 is used.

| With Qt 6.5.3 | With Qt 6.11.0 |
| ------------- | -------------- |
| <img alt="Dolphin with Qt 6.5.3" title="Dolphin with Qt 6.5.3" src="https://github.com/user-attachments/assets/9d341eef-0438-44c0-b341-8d0a53d9eb09" /> | <img alt="Dolphin with Qt 6.11.0" title="Dolphin with Qt 6.11.0" src="https://github.com/user-attachments/assets/1bc793d2-c958-413b-b99c-51d064104a75" /> |

Compile checks have been added now to only apply the custom style if Qt 6.6.0 (or newer) is used.