### PR TITLE
GameSettings: Add Wind Waker pre-release demo

### DIFF
--- a/Data/Sys/GameSettings/D44.ini
+++ b/Data/Sys/GameSettings/D44.ini
@@ -1,4 +1,4 @@
-# GZLE01, GZLJ01, GZLP01 - The Legend of Zelda: The Wind Waker
+# D44J01 - The Legend of Zelda: The Wind Waker Demo Prerelease
 
 [Video_Hacks]
 # Prevent sun flares from going through walls.


### PR DESCRIPTION
It is listed in the [Dolphin wiki](https://wiki.dolphin-emu.org/index.php?title=The_Legend_of_Zelda:_The_Wind_Waker_Demo_Prerelease) with the assumption that it's using the same default settings as regular Wind Waker.

I don't know if the Picto Box is even obtainable in the demo... but maybe it is through glitches or something, so I'll keep `EFBToTextureEnable = False` in.