### PR TITLE
MsgHandler: Use LogLevel matching MsgType for alerts

### DIFF
--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -73,6 +73,19 @@ const char* GetCaption(MsgType style)
     return "Unhandled caption";
   }
 }
+
+Log::LogLevel GetMessageAlertLogLevel(const MsgType style)
+{
+  switch (style)
+  {
+  case MsgType::Critical:
+    return Log::LogLevel::LERROR;
+  case MsgType::Warning:
+    return Log::LogLevel::LWARNING;
+  default:
+    return Log::LogLevel::LINFO;
+  }
+}
 }  // Anonymous namespace
 
 // Select which of these functions that are used for message boxes. If
@@ -108,10 +121,10 @@ static bool ShowMessageAlert(std::string_view text, bool yes_no, Common::Log::Lo
                              MsgType style, const char* file, int line)
 {
   const char* caption = GetCaption(style);
+  const Log::LogLevel level = GetMessageAlertLogLevel(style);
   // Directly call GenericLogFmt rather than using the normal log macros so that we can use the
   // caller's line file and line number
-  Common::Log::GenericLogFmt<2>(Common::Log::LogLevel::LERROR, log_type, file, line,
-                                FMT_STRING("{}: {}"), caption, text);
+  Common::Log::GenericLogFmt<2>(level, log_type, file, line, FMT_STRING("{}: {}"), caption, text);
 
   // Panic alerts.
   if (style == MsgType::Warning && s_abort_on_panic_alert)


### PR DESCRIPTION
When calling `ShowMessageAlert` with a given `MsgType`, log the alert with a `LogLevel` matching the `MsgType` instead of always using `LogLevel::LERROR`.

I noticed this after performing a manual update check when I was up-to-date, which was logged as an error.

master:
<img width="445" height="58" alt="master" src="https://github.com/user-attachments/assets/ccbaad85-7d33-4c66-ac2e-51fb227bfe5c" />
PR:
<img width="453" height="60" alt="PR" src="https://github.com/user-attachments/assets/6e9d9200-74d3-4656-a997-25e6e9c09448" />
