### PR TITLE
Replace some [[maybe_unused]] annotations with commented names

### DIFF
--- a/Source/Core/Common/Logging/ConsoleListenerWin.cpp
+++ b/Source/Core/Common/Logging/ConsoleListenerWin.cpp
@@ -15,7 +15,7 @@ ConsoleListener::~ConsoleListener()
 {
 }
 
-void ConsoleListener::Log([[maybe_unused]] Common::Log::LogLevel level, const char* text)
+void ConsoleListener::Log(Common::Log::LogLevel, const char* text)
 {
   ::OutputDebugStringW(UTF8ToWString(text).c_str());
 }

--- a/Source/Core/Core/IOS/USB/Emulated/Microphone.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/Microphone.cpp
@@ -57,7 +57,7 @@ void Microphone::StreamInit()
 {
 }
 
-void Microphone::StreamStart([[maybe_unused]] u32 sampling_rate)
+void Microphone::StreamStart(u32 /* sampling_rate */)
 {
 }
 

--- a/Source/Core/VideoBackends/Null/NullGfx.cpp
+++ b/Source/Core/VideoBackends/Null/NullGfx.cpp
@@ -34,7 +34,7 @@ bool NullGfx::SupportsUtilityDrawing() const
 }
 
 std::unique_ptr<AbstractTexture> NullGfx::CreateTexture(const TextureConfig& config,
-                                                        [[maybe_unused]] std::string_view name)
+                                                        std::string_view /* name */)
 {
   return std::make_unique<NullTexture>(config);
 }
@@ -52,16 +52,17 @@ public:
 };
 
 std::unique_ptr<AbstractShader>
-NullGfx::CreateShaderFromSource(ShaderStage stage, [[maybe_unused]] std::string_view source,
-                                [[maybe_unused]] VideoCommon::ShaderIncluder* shader_includer,
-                                [[maybe_unused]] std::string_view name)
+NullGfx::CreateShaderFromSource(ShaderStage stage, std::string_view /* source */,
+                                VideoCommon::ShaderIncluder* /* shader_includer */,
+                                std::string_view /* name */)
 {
   return std::make_unique<NullShader>(stage);
 }
 
-std::unique_ptr<AbstractShader>
-NullGfx::CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length,
-                                [[maybe_unused]] std::string_view name)
+std::unique_ptr<AbstractShader> NullGfx::CreateShaderFromBinary(ShaderStage stage,
+                                                                const void* /* data */,
+                                                                size_t /* length */,
+                                                                std::string_view /* name */)
 {
   return std::make_unique<NullShader>(stage);
 }

--- a/Source/Core/VideoBackends/OGL/OGLGfx.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLGfx.cpp
@@ -235,9 +235,10 @@ OGLGfx::CreateShaderFromSource(ShaderStage stage, std::string_view source,
   return OGLShader::CreateFromSource(stage, source, shader_includer, name);
 }
 
-std::unique_ptr<AbstractShader>
-OGLGfx::CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length,
-                               [[maybe_unused]] std::string_view name)
+std::unique_ptr<AbstractShader> OGLGfx::CreateShaderFromBinary(ShaderStage /* stage */,
+                                                               const void* /* data */,
+                                                               size_t /* length */,
+                                                               std::string_view /* name */)
 {
   return nullptr;
 }

--- a/Source/Core/VideoBackends/Software/SWGfx.cpp
+++ b/Source/Core/VideoBackends/Software/SWGfx.cpp
@@ -35,7 +35,7 @@ bool SWGfx::SupportsUtilityDrawing() const
 }
 
 std::unique_ptr<AbstractTexture> SWGfx::CreateTexture(const TextureConfig& config,
-                                                      [[maybe_unused]] std::string_view name)
+                                                      std::string_view /* name */)
 {
   return std::make_unique<SWTexture>(config);
 }
@@ -77,16 +77,17 @@ public:
 };
 
 std::unique_ptr<AbstractShader>
-SWGfx::CreateShaderFromSource(ShaderStage stage, [[maybe_unused]] std::string_view source,
-                              [[maybe_unused]] VideoCommon::ShaderIncluder* shader_includer,
-                              [[maybe_unused]] std::string_view name)
+SWGfx::CreateShaderFromSource(ShaderStage stage, std::string_view /* source */,
+                              VideoCommon::ShaderIncluder* /* shader_includer */,
+                              std::string_view /* name */)
 {
   return std::make_unique<SWShader>(stage);
 }
 
-std::unique_ptr<AbstractShader>
-SWGfx::CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length,
-                              [[maybe_unused]] std::string_view name)
+std::unique_ptr<AbstractShader> SWGfx::CreateShaderFromBinary(ShaderStage stage,
+                                                              const void* /* data */,
+                                                              size_t /* length */,
+                                                              std::string_view /* name */)
 {
   return std::make_unique<SWShader>(stage);
 }

--- a/Source/Core/VideoCommon/TMEM.cpp
+++ b/Source/Core/VideoCommon/TMEM.cpp
@@ -143,7 +143,7 @@ void InvalidateAll()
 // On invalidate cache:
 // 1. invalidate all texture units.
 
-void Invalidate([[maybe_unused]] u32 param)
+void Invalidate(u32 /* param */)
 {
   // The exact arguments of Invalidate commands is currently unknown.
   // It appears to contain the TMEM address and a size.

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -24,7 +24,7 @@ constexpr float PosScale(T val, float scale)
 }
 
 template <>
-constexpr float PosScale(float val, [[maybe_unused]] float scale)
+constexpr float PosScale(float val, float /* scale */)
 {
   return val;
 }

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -26,7 +26,7 @@ constexpr float TCScale(T val, float scale)
 }
 
 template <>
-constexpr float TCScale(float val, [[maybe_unused]] float scale)
+constexpr float TCScale(float val, float /* scale */)
 {
   return val;
 }


### PR DESCRIPTION
Remove the [[maybe_unused]] annotation from various parameters that are unconditionally unused and comment out their names instead. This makes it unambiguous that the variables are unused, while making the remaining [[maybe_unused]] annotations more reliable indicators that those variables are in fact used in some contexts.

These parameters are mostly in overridden functions where the override doesn't need that particular variable.