### PR TITLE
VideoCommon: Allow resizing EFB copies in VRAM

### DIFF
--- a/Data/Sys/GameSettings/REX.ini
+++ b/Data/Sys/GameSettings/REX.ini
@@ -10,4 +10,8 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
+# Fixes black vegetation.
 EFBToTextureEnable = False
+# Needed to properly display car shadows in 2-players split-screen, otherwise, P1's shadows are the same as P2's.
+# (DeferEFBCopies = False would also fix it, but it severely impacts performance and shadows don't scale with the resolution.)
+AllowIncorrectEFBSizeVRAM = True

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -199,6 +199,9 @@ const Info<bool> GFX_HACK_SKIP_EFB_COPY_TO_RAM{{System::GFX, "Hacks", "EFBToText
 const Info<bool> GFX_HACK_SKIP_XFB_COPY_TO_RAM{{System::GFX, "Hacks", "XFBToTextureEnable"}, true};
 const Info<bool> GFX_HACK_DISABLE_COPY_TO_VRAM{{System::GFX, "Hacks", "DisableCopyToVRAM"}, false};
 const Info<bool> GFX_HACK_DEFER_EFB_COPIES{{System::GFX, "Hacks", "DeferEFBCopies"}, true};
+// TODO REVIEW: Change to false.
+const Info<bool> GFX_HACK_ALLOW_INCORRECT_EFB_SIZE_VRAM{
+    {System::GFX, "Hacks", "AllowIncorrectEFBSizeVRAM"}, true};
 const Info<bool> GFX_HACK_IMMEDIATE_XFB{{System::GFX, "Hacks", "ImmediateXFBEnable"}, false};
 const Info<bool> GFX_HACK_CAP_IMMEDIATE_XFB{{System::GFX, "Hacks", "CapImmediateXFB"}, false};
 const Info<bool> GFX_HACK_SKIP_DUPLICATE_XFBS{{System::GFX, "Hacks", "SkipDuplicateXFBs"}, true};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -173,6 +173,7 @@ extern const Info<bool> GFX_HACK_SKIP_EFB_COPY_TO_RAM;
 extern const Info<bool> GFX_HACK_SKIP_XFB_COPY_TO_RAM;
 extern const Info<bool> GFX_HACK_DISABLE_COPY_TO_VRAM;
 extern const Info<bool> GFX_HACK_DEFER_EFB_COPIES;
+extern const Info<bool> GFX_HACK_ALLOW_INCORRECT_EFB_SIZE_VRAM;
 extern const Info<bool> GFX_HACK_IMMEDIATE_XFB;
 extern const Info<bool> GFX_HACK_CAP_IMMEDIATE_XFB;
 extern const Info<bool> GFX_HACK_SKIP_DUPLICATE_XFBS;

--- a/Source/Core/Core/DolphinAnalytics.cpp
+++ b/Source/Core/Core/DolphinAnalytics.cpp
@@ -388,6 +388,8 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-efb-copy-ram", !Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM));
   builder.AddData("cfg-gfx-xfb-copy-ram", !Config::Get(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM));
   builder.AddData("cfg-gfx-defer-efb-copies", Config::Get(Config::GFX_HACK_DEFER_EFB_COPIES));
+  builder.AddData("cfg-gfx-allow-incorrect-efb-size-vram",
+                  Config::Get(Config::GFX_HACK_ALLOW_INCORRECT_EFB_SIZE_VRAM));
   // Note: Incorrectly inverted. Keeping as-is to not break analytics history.
   builder.AddData("cfg-gfx-immediate-xfb", !Config::Get(Config::GFX_HACK_IMMEDIATE_XFB));
   builder.AddData("cfg-gfx-efb-copy-scaled", Config::Get(Config::GFX_HACK_COPY_EFB_SCALED));

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -108,6 +108,7 @@ struct NetSettings
   bool arbitrary_mipmap_detection = false;
   float arbitrary_mipmap_detection_threshold = 0;
   bool enable_gpu_texture_decoding = false;
+  bool allow_incorrect_efb_size_vram = false;
   bool defer_efb_copies = false;
   int efb_access_tile_size = 0;
   bool efb_access_defer_invalidation = false;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1465,6 +1465,8 @@ bool NetPlayServer::SetupNetSettings()
       Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD);
   settings.enable_gpu_texture_decoding = Config::Get(Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
   settings.defer_efb_copies = Config::Get(Config::GFX_HACK_DEFER_EFB_COPIES);
+  settings.allow_incorrect_efb_size_vram =
+      Config::Get(Config::GFX_HACK_ALLOW_INCORRECT_EFB_SIZE_VRAM);
   settings.efb_access_tile_size = Config::Get(Config::GFX_HACK_EFB_ACCESS_TILE_SIZE);
   settings.efb_access_defer_invalidation = Config::Get(Config::GFX_HACK_EFB_DEFER_INVALIDATION);
 

--- a/Source/Core/VideoCommon/FramebufferShaderGen.cpp
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.cpp
@@ -146,21 +146,24 @@ void EmitPixelMainDeclaration(ShaderCode& code, u32 num_tex_inputs, u32 num_colo
   case APIType::OpenGL:
   case APIType::Vulkan:
   {
-    if (g_backend_info.bSupportsGeometryShaders)
+    if (num_tex_inputs != 0 || num_color_inputs != 0)
     {
-      code.Write("VARYING_LOCATION(0) in VertexData {{\n");
-      for (u32 i = 0; i < num_tex_inputs; i++)
-        code.Write("  float3 v_tex{};\n", i);
-      for (u32 i = 0; i < num_color_inputs; i++)
-        code.Write("  float4 v_col{};\n", i);
-      code.Write("}};\n");
-    }
-    else
-    {
-      for (u32 i = 0; i < num_tex_inputs; i++)
-        code.Write("VARYING_LOCATION({}) in float3 v_tex{};\n", i, i);
-      for (u32 i = 0; i < num_color_inputs; i++)
-        code.Write("VARYING_LOCATION({}) in float4 v_col{};\n", num_tex_inputs + i, i);
+      if (g_backend_info.bSupportsGeometryShaders)
+      {
+        code.Write("VARYING_LOCATION(0) in VertexData {{\n");
+        for (u32 i = 0; i < num_tex_inputs; i++)
+          code.Write("  float3 v_tex{};\n", i);
+        for (u32 i = 0; i < num_color_inputs; i++)
+          code.Write("  float4 v_col{};\n", i);
+        code.Write("}};\n");
+      }
+      else
+      {
+        for (u32 i = 0; i < num_tex_inputs; i++)
+          code.Write("VARYING_LOCATION({}) in float3 v_tex{};\n", i, i);
+        for (u32 i = 0; i < num_color_inputs; i++)
+          code.Write("VARYING_LOCATION({}) in float4 v_col{};\n", num_tex_inputs + i, i);
+      }
     }
 
     code.Write("FRAGMENT_OUTPUT_LOCATION(0) out {} ocol0;\n", output_type);
@@ -628,6 +631,34 @@ std::string GenerateTextureReinterpretShader(TextureFormat from_format, TextureF
   }
 
   code.Write("}}\n");
+  return code.GetBuffer();
+}
+
+std::string GenerateTextureResizeShader()
+{
+  ShaderCode code;
+
+  EmitUniformBufferDeclaration(code);
+  code.Write("{{\n"
+             "  int src_width, src_height;\n"
+             "  int dst_width, dst_height;\n"
+             "}};\n");
+
+  EmitSamplerDeclarations(code, 0, 1, false);
+  EmitPixelMainDeclaration(code, 0, 0, "float4", "", true);
+
+  code.Write("{{\n");
+  code.Write("  int idx = int(frag_coord.x) + int(frag_coord.y) * dst_width;\n");
+  code.Write("  int src_size = src_width * src_height;\n");
+  code.Write("  if (idx >= src_size) {{\n");
+  code.Write("    // Unsafely assume that the garbage data is unused.");
+  code.Write("    ocol0 = float4(0.0f);\n");
+  code.Write("  }} else {{\n");
+  code.Write("    int src_x = idx % src_width;\n");
+  code.Write("    int src_y = idx / src_width;\n");
+  code.Write("    ocol0 = texelFetch(samp0, int3(src_x, src_y, 0), 0);\n");
+  code.Write("  }}\n");
+  code.Write("}}");
   return code.GetBuffer();
 }
 

--- a/Source/Core/VideoCommon/FramebufferShaderGen.h
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.h
@@ -22,6 +22,7 @@ std::string GenerateEFBPokeVertexShader();
 std::string GenerateColorPixelShader();
 std::string GenerateFormatConversionShader(EFBReinterpretType convtype, u32 samples);
 std::string GenerateTextureReinterpretShader(TextureFormat from_format, TextureFormat to_format);
+std::string GenerateTextureResizeShader();
 std::string GenerateEFBRestorePixelShader();
 std::string GenerateImGuiVertexShader();
 std::string GenerateImGuiPixelShader(bool linear_space_output = false);

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -413,6 +413,7 @@ void ShaderCache::ClearCaches()
   for (auto& pipeline : m_palette_conversion_pipelines)
     pipeline.reset();
   m_texture_reinterpret_pipelines.clear();
+  m_resize_pipeline.reset();
   m_texture_decoding_shaders.clear();
 
   SETSTAT(g_stats.num_pixel_shaders_created, 0);
@@ -1440,6 +1441,35 @@ const AbstractPipeline* ShaderCache::GetTextureReinterpretPipeline(TextureFormat
   config.usage = AbstractPipelineUsage::Utility;
   iter->second = g_gfx->CreatePipeline(config);
   return iter->second.get();
+}
+
+const AbstractPipeline* ShaderCache::GetTextureResizePipeline()
+{
+  if (m_resize_pipeline)
+    return m_resize_pipeline.get();
+
+  std::string shader_source = FramebufferShaderGen::GenerateTextureResizeShader();
+  if (shader_source.empty())
+    return nullptr;
+
+  std::unique_ptr<AbstractShader> shader =
+      g_gfx->CreateShaderFromSource(ShaderStage::Pixel, shader_source, nullptr,
+                                    fmt::format("Texture reinterpret size pixel shader"));
+  if (!shader)
+    return nullptr;
+
+  AbstractPipelineConfig config;
+  config.vertex_format = nullptr;
+  config.vertex_shader = m_screen_quad_vertex_shader.get();
+  config.geometry_shader = nullptr;
+  config.pixel_shader = shader.get();
+  config.rasterization_state = RenderState::GetNoCullRasterizationState(PrimitiveType::Triangles);
+  config.depth_state = RenderState::GetNoDepthTestingDepthState();
+  config.blending_state = RenderState::GetNoBlendingBlendState();
+  config.framebuffer_state = RenderState::GetRGBA8FramebufferState();
+  config.usage = AbstractPipelineUsage::Utility;
+  m_resize_pipeline = g_gfx->CreatePipeline(config);
+  return m_resize_pipeline.get();
 }
 
 const AbstractShader*

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -110,6 +110,9 @@ public:
   const AbstractPipeline* GetTextureReinterpretPipeline(TextureFormat from_format,
                                                         TextureFormat to_format);
 
+  // Texture resize pipeline
+  const AbstractPipeline* GetTextureResizePipeline();
+
   // Texture decoding compute shaders
   const AbstractShader* GetTextureDecodingShader(TextureFormat format,
                                                  std::optional<TLUTFormat> palette_format);
@@ -248,6 +251,9 @@ private:
   // Texture reinterpreting pipeline
   std::map<std::pair<TextureFormat, TextureFormat>, std::unique_ptr<AbstractPipeline>>
       m_texture_reinterpret_pipelines;
+
+  // Texture resize pipeline
+  std::unique_ptr<AbstractPipeline> m_resize_pipeline;
 
   // Texture decoding shaders
   std::map<std::pair<u32, u32>, std::unique_ptr<AbstractShader>> m_texture_decoding_shaders;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1487,8 +1487,6 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
         // The reason why this is an option is because it's unsafely assuming that the game is
         // indeed not using the garbage data.
         //
-        // TODO: On hardware, does the texture cache hit textures of the wrong size? If not, than
-        // this should be done *after* searching in the texture cache.
         // TODO: Are there games getting a EFB texture smaller than its actual size?
         // TODO: Should we check texture_info.GetRawWidth() % entry->BlockAlignedWidth() == 0?
         // (Maybe only when upscaling?)
@@ -1602,21 +1600,33 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     ++iter;
   }
 
-  if (copy_addr_iter != m_textures_by_address.end())
+  // TODO: These kinds of processing are also performed in `DoPartialTextureUpdates`. It might be
+  // better to make that function more generic and support EFB copies, instead of having a
+  // specialized code path here.
+  const auto ProcessEntry = [&]() -> std::shared_ptr<TCacheEntry> {
+    if (copy_addr_iter != m_textures_by_address.end())
+    {
+      auto entry = copy_addr_iter->second;
+
+      if (copy_needs_reinterpretation)
+        entry = ReinterpretEntry(entry, texture_info.GetTextureFormat());
+
+      if (copy_needs_conversion && entry)
+        entry =
+            ApplyPaletteToEntry(entry, texture_info.GetTlutAddress(), texture_info.GetTlutFormat());
+
+      if (copy_needs_resizing && entry)
+        entry = ResizeEntry(entry, texture_info.GetRawWidth(), texture_info.GetRawHeight(),
+                            base_hash, full_hash);
+      return entry;
+    }
+    return {};
+  };
+  // A texture that needs resizing should only be considered after failing a search in the texture
+  // cache.
+  if (!copy_needs_resizing)
   {
-    auto entry = copy_addr_iter->second;
-
-    if (copy_needs_reinterpretation)
-      entry = ReinterpretEntry(entry, texture_info.GetTextureFormat());
-
-    if (copy_needs_conversion && entry)
-      entry =
-          ApplyPaletteToEntry(entry, texture_info.GetTlutAddress(), texture_info.GetTlutFormat());
-
-    if (copy_needs_resizing && entry)
-      entry = ResizeEntry(entry, texture_info.GetRawWidth(), texture_info.GetRawHeight(), base_hash,
-                          full_hash);
-
+    auto entry = ProcessEntry();
     if (entry)
       return entry;
   }
@@ -1651,6 +1661,13 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
       }
       ++hash_iter;
     }
+  }
+
+  if (copy_needs_resizing)
+  {
+    auto entry = ProcessEntry();
+    if (entry)
+      return entry;
   }
 
   // If at least one entry was not used for the same frame, overwrite the oldest one

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -386,6 +386,64 @@ RcTcacheEntry TextureCacheBase::ReinterpretEntry(const RcTcacheEntry& existing_e
   return reinterpreted_entry;
 }
 
+RcTcacheEntry TextureCacheBase::ResizeEntry(const RcTcacheEntry& existing_entry,
+                                            unsigned int new_native_width,
+                                            unsigned int new_native_height, u64 base_hash,
+                                            u64 full_hash)
+{
+  const AbstractPipeline* pipeline = g_shader_cache->GetTextureResizePipeline();
+  if (!pipeline)
+  {
+    ERROR_LOG_FMT(VIDEO, "Failed to obtain texture resize pipeline");
+    return {};
+  }
+
+  TextureConfig new_config = existing_entry->texture->GetConfig();
+  new_config.width = new_config.width * new_native_width / existing_entry->BlockAlignedWidth();
+  new_config.height = new_config.height * new_native_height / existing_entry->BlockAlignedHeight();
+
+  RcTcacheEntry resized_entry = AllocateCacheEntry(new_config);
+  if (!resized_entry)
+    return {};
+
+  resized_entry->SetDimensions(new_native_width, new_native_height, 1);
+  resized_entry->SetGeneralParameters(
+      existing_entry->addr, resized_entry->memory_stride * resized_entry->NumBlocksY(),
+      existing_entry->format, existing_entry->should_force_safe_hashing);
+  // If the new size if bigger, there's a bit of a contradiction: we assume that the extra data is
+  // unused, yet it will be part of the hash. But this is what GetTexture() wants.
+  resized_entry->SetHashes(base_hash, full_hash);
+  resized_entry->frameCount = existing_entry->frameCount;
+  // TODO REVIEW: Is this correct?
+  resized_entry->SetNotCopy();
+  resized_entry->is_efb_copy = existing_entry->is_efb_copy;
+  // If the new size if bigger, we are assuming that the extra data is unused, so we don't care if
+  // it overlaps.
+  resized_entry->may_have_overlapping_textures = existing_entry->may_have_overlapping_textures;
+
+  g_gfx->BeginUtilityDrawing();
+  struct Uniforms
+  {
+    u32 src_width, src_height;
+    u32 dst_width, dst_height;
+  };
+  Uniforms uniforms = {existing_entry->GetWidth(), existing_entry->GetHeight(), new_config.width,
+                       new_config.height};
+  g_vertex_manager->UploadUtilityUniforms(&uniforms, sizeof(uniforms));
+  g_gfx->SetAndDiscardFramebuffer(resized_entry->framebuffer.get());
+  g_gfx->SetViewportAndScissor(resized_entry->texture->GetRect());
+  g_gfx->SetPipeline(pipeline);
+  g_gfx->SetTexture(0, existing_entry->texture.get());
+  g_gfx->SetSamplerState(0, RenderState::GetPointSamplerState());
+  g_gfx->Draw(0, 3);
+  g_gfx->EndUtilityDrawing();
+  resized_entry->texture->FinishedRendering();
+
+  m_textures_by_address.emplace(resized_entry->addr, resized_entry);
+
+  return resized_entry;
+}
+
 void TextureCacheBase::ScaleTextureCacheEntryTo(RcTcacheEntry& entry, u32 new_width, u32 new_height)
 {
   if (entry->GetWidth() == new_width && entry->GetHeight() == new_height)
@@ -1385,8 +1443,10 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
   TexAddrCache::iterator iter = iter_range.first;
   TexAddrCache::iterator oldest_entry = iter;
   int temp_frameCount = 0x7fffffff;
-  TexAddrCache::iterator unconverted_copy = m_textures_by_address.end();
-  TexAddrCache::iterator unreinterpreted_copy = m_textures_by_address.end();
+  TexAddrCache::iterator copy_addr_iter = m_textures_by_address.end();
+  bool copy_needs_conversion = false;
+  bool copy_needs_reinterpretation = false;
+  bool copy_needs_resizing = false;
 
   while (iter != iter_range.second)
   {
@@ -1398,57 +1458,105 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     // out a purple screen in XFB2Tex. Check for this here and convert them if necessary.
 
     // Do not load strided EFB copies, they are not meant to be used directly.
-    // Also do not directly load EFB copies, which were partly overwritten.
-    if (entry->IsEfbCopy() && entry->native_width == texture_info.GetRawWidth() &&
-        entry->native_height == texture_info.GetRawHeight() &&
-        entry->memory_stride == entry->BytesPerRow() && !entry->may_have_overlapping_textures)
+    // Also do not directly load EFB copies which were partly overwritten.
+    if (entry->IsEfbCopy() && entry->memory_stride == entry->BytesPerRow() &&
+        !entry->may_have_overlapping_textures)
     {
-      // EFB copies have slightly different rules as EFB copy formats have different
-      // meanings from texture formats.
-      if ((base_hash == entry->hash &&
+      // TODO: Should the native width/height be compared with entry->BlockAlignedWidth/Height()
+      // instead?
+      bool is_incorrect_size = entry->native_width != texture_info.GetRawWidth() ||
+                               entry->native_height != texture_info.GetRawHeight();
+      u64 testing_base_hash = base_hash;
+      if (is_incorrect_size)
+      {
+        if (!g_ActiveConfig.bAllowIncorrectEFBSizeVRAM)
+        {
+          ++iter;
+          continue;
+        }
+        // Some games allocate a texture once, and then use it as a EFB target even for smaller
+        // sizes. Finally, they set the UV parameters to avoid using the garbage data.
+        //
+        // An example is Excite Truck, which uses a 640x448 texture for the shadow alpha, even in 2
+        // players where the EFB copy is 320x448 instead (318x448 in the car select screen):
+        // the resulting texture has the top-left quadrant as the even lines of the copy, the
+        // top-right quadrant as the odd lines of the copy, and the bottom half as garbage.
+        // It then sets the UV coordinates to only use the top-left quadrant (which "works",
+        // though it halves its vertical resolution).
+        //
+        // The reason why this is an option is because it's unsafely assuming that the game is
+        // indeed not using the garbage data.
+        //
+        // TODO: On hardware, does the texture cache hit textures of the wrong size? If not, than
+        // this should be done *after* searching in the texture cache.
+        // TODO: Are there games getting a EFB texture smaller than its actual size?
+        // TODO: Should we check texture_info.GetRawWidth() % entry->BlockAlignedWidth() == 0?
+        // (Maybe only when upscaling?)
+
+        // If the texture is bigger than the EFB entry, the expectation is that the excess bytes are
+        // unused. If it's smaller than the EFB entry, then it's gross to hash more than necessary,
+        // but there's no other way for the hashes to match.
+        testing_base_hash = Common::GetHash64(texture_info.GetData(), entry->size_in_bytes,
+                                              textureCacheSafetyColorSampleSize);
+      }
+
+      // EFB copies have slightly different rules as EFB copy formats have different meanings from
+      // texture formats.
+      if ((testing_base_hash == entry->hash &&
            (!texture_info.GetPaletteSize() || g_backend_info.bSupportsPaletteConversion)) ||
           IsPlayingBackFifologWithBrokenEFBCopies)
       {
+        bool needs_conversion = false;
+        bool needs_reintepretation = false;
+
         // The texture format in VRAM must match the format that the copy was created with. Some
         // formats are inherently compatible, as the channel and bit layout is identical (e.g.
         // I8/C8). Others have the same number of bits per texel, and can be reinterpreted on the
         // GPU (e.g. IA4 and I8 or RGB565 and RGBA5). The only known game which reinteprets texels
-        // in this manner is Spiderman Shattered Dimensions, where it creates a copy in B8 format,
+        // in this manner is Spider-Man: Shattered Dimensions, where it creates a copy in B8 format,
         // and sets it up as a IA4 texture.
         if (!IsCompatibleTextureFormat(entry->format.texfmt, texture_info.GetTextureFormat()))
         {
           // Can we reinterpret this in VRAM?
           if (CanReinterpretTextureOnGPU(entry->format.texfmt, texture_info.GetTextureFormat()))
           {
-            // Delay the conversion until afterwards, it's possible this texture has already been
-            // converted.
-            unreinterpreted_copy = iter++;
-            continue;
+            needs_reintepretation = true;
           }
           else
           {
-            // If the EFB copies are in a different format and are not reinterpretable, use the RAM
-            // copy.
+            // If the EFB copies are in a different format and are not reinterpretable, fallback to
+            // the RAM copy.
             ++iter;
             continue;
           }
         }
-        else
-        {
-          // Prefer the already-converted copy.
-          unconverted_copy = m_textures_by_address.end();
-        }
 
         // TODO: We should check width/height/levels for EFB copies. I'm not sure what effect
         // checking width/height/levels would have.
-        if (!texture_info.GetPaletteSize() || !g_backend_info.bSupportsPaletteConversion)
+        if (texture_info.GetPaletteSize() && g_backend_info.bSupportsPaletteConversion)
+          needs_conversion = true;
+
+        if (!is_incorrect_size && !needs_conversion && !needs_reintepretation)
           return entry;
 
-        // Note that we found an unconverted EFB copy, then continue.  We'll
-        // perform the conversion later.  Currently, we only convert EFB copies to
-        // palette textures; we could do other conversions if it proved to be
-        // beneficial.
-        unconverted_copy = iter;
+        const auto negative_score = [&](bool convert, bool reinterpret, bool resize) -> u32 {
+          // TODO: Not all conversions/reinterpretations/resizings are equal.
+          return convert + 2 * reinterpret + 4 * resize;
+        };
+
+        const bool should_replace =
+            negative_score(needs_conversion, needs_reintepretation, is_incorrect_size) <
+            negative_score(copy_needs_conversion, copy_needs_reinterpretation, copy_needs_resizing);
+        if (copy_addr_iter == m_textures_by_address.end() || should_replace)
+        {
+          // Annotate that we found an unprocessed EFB copy, then continue. It'll be processed
+          // later.
+          // We could do other types of conversions if it proved to be beneficial.
+          copy_addr_iter = iter;
+          copy_needs_conversion = needs_conversion;
+          copy_needs_reinterpretation = needs_reintepretation;
+          copy_needs_resizing = is_incorrect_size;
+        }
       }
       else
       {
@@ -1494,29 +1602,23 @@ RcTcacheEntry TextureCacheBase::GetTexture(const int textureCacheSafetyColorSamp
     ++iter;
   }
 
-  if (unreinterpreted_copy != m_textures_by_address.end())
+  if (copy_addr_iter != m_textures_by_address.end())
   {
-    auto decoded_entry =
-        ReinterpretEntry(unreinterpreted_copy->second, texture_info.GetTextureFormat());
+    auto entry = copy_addr_iter->second;
 
-    // It's possible to combine reinterpreted textures + palettes.
-    if (unreinterpreted_copy == unconverted_copy && decoded_entry)
-      decoded_entry = ApplyPaletteToEntry(decoded_entry, texture_info.GetTlutAddress(),
-                                          texture_info.GetTlutFormat());
+    if (copy_needs_reinterpretation)
+      entry = ReinterpretEntry(entry, texture_info.GetTextureFormat());
 
-    if (decoded_entry)
-      return decoded_entry;
-  }
+    if (copy_needs_conversion && entry)
+      entry =
+          ApplyPaletteToEntry(entry, texture_info.GetTlutAddress(), texture_info.GetTlutFormat());
 
-  if (unconverted_copy != m_textures_by_address.end())
-  {
-    auto decoded_entry = ApplyPaletteToEntry(
-        unconverted_copy->second, texture_info.GetTlutAddress(), texture_info.GetTlutFormat());
+    if (copy_needs_resizing && entry)
+      entry = ResizeEntry(entry, texture_info.GetRawWidth(), texture_info.GetRawHeight(), base_hash,
+                          full_hash);
 
-    if (decoded_entry)
-    {
-      return decoded_entry;
-    }
+    if (entry)
+      return entry;
   }
 
   // Search the texture cache for normal textures by hash
@@ -3167,23 +3269,34 @@ u32 TCacheEntry::BytesPerRow() const
   return NumBlocksX() * bytes_per_block;
 }
 
-u32 TCacheEntry::NumBlocksX() const
+u32 TCacheEntry::BlockAlignedWidth() const
 {
   const u32 blockW = TexDecoder_GetBlockWidthInTexels(format.texfmt);
 
   // Round up source height to multiple of block size
-  const u32 actualWidth = Common::AlignUp(native_width, blockW);
+  return Common::AlignUp(native_width, blockW);
+}
 
-  return actualWidth / blockW;
+u32 TCacheEntry::NumBlocksX() const
+{
+  const u32 blockW = TexDecoder_GetBlockWidthInTexels(format.texfmt);
+
+  return BlockAlignedWidth() / blockW;
+}
+
+u32 TCacheEntry::BlockAlignedHeight() const
+{
+  const u32 blockH = TexDecoder_GetBlockHeightInTexels(format.texfmt);
+
+  // Round up source height to multiple of block size
+  return Common::AlignUp(native_height, blockH);
 }
 
 u32 TCacheEntry::NumBlocksY() const
 {
-  u32 blockH = TexDecoder_GetBlockHeightInTexels(format.texfmt);
-  // Round up source height to multiple of block size
-  u32 actualHeight = Common::AlignUp(native_height, blockH);
+  const u32 blockH = TexDecoder_GetBlockHeightInTexels(format.texfmt);
 
-  return actualHeight / blockH;
+  return BlockAlignedHeight() / blockH;
 }
 
 void TCacheEntry::SetXfbCopy(u32 stride)

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -225,7 +225,9 @@ struct TCacheEntry
 
   bool IsEfbCopy() const { return is_efb_copy; }
   bool IsCopy() const { return is_xfb_copy || is_efb_copy; }
+  u32 BlockAlignedWidth() const;
   u32 NumBlocksX() const;
+  u32 BlockAlignedHeight() const;
   u32 NumBlocksY() const;
   u32 BytesPerRow() const;
 
@@ -363,6 +365,9 @@ private:
   RcTcacheEntry ApplyPaletteToEntry(RcTcacheEntry& entry, const u8* palette, TLUTFormat tlutfmt);
 
   RcTcacheEntry ReinterpretEntry(const RcTcacheEntry& existing_entry, TextureFormat new_format);
+
+  RcTcacheEntry ResizeEntry(const RcTcacheEntry& existing_entry, unsigned int new_native_width,
+                            unsigned int new_native_height, u64 base_hash, u64 full_hash);
 
   RcTcacheEntry DoPartialTextureUpdates(RcTcacheEntry& entry_to_update, const u8* palette,
                                         TLUTFormat tlutfmt);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -182,6 +182,7 @@ void VideoConfig::Refresh()
   bSkipXFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
   bDisableCopyToVRAM = Config::Get(Config::GFX_HACK_DISABLE_COPY_TO_VRAM);
   bDeferEFBCopies = Config::Get(Config::GFX_HACK_DEFER_EFB_COPIES);
+  bAllowIncorrectEFBSizeVRAM = Config::Get(Config::GFX_HACK_ALLOW_INCORRECT_EFB_SIZE_VRAM);
   bImmediateXFB = Config::Get(Config::GFX_HACK_IMMEDIATE_XFB);
   bVISkip = Config::Get(Config::GFX_HACK_VI_SKIP);
   bSkipPresentingDuplicateXFBs = bVISkip || Config::Get(Config::GFX_HACK_SKIP_DUPLICATE_XFBS);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -295,6 +295,7 @@ struct VideoConfig final
   bool bSkipXFBCopyToRam = false;
   bool bDisableCopyToVRAM = false;
   bool bDeferEFBCopies = false;
+  bool bAllowIncorrectEFBSizeVRAM = false;
   bool bImmediateXFB = false;
   bool bSkipPresentingDuplicateXFBs = false;
   bool bCopyEFBScaled = false;


### PR DESCRIPTION
Some games intentionally copy the EFB to a texture of the wrong size.
This required `EFBToTextureEnable = False` to emulate, sometimes even `DeferEFBCopies = False`, and it prevents upscaling of the EFB copy.

With this change, Dolphin now supports this behavior on the VRAM, eliminating the problems described above.

### Excite Truck screenshots

#### Master + `EFBToTextureEnable = False`
<img width="3209" height="1792" alt="REXP01_Master_NoDefer" src="https://github.com/user-attachments/assets/db1d16a8-8356-4f4c-ac25-b505dc4f28f2" />

#### Master + `DeferEFBCopies = False` (a.k.a. halve my emulation performance)
<img width="3209" height="1792" alt="REXP01_Master" src="https://github.com/user-attachments/assets/cf0a747f-efd7-4b99-9d08-a1b63ef00eb8" />

#### Master
(Not putting a screenshot because `EFBToTextureEnable = True` also affects vegetation. Pretend there are no shadows.)

#### PR
<img width="3209" height="1792" alt="REXP01_PR" src="https://github.com/user-attachments/assets/009490da-e6bb-48c4-967a-ffb041715b0c" />

#### FIFO Logs
[ExciteTruckMultiplayerShadows.zip](https://github.com/user-attachments/files/28193612/ExciteTruckMultiplayerShadows.zip)

The game allocates a 640x448 texture at boot, and never changes it.
In multiplayer, the EFB copy is 320x448, or 318x448 in the car select screen.

### Notes
- I refactored the loop in `TextureCacheBase::GetTexture`. Both because it was a mess in the control flow and I didn't want to make it worse, but also because it seems it didn't even do what it intended (for instance the reinterpreted + palettes condition below the loop was impossible to achieve). So hopefully it now does.
- This is a setting (not exposed in the UI) which should default to `False`, but I'm pushing it to `True` to see how the FIFO CI reacts. (So, if it complains, that's likely why.)
- I don't like the names I chose for the setting and for the function names. If you have better ideas, let me know.
<sub><super>For the function name, "resize" might be misinterpreted as stretching. I'd prefer "reinterpret size", but "reinterpret" is already used for the texture format.</super></sub>
- I never worked on anything like this before, so the likelihood I have made mistakes is high.

Finally, it's very likely that there is more than one game that would also take advantage of this. The ones with `DeferEFBCopies = False` ([INI](https://github.com/search?q=repo%3Adolphin-emu%2Fdolphin+DeferEFBCopies+language%3AINI&type=code&l=INI), [wiki](https://wiki.dolphin-emu.org/index.php?search=DeferEFB&title=Special%3ASearch&profile=default&fulltext=1)) are good candidates and should be tested.

(If broken effects are still broken but in a different way, also test native resolution.)

(Marking as draft because it's not ready for merge, but it is ready for review.)