### PR TITLE
VideoCommon: Added option for showcasing internal resolution

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -38,6 +38,8 @@ const Info<bool> GFX_CROP{{System::GFX, "Settings", "Crop"}, false};
 const Info<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES{
     {System::GFX, "Settings", "SafeTextureCacheColorSamples"}, 128};
 const Info<bool> GFX_SHOW_FPS{{System::GFX, "Settings", "ShowFPS"}, false};
+const Info<bool> GFX_SHOW_INTERNAL_RESOLUTION{{System::GFX, "Settings", "ShowInternalResolution"},
+                                              false};
 const Info<bool> GFX_SHOW_FTIMES{{System::GFX, "Settings", "ShowFTimes"}, false};
 const Info<bool> GFX_SHOW_VPS{{System::GFX, "Settings", "ShowVPS"}, false};
 const Info<bool> GFX_SHOW_VTIMES{{System::GFX, "Settings", "ShowVTimes"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -42,6 +42,7 @@ extern const Info<float> GFX_WIDESCREEN_HEURISTIC_WIDESCREEN_RATIO;
 extern const Info<bool> GFX_CROP;
 extern const Info<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES;
 extern const Info<bool> GFX_SHOW_FPS;
+extern const Info<bool> GFX_SHOW_INTERNAL_RESOLUTION;
 extern const Info<bool> GFX_SHOW_FTIMES;
 extern const Info<bool> GFX_SHOW_VPS;
 extern const Info<bool> GFX_SHOW_VTIMES;

--- a/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.cpp
+++ b/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.cpp
@@ -43,6 +43,8 @@ void OnScreenDisplayPane::CreateLayout()
   performance_box->setLayout(performance_layout);
 
   m_show_fps = new ConfigBool(tr("Show FPS"), Config::GFX_SHOW_FPS);
+  m_show_internal_resolution =
+      new ConfigBool(tr("Show Internal Resolution"), Config::GFX_SHOW_INTERNAL_RESOLUTION);
   m_show_ftimes = new ConfigBool(tr("Show Frame Times"), Config::GFX_SHOW_FTIMES);
   m_show_vps = new ConfigBool(tr("Show VPS"), Config::GFX_SHOW_VPS);
   m_show_vtimes = new ConfigBool(tr("Show VBlank Times"), Config::GFX_SHOW_VTIMES);
@@ -104,6 +106,7 @@ void OnScreenDisplayPane::CreateLayout()
 
   debug_layout->addWidget(m_show_statistics, 0, 0);
   debug_layout->addWidget(m_show_proj_statistics, 0, 1);
+  debug_layout->addWidget(m_show_internal_resolution, 1, 0);
 
   // Stack GroupBoxes
   auto* main_layout = new QVBoxLayout;
@@ -149,6 +152,11 @@ void OnScreenDisplayPane::AddDescriptions()
   static const char TR_SHOW_FPS_DESCRIPTION[] =
       QT_TR_NOOP("Shows the number of distinct frames rendered per second as a measure of "
                  "visual smoothness.<br><br><dolphin_emphasis>If unsure, leave this "
+                 "unchecked.</dolphin_emphasis>");
+
+  static const char TR_SHOW_INTERNAL_RESOLUTION_DESCRIPTION[] =
+      QT_TR_NOOP("Shows the internal resolution in pixels, as a product of "
+                 "width and height. <br><br><dolphin_emphasis>If unsure, leave this "
                  "unchecked.</dolphin_emphasis>");
   static const char TR_SHOW_FTIMES_DESCRIPTION[] =
       QT_TR_NOOP("Shows the average time in ms between each distinct rendered frame alongside "
@@ -222,6 +230,7 @@ void OnScreenDisplayPane::AddDescriptions()
   m_font_size->SetDescription(tr(TR_OSD_FONT_SIZE_DESCRIPTION));
 
   m_show_fps->SetDescription(tr(TR_SHOW_FPS_DESCRIPTION));
+  m_show_internal_resolution->SetDescription(tr(TR_SHOW_INTERNAL_RESOLUTION_DESCRIPTION));
   m_show_ftimes->SetDescription(tr(TR_SHOW_FTIMES_DESCRIPTION));
   m_show_vps->SetDescription(tr(TR_SHOW_VPS_DESCRIPTION));
   m_show_vtimes->SetDescription(tr(TR_SHOW_VTIMES_DESCRIPTION));

--- a/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.h
+++ b/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.h
@@ -25,6 +25,7 @@ private:
 
   // Performance
   ConfigBool* m_show_fps;
+  ConfigBool* m_show_internal_resolution;
   ConfigBool* m_show_ftimes;
   ConfigBool* m_show_vps;
   ConfigBool* m_show_vtimes;

--- a/Source/Core/VideoCommon/PerformanceMetrics.cpp
+++ b/Source/Core/VideoCommon/PerformanceMetrics.cpp
@@ -11,6 +11,7 @@
 #include "Common/HookableEvent.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Core.h"
+#include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/VideoConfig.h"
 
 PerformanceMetrics::PerformanceMetrics()
@@ -88,6 +89,20 @@ double PerformanceMetrics::GetFPS() const
   return m_fps_counter.GetHzAvg();
 }
 
+u32 PerformanceMetrics::GetEFBWidth() const
+{
+  if (g_framebuffer_manager)
+    return g_framebuffer_manager->GetEFBWidth();
+  return 0;
+}
+
+u32 PerformanceMetrics::GetEFBHeight() const
+{
+  if (g_framebuffer_manager)
+    return g_framebuffer_manager->GetEFBHeight();
+  return 0;
+}
+
 double PerformanceMetrics::GetVPS() const
 {
   return m_vps_counter.GetHzAvg();
@@ -124,6 +139,8 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
   const double fps = GetFPS();
   const double vps = GetVPS();
   const double speed = GetSpeed();
+  const u32 width = GetEFBWidth();
+  const u32 height = GetEFBHeight();
 
   static ImVec2 last_display_size(-1.0f, -1.0f);
 
@@ -314,6 +331,26 @@ void PerformanceMetrics::DrawImGuiStats(const float backbuffer_scale)
             DT_ms(m_frame_presentation_offset.load(std::memory_order_relaxed)).count();
         ImGui::TextColored(ImVec4(r, g, b, 1.0f), "ofs:%5.1lfms", offset);
       }
+    }
+    ImGui::End();
+  }
+
+  if (g_ActiveConfig.bShowInternalResolution)
+  {
+    ImGui::SetNextWindowPos(ImVec2(window_x, window_y), set_next_position_condition,
+                            ImVec2(1.0f, 0.0f));
+    ImGui::SetNextWindowBgAlpha(bg_alpha);
+
+    if (ImGui::Begin("ResolutionStats", nullptr, imgui_flags))
+    {
+      if (stack_vertically)
+        window_y += ImGui::GetWindowHeight() + window_padding;
+      else
+        window_x -= ImGui::GetWindowWidth() + window_padding;
+
+      clamp_window_position();
+
+      ImGui::TextColored(ImVec4(r, g, b, 1.0f), "Res: %ux%u", width, height);
     }
     ImGui::End();
   }

--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -41,7 +41,8 @@ public:
   double GetVPS() const;
   double GetSpeed() const;
   double GetMaxSpeed() const;
-
+  u32 GetEFBWidth() const;
+  u32 GetEFBHeight() const;
   // Call from any thread.
   void SetLatestFramePresentationOffset(DT offset);
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -101,6 +101,7 @@ void VideoConfig::Refresh()
   bCrop = Config::Get(Config::GFX_CROP);
   iSafeTextureCache_ColorSamples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
   bShowFPS = Config::Get(Config::GFX_SHOW_FPS);
+  bShowInternalResolution = Config::Get(Config::GFX_SHOW_INTERNAL_RESOLUTION);
   bShowFTimes = Config::Get(Config::GFX_SHOW_FTIMES);
   bShowVPS = Config::Get(Config::GFX_SHOW_VPS);
   bShowVTimes = Config::Get(Config::GFX_SHOW_VTIMES);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -245,6 +245,7 @@ struct VideoConfig final
 
   // Information
   bool bShowFPS = false;
+  bool bShowInternalResolution = false;
   bool bShowFTimes = false;
   bool bShowVPS = false;
   bool bShowVTimes = false;


### PR DESCRIPTION
Feature was suggested by  [this](https://bugs.dolphin-emu.org/issues/14017) issue. Added a checkbox in OSD settings for showcasing the internal resolution and linked it with a variable in GraphicsSettings.h/cpp. The resolution is shows as width x height, and stacks with other displays feature. All tests pass, and it supports enhancements in real time. 