### PR TITLE
JitArm64: Fix DR check in MSRUpdated

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -471,8 +471,6 @@ void JitArm64::MSRUpdated(u32 msr)
 
 void JitArm64::MSRUpdated(ARM64Reg msr)
 {
-  constexpr LogicalImm dr_bit(1ULL << UReg_MSR{}.DR.StartBit(), GPRSize::B32);
-
   auto WA = gpr.GetScopedReg();
   ARM64Reg XA = EncodeRegTo64(WA);
 
@@ -480,7 +478,7 @@ void JitArm64::MSRUpdated(ARM64Reg msr)
   auto& memory = m_system.GetMemory();
   MOVP2R(MEM_REG, jo.fastmem ? memory.GetLogicalBase() : memory.GetLogicalPageMappingsBase());
   MOVP2R(XA, jo.fastmem ? memory.GetPhysicalBase() : memory.GetPhysicalPageMappingsBase());
-  TST(msr, dr_bit);
+  TST(msr, LogicalImm(1ULL << UReg_MSR{}.DR.StartBit(), GPRSize::B32));
   CSEL(MEM_REG, MEM_REG, XA, CCFlags::CC_NEQ);
   STR(IndexType::Unsigned, MEM_REG, PPC_REG, PPCSTATE_OFF(mem_ptr));
 
@@ -499,7 +497,7 @@ void JitArm64::MSRUpdated(ARM64Reg msr)
   MOV(WA, msr);
   gpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
   fpr.Flush(FlushMode::All, ARM64Reg::INVALID_REG);
-  FixupBranch dr_unset = TBZ(WA, dr_bit);
+  FixupBranch dr_unset = TBZ(WA, u8(UReg_MSR{}.DR.StartBit()));
   static_assert(PPCSTATE_OFF(pagetable_update_pending) < 0x1000);
   LDRB(IndexType::Unsigned, WA, PPC_REG, PPCSTATE_OFF(pagetable_update_pending));
   FixupBranch update_not_pending = CBZ(WA);


### PR DESCRIPTION
TBZ takes the index of the bit to test, not a LogicalImm.