### PR TITLE
IOS/Network: reduce log verbosity of SO_EAGAIN to info level

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -117,10 +117,12 @@ s32 WiiSockMan::GetNetErrorCode(s32 ret, std::string_view caller, bool is_rw)
     return ret;
   }
 
-  ERROR_LOG_FMT(IOS_NET, "{} failed with error {}: {}, ret= {}", caller, error_code,
-                Common::DecodeNetworkError(error_code), ret);
-
   const s32 return_value = TranslateErrorCode(error_code, is_rw);
+  const auto level =
+      return_value == -SO_EAGAIN ? Common::Log::LogLevel::LINFO : Common::Log::LogLevel::LERROR;
+  GENERIC_LOG_FMT(Common::Log::LogType::IOS_NET, level, "{} failed with error {}: {}, ret = {}",
+                  caller, error_code, Common::DecodeNetworkError(error_code), ret);
+
   SetLastNetError(return_value);
 
   return return_value;


### PR DESCRIPTION
Otherwise IOCTL_SO_ACCEPT is very noisy until a client connects.