### PR TITLE
GameSettings: Disable PageTableFastmem in "Second Sight" to fix freeze.

### DIFF
--- a/Data/Sys/GameSettings/GIS.ini
+++ b/Data/Sys/GameSettings/GIS.ini
@@ -1,13 +1,7 @@
 # GISE36, GISP36 - Second Sight
 
 [Core]
-# Values set here will override the main Dolphin settings.
 CPUThread = False
 MMU = True
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
+# Fixes freeze on opening "play" screen.
+PageTableFastmem = False


### PR DESCRIPTION
Addresses: https://bugs.dolphin-emu.org/issues/14030