### PR TITLE
GCAdapter: Automatically start and stop thread

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.kt
@@ -300,9 +300,6 @@ object NativeLibrary {
     @JvmStatic
     external fun ResetDolphinSettings()
 
-    @JvmStatic
-    external fun UpdateGCAdapterScanThread()
-
     /**
      * Initializes the native parts of the app.
      *

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.kt
@@ -56,7 +56,6 @@ class Settings : Closeable {
             NativeConfig.save(NativeConfig.LAYER_BASE)
 
             NativeLibrary.ReloadLoggerConfig()
-            NativeLibrary.UpdateGCAdapterScanThread()
         } else {
             NativeConfig.save(NativeConfig.LAYER_LOCAL_GAME)
         }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -56,8 +56,6 @@
 #include "DiscIO/ScrubbedBlob.h"
 #include "DiscIO/Volume.h"
 
-#include "InputCommon/GCAdapter.h"
-
 #include "UICommon/GameFile.h"
 #include "UICommon/UICommon.h"
 
@@ -531,20 +529,6 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ResetDolphin
   HostThreadLock guard;
   SConfig::ResetAllSettings();
   UICommon::SetUserDirectory(File::GetUserPath(D_USER_IDX));
-}
-
-JNIEXPORT void JNICALL
-Java_org_dolphinemu_dolphinemu_NativeLibrary_UpdateGCAdapterScanThread(JNIEnv*, jclass)
-{
-  HostThreadLock guard;
-  if (GCAdapter::UseAdapter())
-  {
-    GCAdapter::StartScanThread();
-  }
-  else
-  {
-    GCAdapter::StopScanThread();
-  }
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Initialize(JNIEnv*, jclass)

--- a/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GamecubeControllersWidget.cpp
@@ -26,8 +26,6 @@
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
-#include "InputCommon/GCAdapter.h"
-
 using SIDeviceName = std::pair<SerialInterface::SIDevices, const char*>;
 static constexpr std::array s_gc_types = {
     SIDeviceName{SerialInterface::SIDEVICE_NONE, _trans("None")},
@@ -205,10 +203,6 @@ void GamecubeControllersWidget::SaveSettings()
       }
     }
   }
-  if (GCAdapter::UseAdapter())
-    GCAdapter::StartScanThread();
-  else
-    GCAdapter::StopScanThread();
 
   SConfig::GetInstance().SaveSettings();
 }

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -460,7 +460,7 @@ static void ScanThreadFunc()
 
   while (s_adapter_detect_thread_running.IsSet())
   {
-    if (!s_detected && UseAdapter() &&
+    if (!s_detected && s_is_adapter_wanted &&
         env->CallStaticBooleanMethod(s_adapter_class, is_usb_device_available_func))
     {
       std::lock_guard lk(s_init_mutex);
@@ -481,6 +481,27 @@ void SetAdapterCallback(std::function<void(void)> func)
 #endif
 }
 
+static void StartScanThread()
+{
+  if (s_adapter_detect_thread_running.IsSet())
+    return;
+#if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
+  if (!s_libusb_context->IsValid())
+    return;
+#endif
+  s_adapter_detect_thread_running.Set(true);
+  s_adapter_detect_thread = std::thread(ScanThreadFunc);
+}
+
+static void StopScanThread()
+{
+  if (s_adapter_detect_thread_running.TestAndClear())
+  {
+    s_hotplug_event.Set();
+    s_adapter_detect_thread.join();
+  }
+}
+
 static void RefreshConfig()
 {
   s_is_adapter_wanted = false;
@@ -491,6 +512,11 @@ static void RefreshConfig()
                            SerialInterface::SIDevices::SIDEVICE_WIIU_ADAPTER;
     s_config_rumble_enabled[i] = Config::Get(Config::GetInfoForAdapterRumble(i));
   }
+
+  if (s_is_adapter_wanted)
+    StartScanThread();
+  else
+    StopScanThread();
 }
 
 void Init()
@@ -529,30 +555,6 @@ void Init()
   if (!s_config_callback_id)
     s_config_callback_id = Config::AddConfigChangedCallback(RefreshConfig);
   RefreshConfig();
-
-  if (UseAdapter())
-    StartScanThread();
-}
-
-void StartScanThread()
-{
-  if (s_adapter_detect_thread_running.IsSet())
-    return;
-#if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
-  if (!s_libusb_context->IsValid())
-    return;
-#endif
-  s_adapter_detect_thread_running.Set(true);
-  s_adapter_detect_thread = std::thread(ScanThreadFunc);
-}
-
-void StopScanThread()
-{
-  if (s_adapter_detect_thread_running.TestAndClear())
-  {
-    s_hotplug_event.Set();
-    s_adapter_detect_thread.join();
-  }
 }
 
 static void Setup()
@@ -826,7 +828,7 @@ static void Reset()
 
 GCPadStatus Input(int chan)
 {
-  if (!UseAdapter())
+  if (!s_is_adapter_wanted)
     return {};
 
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
@@ -964,11 +966,6 @@ void ResetDeviceType(int chan)
   s_port_states[chan].controller_type = ControllerType::None;
 }
 
-bool UseAdapter()
-{
-  return s_is_adapter_wanted;
-}
-
 void ResetRumble()
 {
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
@@ -992,7 +989,7 @@ void ResetRumble()
 // being called while the libusb state is being reset
 static void ResetRumbleLockNeeded()
 {
-  if (!UseAdapter() || (s_handle == nullptr || s_status != AdapterStatus::Detected))
+  if (!s_is_adapter_wanted || s_handle == nullptr || s_status != AdapterStatus::Detected)
   {
     return;
   }
@@ -1019,7 +1016,7 @@ static void ResetRumbleLockNeeded()
 
 void Output(int chan, u8 rumble_command)
 {
-  if (!UseAdapter() || !s_config_rumble_enabled[chan])
+  if (!s_is_adapter_wanted || !s_config_rumble_enabled[chan])
     return;
 
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -15,8 +15,6 @@ void Init();
 void ResetRumble();
 void Shutdown();
 void SetAdapterCallback(std::function<void(void)> func);
-void StartScanThread();
-void StopScanThread();
 
 // Buttons have PAD_GET_ORIGIN set on new connection
 // Netplay and CSIDevice_GCAdapter make use of this.
@@ -26,7 +24,6 @@ void Output(int chan, u8 rumble_command);
 bool IsDetected(const char** error_message);
 bool DeviceConnected(int chan);
 void ResetDeviceType(int chan);
-bool UseAdapter();
 
 // Callable from any thread. Returns 0 when the adapter is not detected.
 double GetCurrentPollRate();


### PR DESCRIPTION
This keeps the logic encapsulated inside GCAdapter.cpp so callers don't have to think about it.