### PR TITLE
ARCodeWidget/GeckoCodeWidget: Add button to enable/disable all codes

### DIFF
--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -4,6 +4,7 @@
 #include "DolphinQt/Config/ARCodeWidget.h"
 
 #include <algorithm>
+#include <functional>
 #include <utility>
 
 #include <QCursor>
@@ -72,6 +73,7 @@ void ARCodeWidget::CreateWidgets()
   m_code_add = new NonDefaultQPushButton(tr("&Add New Code..."));
   m_code_edit = new NonDefaultQPushButton(tr("&Edit Code..."));
   m_code_remove = new NonDefaultQPushButton(tr("&Remove Code"));
+  m_code_toggle_all = new NonDefaultQPushButton(tr("Disable All"));
 
   m_cheat_code_editor = new CheatCodeEditor(this);
 
@@ -82,6 +84,7 @@ void ARCodeWidget::CreateWidgets()
   button_layout->addWidget(m_code_add);
   button_layout->addWidget(m_code_edit);
   button_layout->addWidget(m_code_remove);
+  button_layout->addWidget(m_code_toggle_all);
 
   auto* const layout = new QVBoxLayout{this};
 
@@ -113,6 +116,7 @@ void ARCodeWidget::ConnectWidgets()
   connect(m_code_add, &QPushButton::clicked, this, &ARCodeWidget::OnCodeAddClicked);
   connect(m_code_edit, &QPushButton::clicked, this, &ARCodeWidget::OnCodeEditClicked);
   connect(m_code_remove, &QPushButton::clicked, this, &ARCodeWidget::OnCodeRemoveClicked);
+  connect(m_code_toggle_all, &QPushButton::clicked, this, &ARCodeWidget::OnCodeToggleAllClicked);
 }
 
 void ARCodeWidget::OnItemChanged(QListWidgetItem* item)
@@ -122,7 +126,7 @@ void ARCodeWidget::OnItemChanged(QListWidgetItem* item)
   if (!m_restart_required)
     ActionReplay::ApplyCodes(m_ar_codes, m_game_id, m_game_revision);
 
-  UpdateList();
+  UpdateToggleButton();
   SaveCodes();
 }
 
@@ -155,6 +159,21 @@ void ARCodeWidget::SortDisabledCodesFirst()
   std::ranges::stable_partition(m_ar_codes, std::logical_not{}, &ActionReplay::ARCode::enabled);
   UpdateList();
   SaveCodes();
+}
+
+bool ARCodeWidget::IsEveryCodeEnabled()
+{
+  return std::ranges::all_of(m_ar_codes, &ActionReplay::ARCode::enabled);
+}
+
+void ARCodeWidget::UpdateToggleButton()
+{
+  if (IsEveryCodeEnabled())
+    m_code_toggle_all->setText(tr("Disable All"));
+  else
+    m_code_toggle_all->setText(tr("Enable All"));
+
+  m_code_toggle_all->setDisabled(m_ar_codes.empty());
 }
 
 void ARCodeWidget::OnListReordered()
@@ -229,6 +248,7 @@ void ARCodeWidget::UpdateList()
   }
 
   m_code_list->setDragDropMode(QAbstractItemView::InternalMove);
+  UpdateToggleButton();
 }
 
 void ARCodeWidget::LoadCodes()
@@ -340,4 +360,29 @@ void ARCodeWidget::OnCodeRemoveClicked()
   UpdateList();
 
   m_code_remove->setEnabled(false);
+}
+
+void ARCodeWidget::OnCodeToggleAllClicked()
+{
+  const bool new_state = !IsEveryCodeEnabled();
+  const Qt::CheckState new_check_state =
+      new_state ? Qt::CheckState::Checked : Qt::CheckState::Unchecked;
+
+  {
+    // Without this blocker, the call to setCheckState below would end up loading and saving the ini
+    // file once per code.
+    QSignalBlocker blocker(m_code_list);
+
+    for (int i = 0; i < m_ar_codes.size(); ++i)
+    {
+      m_ar_codes[i].enabled = new_state;
+      m_code_list->item(i)->setCheckState(new_check_state);
+    }
+  }
+
+  if (!m_restart_required)
+    ActionReplay::ApplyCodes(m_ar_codes, m_game_id, m_game_revision);
+
+  UpdateList();
+  SaveCodes();
 }

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.h
@@ -54,12 +54,16 @@ private:
   void SortAlphabetically();
   void SortEnabledCodesFirst();
   void SortDisabledCodesFirst();
+  void UpdateToggleButton();
 
   void OnCodeAddClicked();
   void OnCodeEditClicked();
   void OnCodeRemoveClicked();
+  void OnCodeToggleAllClicked();
 
   void OnListReordered();
+
+  bool IsEveryCodeEnabled();
 
   std::string m_game_id;
   u16 m_game_revision;
@@ -72,6 +76,7 @@ private:
   QPushButton* m_code_add;
   QPushButton* m_code_edit;
   QPushButton* m_code_remove;
+  QPushButton* m_code_toggle_all;
 
   CheatCodeEditor* m_cheat_code_editor;
 

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -4,6 +4,7 @@
 #include "DolphinQt/Config/GeckoCodeWidget.h"
 
 #include <algorithm>
+#include <functional>
 #include <utility>
 
 #include <QCursor>
@@ -108,6 +109,7 @@ void GeckoCodeWidget::CreateWidgets()
   m_edit_code = new NonDefaultQPushButton(tr("&Edit Code..."));
   m_remove_code = new NonDefaultQPushButton(tr("&Remove Code"));
   m_download_codes = new NonDefaultQPushButton(tr("Download Codes"));
+  m_toggle_all_codes = new NonDefaultQPushButton(tr("Disable All"));
 
   m_cheat_code_editor = new CheatCodeEditor(this);
 
@@ -145,6 +147,7 @@ void GeckoCodeWidget::CreateWidgets()
   btn_layout->addWidget(m_edit_code);
   btn_layout->addWidget(m_remove_code);
   btn_layout->addWidget(m_download_codes);
+  btn_layout->addWidget(m_toggle_all_codes);
 
   layout->addLayout(btn_layout);
 }
@@ -163,6 +166,7 @@ void GeckoCodeWidget::ConnectWidgets()
   connect(m_remove_code, &QPushButton::clicked, this, &GeckoCodeWidget::RemoveCode);
   connect(m_edit_code, &QPushButton::clicked, this, &GeckoCodeWidget::EditCode);
   connect(m_download_codes, &QPushButton::clicked, this, &GeckoCodeWidget::DownloadCodes);
+  connect(m_toggle_all_codes, &QPushButton::clicked, this, &GeckoCodeWidget::ToggleAllCodes);
   connect(m_warning, &CheatWarningWidget::OpenCheatEnableSettings, this,
           &GeckoCodeWidget::OpenGeneralSettings);
 #ifdef USE_RETRO_ACHIEVEMENTS
@@ -212,6 +216,7 @@ void GeckoCodeWidget::OnItemChanged(QListWidgetItem* item)
   if (!m_restart_required)
     Gecko::SetActiveCodes(m_gecko_codes, m_game_id, m_game_revision);
 
+  UpdateToggleButton();
   SaveCodes();
 }
 
@@ -336,6 +341,21 @@ void GeckoCodeWidget::SortDisabledCodesFirst()
   SaveCodes();
 }
 
+bool GeckoCodeWidget::IsEveryCodeEnabled()
+{
+  return std::ranges::all_of(m_gecko_codes, &Gecko::GeckoCode::enabled);
+}
+
+void GeckoCodeWidget::UpdateToggleButton()
+{
+  if (IsEveryCodeEnabled())
+    m_toggle_all_codes->setText(tr("Disable All"));
+  else
+    m_toggle_all_codes->setText(tr("Enable All"));
+
+  m_toggle_all_codes->setDisabled(m_gecko_codes.empty());
+}
+
 void GeckoCodeWidget::OnListReordered()
 {
   // Reorder codes based on the indices of table item
@@ -391,6 +411,7 @@ void GeckoCodeWidget::UpdateList()
   }
 
   m_code_list->setDragDropMode(QAbstractItemView::InternalMove);
+  UpdateToggleButton();
 }
 
 void GeckoCodeWidget::DownloadCodes()
@@ -437,4 +458,29 @@ void GeckoCodeWidget::DownloadCodes()
       this, tr("Download complete"),
       tr("Downloaded %1 codes. (added %2)")
           .arg(QString::number(codes.size()), QString::number(added_count)));
+}
+
+void GeckoCodeWidget::ToggleAllCodes()
+{
+  const bool new_state = !IsEveryCodeEnabled();
+  const Qt::CheckState new_check_state =
+      new_state ? Qt::CheckState::Checked : Qt::CheckState::Unchecked;
+
+  {
+    // Without this blocker, the call to setCheckState below would end up loading and saving the ini
+    // file once per code.
+    QSignalBlocker blocker(m_code_list);
+
+    for (int i = 0; i < m_gecko_codes.size(); ++i)
+    {
+      m_gecko_codes[i].enabled = new_state;
+      m_code_list->item(i)->setCheckState(new_check_state);
+    }
+  }
+
+  if (!m_restart_required)
+    Gecko::SetActiveCodes(m_gecko_codes, m_game_id, m_game_revision);
+
+  UpdateList();
+  SaveCodes();
 }

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
@@ -55,11 +55,15 @@ private:
   void EditCode();
   void RemoveCode();
   void DownloadCodes();
+  void ToggleAllCodes();
   void LoadCodes();
   void SaveCodes();
   void SortAlphabetically();
   void SortEnabledCodesFirst();
   void SortDisabledCodesFirst();
+  void UpdateToggleButton();
+
+  bool IsEveryCodeEnabled();
 
   std::string m_game_id;
   std::string m_gametdb_id;
@@ -78,6 +82,7 @@ private:
   QPushButton* m_edit_code;
   QPushButton* m_remove_code;
   QPushButton* m_download_codes;
+  QPushButton* m_toggle_all_codes;
   CheatCodeEditor* m_cheat_code_editor;
   std::vector<Gecko::GeckoCode> m_gecko_codes;
   bool m_restart_required;


### PR DESCRIPTION
Add a button to ARCodeWidget and GeckoCodeWidget to enable/disable all codes at once instead of having to click each code's checkbox individually.