### PR TITLE
Core: Fix memory breakpoints with MSR.DR off

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -18,6 +18,7 @@
 #include <span>
 #include <tuple>
 
+#include "Common/Align.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -36,6 +37,7 @@
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/VideoInterface.h"
 #include "Core/HW/WII_IPC.h"
+#include "Core/PowerPC/BreakPoints.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
@@ -137,8 +139,6 @@ void MemoryManager::Init()
   }
   m_arena.GrabSHMSegment(mem_size, "dolphin-emu");
 
-  m_physical_page_mappings.fill(nullptr);
-
   // Create an anonymous view of the physical memory
   for (const PhysicalMemoryRegion& region : m_physical_regions)
   {
@@ -153,12 +153,6 @@ void MemoryManager::Init()
           "Memory::Init(): Failed to create view for physical region at 0x{:08X} (size 0x{:08X}).",
           region.physical_address, region.size);
       exit(0);
-    }
-
-    for (u32 i = 0; i < region.size; i += PowerPC::BAT_PAGE_SIZE)
-    {
-      const size_t index = (i + region.physical_address) >> PowerPC::BAT_INDEX_SHIFT;
-      m_physical_page_mappings[index] = *region.out_pointer + i;
     }
   }
 
@@ -223,25 +217,85 @@ bool MemoryManager::InitFastmemArena()
   m_physical_base = m_fastmem_arena + guard_size;
   m_logical_base = m_fastmem_arena + ppc_view_size + guard_size * 2;
 
-  for (const PhysicalMemoryRegion& region : m_physical_regions)
-  {
-    if (!region.active)
-      continue;
-
-    void* base = m_physical_base + region.physical_address;
-    void* view = m_arena.MapInMemoryRegion(region.shm_position, region.size, base, true);
-
-    if (base != view)
-    {
-      PanicAlertFmt("Memory::InitFastmemArena(): Failed to map memory region at 0x{:08X} "
-                    "(size 0x{:08X}) into physical fastmem region.",
-                    region.physical_address, region.size);
-      return false;
-    }
-  }
+  if (!UpdatePhysicalMappings())
+    return false;
 
   m_is_fastmem_arena_initialized = true;
   m_fastmem_arena_size = memory_size;
+  return true;
+}
+
+bool MemoryManager::UpdatePhysicalMappings()
+{
+  if (!m_is_initialized)
+    return true;
+
+  for (const auto& entry : m_physical_mapped_entries)
+  {
+    m_arena.UnmapFromMemoryRegion(entry.mapped_pointer, entry.mapped_size);
+  }
+  m_physical_mapped_entries.clear();
+
+  m_physical_page_mappings.fill(nullptr);
+
+  for (const PhysicalMemoryRegion& region : m_physical_regions)
+  {
+    if (!AddPhysicalMapping(region))
+      return false;
+  }
+
+  return true;
+}
+
+bool MemoryManager::AddPhysicalMapping(const PhysicalMemoryRegion& region)
+{
+  if (!region.active || region.size == 0)
+    return true;
+
+  // If the region overlaps with a memcheck, split the region in two,
+  // one on each side of the memcheck.
+  const auto& memchecks = m_system.GetPowerPC().GetMemChecks().GetMemChecks();
+  for (const TMemCheck& memcheck : memchecks)
+  {
+    DEBUG_ASSERT(memcheck.start_address < memcheck.end_address);
+    if (memcheck.start_address <= region.physical_address + region.size &&
+        memcheck.end_address >= region.physical_address)
+    {
+      PhysicalMemoryRegion split_region_1 = region;
+      split_region_1.size = Common::AlignDown(memcheck.start_address - region.physical_address,
+                                              PowerPC::BAT_PAGE_SIZE);
+      if (!AddPhysicalMapping(split_region_1))
+        return false;
+
+      PhysicalMemoryRegion split_region_2 = region;
+      const u32 offset =
+          Common::AlignUp(memcheck.end_address - region.physical_address, PowerPC::BAT_PAGE_SIZE);
+      split_region_2.out_pointer += offset;
+      split_region_2.physical_address += offset;
+      split_region_2.shm_position += offset;
+      split_region_2.size -= offset;
+      return AddPhysicalMapping(split_region_2);
+    }
+  }
+
+  void* base = m_physical_base + region.physical_address;
+  void* view = m_arena.MapInMemoryRegion(region.shm_position, region.size, base, true);
+
+  if (base != view)
+  {
+    PanicAlertFmt("Memory::AddPhysicalMapping(): Failed to map memory region at 0x{:08X} "
+                  "(size 0x{:08X}) into physical fastmem region.",
+                  region.physical_address, region.size);
+    return false;
+  }
+  m_physical_mapped_entries.emplace_back(view, region.size);
+
+  for (u32 i = 0; i < region.size; i += PowerPC::BAT_PAGE_SIZE)
+  {
+    const size_t index = (i + region.physical_address) >> PowerPC::BAT_INDEX_SHIFT;
+    m_physical_page_mappings[index] = *region.out_pointer + i;
+  }
+
   return true;
 }
 
@@ -564,14 +618,11 @@ void MemoryManager::ShutdownFastmemArena()
   if (!m_is_fastmem_arena_initialized)
     return;
 
-  for (const PhysicalMemoryRegion& region : m_physical_regions)
+  for (const auto& entry : m_physical_mapped_entries)
   {
-    if (!region.active)
-      continue;
-
-    u8* base = m_physical_base + region.physical_address;
-    m_arena.UnmapFromMemoryRegion(base, region.size);
+    m_arena.UnmapFromMemoryRegion(entry.mapped_pointer, entry.mapped_size);
   }
+  m_physical_mapped_entries.clear();
 
   for (const auto& [logical_address, entry] : m_dbat_mapped_entries)
   {

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -104,6 +104,7 @@ public:
   void ShutdownFastmemArena();
   void DoState(PointerWrap& p);
 
+  bool UpdatePhysicalMappings();
   void UpdateDBATMappings(const PowerPC::BatTable& dbat_table);
   void AddPageTableMapping(u32 logical_address, u32 translated_address, bool writeable);
   void RemovePageTableMappings(const std::set<u32>& mappings);
@@ -269,6 +270,8 @@ private:
   // TODO: Do we want to handle the mirrors of the GC RAM?
   std::array<PhysicalMemoryRegion, 4> m_physical_regions{};
 
+  std::vector<LogicalMemoryView> m_physical_mapped_entries;
+
   // The key is the logical address
   std::map<u32, LogicalMemoryView> m_dbat_mapped_entries;
   std::map<u32, LogicalMemoryView> m_page_table_mapped_entries;
@@ -285,6 +288,8 @@ private:
   Core::System& m_system;
 
   static HostPageType GetHostPageTypeForPageSize(u32 page_size);
+
+  bool AddPhysicalMapping(const PhysicalMemoryRegion& region);
 
   void TryAddLargePageTableMapping(u32 logical_address, u32 translated_address, bool writeable);
   bool TryAddLargePageTableMapping(u32 logical_address, u32 translated_address,

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -15,6 +15,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/Core.h"
 #include "Core/Debugger/DebugInterface.h"
+#include "Core/HW/Memmap.h"
 #include "Core/PowerPC/Expression.h"
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/MMU.h"
@@ -368,6 +369,11 @@ void MemChecks::Update()
     m_mem_breakpoints_set = HasAny();
   }
 
+  // We have to make sure there are no fastmem mappings for memory covered by memchecks, otherwise
+  // the JIT can access the memory without triggering the memcheck. We accomplish this by recreating
+  // fastmem mappings here. The code that creates the mappings calls into this class to find out
+  // what regions of memory to skip mapping.
+  m_system.GetMemory().UpdatePhysicalMappings();
   m_system.GetMMU().DBATUpdated();
 }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -140,8 +140,7 @@ void JitBase::RefreshConfig()
   analyzer.SetDivByZeroExceptionsEnabled(m_enable_div_by_zero_exceptions);
 
   bool any_watchpoints = m_system.GetPowerPC().GetMemChecks().HasAny();
-  jo.fastmem = m_fastmem_enabled && jo.fastmem_arena && (m_ppc_state.msr.DR || !any_watchpoints) &&
-               EMM::IsExceptionHandlerSupported();
+  jo.fastmem = m_fastmem_enabled && jo.fastmem_arena && EMM::IsExceptionHandlerSupported();
   jo.memcheck = m_system.IsMMUMode() || m_system.IsPauseOnPanicMode() || any_watchpoints;
   jo.fp_exceptions = m_enable_float_exceptions;
   jo.div_by_zero_exceptions = m_enable_div_by_zero_exceptions;


### PR DESCRIPTION
`JitBase::RefreshConfig` has had a check to disable fastmem if there are memory breakpoints and MSR.DR is disabled. This is because the code in `MemoryManager` that sets up physical fastmem mappings (which are used when MSR.DR is disabled) doesn't skip creating mappings in locations that have memory breakpoints, unlike the corresponding code that sets up logical fastmem mappings (which are used when MSR.DR is enabled).

There is a problem with this check: `JitBase::RefreshConfig` doesn't re-run if MSR.DR changes. So if MSR.DR happened to be enabled when `JitBase::RefreshConfig` last ran, memory breakpoints would be broken when MSR.DR is disabled, and if MSR.DR happened to be disabled when `JitBase::RefreshConfig` last ran, fastmem would be disabled across the board, impacting performance.

To fix this, let's remove the check from `JitBase::RefreshConfig` and make `MemoryManager`'s code for creating physical fastmem mappings take memory breakpoints into account.