### PR TITLE
DoAllPlayersHaveSameGame returns correct result instead of always true

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2505,7 +2505,7 @@ void NetPlayClient::SendGameStatus()
     }
   }
 
-  packet << static_cast<u32>(result);
+  packet << result;
   Send(packet);
 }
 


### PR DESCRIPTION
SendGameStatus() was writing SyncIdentifierComparison as a u32 but the server reads it as a u8 enum, so the server always gets 0 (SameGame). ~~This bug was introduced in commit a41166bb.~~ This bug was introduced in commit https://github.com/dolphin-emu/dolphin/commit/66276ac61ba3ae3a8b5f840cdb8616ee9bd5dc83