### PR TITLE
GameSettings: Add idle loop speed hack for Knights of the Temple: Infernal Crusade

### DIFF
--- a/Data/Sys/GameSettings/GTP.ini
+++ b/Data/Sys/GameSettings/GTP.ini
@@ -1,0 +1,29 @@
+# GTPP6S - Knights of the Temple: Infernal Crusade
+
+[OnFrame]
+# In function `WaitForToken` there's a loop that continously calls
+# `GXReadDrawSync`, waiting for it to reach a certain value.
+# However, if the loop is executed 10000 times without that happening,
+# then it timeouts and proceeds anyway (with broken graphics).
+#
+# The logic for the timeout prevents Dolphin from idling during the loop.
+# The patch modifies `WaitForToken` to remove the timeout, allowing
+# Dolphin to idle and improving emulation performance.
+#
+# As a side effect, this allows to use hacks that affect the emulated CPU
+# clock without the graphics breaking.
+#
+# Note that there's a function that calls `WaitForToken` with nonsensical
+# arguments (is it intentional?). Normally, this is escapable due to the
+# timeout, but since that's removed, it freezes the game.
+# Thus, the patch nopes out the nonsensical call.
+$Speed hack
+0x80279D28:dword:0x4180FFF4
+0x80279D2C:dword:0x48000030
+0x802723B4:dword:0x60000000
+
+[OnFrame_Enabled]
+$Speed hack
+
+[Patches_RetroAchievements_Verified]
+$Speed hack


### PR DESCRIPTION
(Reminder: after this is merged, edit the wiki (it related to the Menu Backgrounds problem), and add that it supports VBI Frequency Override (not adding now because it's a bad experience without the speed hack))

Draft because it needs more testing (and then updating the RetroAchievements hash). So, currently leaving just for documentation.
At least there's no other versions that need porting!