### PR TITLE
Android: Move alert message log from Kotlin to C++

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.kt
@@ -480,7 +480,6 @@ object NativeLibrary {
     fun displayAlertMsg(
         caption: String, text: String, yesNo: Boolean, isWarning: Boolean, nonBlocking: Boolean
     ): Boolean {
-        Log.error("[NativeLibrary] Alert: $text")
         val emulationActivity = emulationActivityRef.get()
         var result = false
 

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -202,6 +202,8 @@ std::unique_ptr<GBAHostInterface> Host_CreateGBAHost(std::weak_ptr<HW::GBA::Core
 
 static bool MsgAlert(const char* caption, const char* text, bool yes_no, Common::MsgType style)
 {
+  __android_log_print(ANDROID_LOG_ERROR, DOLPHIN_TAG, "[NativeLibrary] Alert: %s", text);
+
   JNIEnv* env = IDCache::GetEnvForThread();
 
   jstring j_caption = ToJString(env, caption);


### PR DESCRIPTION
For some reason, NativeLibrary.kt calling Log for the alert message text makes Dolphin die with a JNI error. Supposedly the jstring passed to the logging function is invalid. I don't understand why, because the dialog that we show right afterwards is able to read the string just fine. The error happens even if I pass the string directly to Log without prepending any extra text.

There's no real downside to having the logging in C++ instead of Kotlin, so let's move it to C++ to avoid the JNI error.