### PR TITLE
GameSettings: Set SafeTextureCacheColorSamples for "Sonic and the Secret Rings".

### DIFF
--- a/Data/Sys/GameSettings/DSR.ini
+++ b/Data/Sys/GameSettings/DSR.ini
@@ -1,11 +1,9 @@
 # DSRJ8P - Sonic and the Secret Rings
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Fixes detection of motion actions.
 RealWiiRemoteRepeatReports = False
 
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
+[Video_Settings]
+# Fixes text glitching in the ring customization menu.
+SafeTextureCacheColorSamples = 2048

--- a/Data/Sys/GameSettings/RSR.ini
+++ b/Data/Sys/GameSettings/RSR.ini
@@ -1,11 +1,9 @@
 # RSRP8P, RSRE8P, RSRJ8P - Sonic and the Secret Rings
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Fixes detection of motion actions.
 RealWiiRemoteRepeatReports = False
 
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
+[Video_Settings]
+# Fixes text glitching in the ring customization menu.
+SafeTextureCacheColorSamples = 2048


### PR DESCRIPTION
Fixes glitching text in the ring customization menu: https://bugs.dolphin-emu.org/issues/13999