### PR TITLE
GameSettings: Add idle loop speed hack for Pokémon Colosseum

### DIFF
--- a/Data/Sys/GameSettings/GC6P01.ini
+++ b/Data/Sys/GameSettings/GC6P01.ini
@@ -26,8 +26,17 @@ $Allow Memory Card saving with Savestates
 0x801d429c:dword:0x9005002c
 0x801d42ec:dword:0x60000000
 
+# The game at launch calls `OSSetIdleFunction` to create a thread
+# of unknown purpose. This thread prevents Dolphin from idling
+# whenever the main thread calls `VIWaitForRetrace`.
+#
+# The patch prevents that thread from being created.
+$Speed hack
+0x80101F68:dword:0x60000000
+
 [OnFrame_Enabled]
 $Allow Memory Card saving with Savestates
+$Speed hack
 
 [ActionReplay]
 $16:9 Widescreen [Ralf]
@@ -41,6 +50,7 @@ $60 FPS [Nerdzilla]
 
 [Patches_RetroAchievements_Verified]
 $Allow Memory Card saving with Savestates
+$Speed hack
 
 [AR_RetroAchievements_Verified]
 $16:9 Widescreen [Ralf]


### PR DESCRIPTION
Draft because it's barely tested (I did test the "main features" (except for GBA linking), but maybe there's a nasty bug somewhere), versions outside of PAL need porting, and the RetroAchievements hash isn't updated.