### PR TITLE
Core: Address `-Wrange-loop-construct` warning.

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -3133,7 +3133,7 @@ void TextureCacheBase::ApplyMaterialToCacheEntry(const VideoCommon::MaterialReso
   g_gfx->SetTexture(0, entry->texture.get());
   g_gfx->SetSamplerState(0, RenderState::GetPointSamplerState());
 
-  for (const auto texture : material_data->GetTextures())
+  for (const auto& texture : material_data->GetTextures())
   {
     g_gfx->SetTexture(texture.sampler_index, texture.texture);
     g_gfx->SetSamplerState(texture.sampler_index, texture.sampler);


### PR DESCRIPTION
The warning can be seen since 1f72403ec7ac026ff when GCC 13.3.0 is used:

```counterexample
[1540/1898] Building CXX object Source/Core/VideoCommon/CMakeFiles/videocommon.dir/TextureCacheBase.cpp.o
/w/dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp: In member function 'void TextureCacheBase::ApplyMaterialToCacheEntry(const VideoCommon::MaterialResource&, TCacheEntry*)':
/w/dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp:3136:19: warning: loop variable 'texture' creates a copy from type 'const VideoCommon::MaterialResource::TextureLikeReference' [-Wrange-loop-construct]
 3136 |   for (const auto texture : material_data->GetTextures())
      |                   ^~~~~~~
/w/dolphin/Source/Core/VideoCommon/TextureCacheBase.cpp:3136:19: note: use reference type to prevent copying
 3136 |   for (const auto texture : material_data->GetTextures())
      |                   ^~~~~~~
      |                   &
```