### PR TITLE
Unconditionally lock in ControllerInterface::UpdateInput

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -319,7 +319,7 @@ void ControllerInterface::RemoveDevice(std::function<bool(const ciface::Core::De
     InvokeDevicesChangedCallbacks();
 }
 
-// Update input for all devices if lock can be acquired without waiting.
+// Update input for all devices.
 void ControllerInterface::UpdateInput()
 {
   // This should never happen
@@ -337,13 +337,7 @@ void ControllerInterface::UpdateInput()
   std::vector<std::weak_ptr<ciface::Core::Device>> devices_to_remove;
 
   {
-    // TODO: if we are an emulation input channel, we should probably always lock.
-    // Prefer outdated values over blocking UI or CPU thread (this avoids short but noticeable frame
-    // drops)
-    if (!m_devices_mutex.try_lock())
-      return;
-
-    std::lock_guard lk_devices(m_devices_mutex, std::adopt_lock);
+    std::lock_guard lk_devices(m_devices_mutex);
 
     tls_is_updating_devices = true;
 


### PR DESCRIPTION
I made these changes originally to the [slippi](https://github.com/project-slippi/dolphin) fork but I believe they affect upstream as well. Without these changes I'm seeing dropped inputs from PipeDevices. These changes were mostly discovered/written by Claude so I'd like some feedback from people with a better understanding of dolphin to check whether they makes sense.

It's interesting that the second commit to `ControllerInterface.cpp` could affect regular controllers as well. Claude's analysis for why the `lock` is necessary is that contention between the SI device polling and the HotkeyScheduler could be causing inputs to be dropped. There is also an existing comment suggesting that a `lock` should be used.