### PR TITLE
Windows: Fix command line output not displaying when using Git Bash

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -120,12 +120,27 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
 int main(int argc, char* argv[])
 {
 #ifdef _WIN32
-  const bool console_attached = AttachConsole(ATTACH_PARENT_PROCESS) != FALSE;
-  HANDLE stdout_handle = ::GetStdHandle(STD_OUTPUT_HANDLE);
-  if (console_attached && stdout_handle)
+  const HANDLE stdout_handle = ::GetStdHandle(STD_OUTPUT_HANDLE);
+  const HANDLE stderr_handle = ::GetStdHandle(STD_ERROR_HANDLE);
+
+  const bool is_invalid_stdout_handle =
+      stdout_handle == nullptr || stdout_handle == INVALID_HANDLE_VALUE;
+  const bool is_invalid_stderr_handle =
+      stderr_handle == nullptr || stderr_handle == INVALID_HANDLE_VALUE;
+
+  // If we already have a console don't try to use one from our parent. This happens when running
+  // Dolphin using `Git Bash`.
+  if (is_invalid_stdout_handle && is_invalid_stderr_handle)
   {
-    freopen("CONOUT$", "w", stdout);
-    freopen("CONOUT$", "w", stderr);
+    // See if the parent process has a console we can use (which happens when Dolphin is launched
+    // via `Command Prompt` or `PowerShell`). If this fails Dolphin was probably launched via the
+    // GUI, in which case we don't want a console anyway.
+    const bool attached_to_parent_console = AttachConsole(ATTACH_PARENT_PROCESS) != FALSE;
+    if (attached_to_parent_console)
+    {
+      static_cast<void>(freopen("CONOUT$", "w", stdout));
+      static_cast<void>(freopen("CONOUT$", "w", stderr));
+    }
   }
 #endif
 


### PR DESCRIPTION
On Windows, check if Dolphin already has a handle for `stdout` or `stderr` before trying to attach to the console of the parent process.

Previously, running Dolphin via `Git Bash` with options like `--help` or `--version` wouldn't produce any output. This was the result of [the fix](https://github.com/dolphin-emu/dolphin/pull/6721) for https://bugs.dolphin-emu.org/issues/11042, before which console output did work for `Git Bash` but didn't for `Command Prompt` or `PowerShell`.