### PR TITLE
GameINI: Add fix codes to the internal color bug in Capcom vs. SNK 2 EO

### DIFF
--- a/Data/Sys/GameSettings/GEOE08.ini
+++ b/Data/Sys/GameSettings/GEOE08.ini
@@ -1,0 +1,23 @@
+# GEOE08 - Capcom vs. SNK 2 EO (USA)
+
+[Gecko]
+$Fix Gameplay Character/Object Green Tint (Matches DC/PS2 Colors) [Immersion95]
+*Removes the forced RGB5A3 high bit during TLUT palette copies for editable,
+*common, and secondary gameplay character/object palettes.
+*Also neutralizes the final gameplay vertex-color green tint from 90% to 100%.
+04076A18 60000000
+04076A2C 60000000
+04076A40 60000000
+04076A54 60000000
+04076A6C 60000000
+040671C8 60000000
+040671DC 60000000
+040671F0 60000000
+04067204 60000000
+0406721C 60000000
+04076B30 60000000
+04076B44 60000000
+04076B58 60000000
+04076B6C 60000000
+04076B84 60000000
+040169CC 1C000064

--- a/Data/Sys/GameSettings/GEOJ08.ini
+++ b/Data/Sys/GameSettings/GEOJ08.ini
@@ -1,0 +1,23 @@
+# GEOJ08 - Capcom vs. SNK 2 EO (Japan)
+
+[Gecko]
+$Fix Gameplay Character/Object Green Tint (Matches DC/PS2 Colors) [Immersion95]
+*Removes the forced RGB5A3 high bit during TLUT palette copies for editable,
+*common, and secondary gameplay character/object palettes.
+*Also neutralizes the final gameplay vertex-color green tint from 90% to 100%.
+040761A0 60000000
+040761B4 60000000
+040761C8 60000000
+040761DC 60000000
+040761F4 60000000
+04066950 60000000
+04066964 60000000
+04066978 60000000
+0406698C 60000000
+040669A4 60000000
+040762B8 60000000
+040762CC 60000000
+040762E0 60000000
+040762F4 60000000
+0407630C 60000000
+040163D4 1C000064

--- a/Data/Sys/GameSettings/GEOP08.ini
+++ b/Data/Sys/GameSettings/GEOP08.ini
@@ -1,0 +1,23 @@
+# GEOP08 - Capcom vs. SNK 2 EO (Europe)
+
+[Gecko]
+$Fix Gameplay Character/Object Green Tint (Matches DC/PS2 Colors) [Immersion95]
+*Removes the forced RGB5A3 high bit during TLUT palette copies for editable,
+*common, and secondary gameplay character/object palettes.
+*Also neutralizes the final gameplay vertex-color green tint from 90% to 100%.
+04076AEC 60000000
+04076B00 60000000
+04076B14 60000000
+04076B28 60000000
+04076B40 60000000
+0406729C 60000000
+040672B0 60000000
+040672C4 60000000
+040672D8 60000000
+040672F0 60000000
+04076C04 60000000
+04076C18 60000000
+04076C2C 60000000
+04076C40 60000000
+04076C58 60000000
+04016AA0 1C000064


### PR DESCRIPTION
## Summary

This PR adds Gecko codes for all three GameCube releases of **Capcom vs. SNK 2 EO**:

- **GEOJ08** (Japan)
- **GEOE08** (USA)
- **GEOP08** (Europe)

These codes fix the **green-tinted gameplay colors** seen in the GameCube version and restore the in-game characters/objects colors from the **Naomi, Dreamcast and PS2** versions.

---

## Problem

The GameCube version of *Capcom vs. SNK 2 EO* applies an incorrect color treatment during gameplay.

In practice, this causes:
- a noticeable **green tint** on characters and gameplay objects,
- palette-dependent color shifts,
- colors that do **not** match the game’s own **Color Edit mode**,
- and colors that differ from the appearance seen in the **Dreamcast / PS2 / Naomi** versions.

A simple way to observe the issue is to compare:
1. a character’s appearance in **Color Edit mode**,
2. the same character in **normal gameplay**,
3. and the same character with the fix enabled.

Without the patch, gameplay colors are visibly off. With the patch, they become identical to the intended rendering.

---

## What does this cheat do ?

The fix targets two separate parts of the GameCube gameplay rendering path.

### 1. Palette / TLUT high-bit forcing

Several gameplay palette/TLUT copy routines force the RGB5A3 high bit with instructions equivalent to:

    ori ..., ..., 0x8000

This appears to be intended to force palette entries into opaque RGB555 mode. However, in the affected gameplay paths, this produces an unwanted green-bit bias on some colors.

In practical terms, some palette entries behave as if one bit of the 5-bit green channel was forced on:

    G5 = G5 | 0b00100

This is why the tint is not uniform. Colors where that green bit was already set stay mostly unchanged, while colors where it was clear gain roughly +33 green in 8-bit RGB.

The patch removes this forced high-bit operation from the relevant gameplay palette/TLUT paths:

- main editable character palette path
- common palette loader path
- secondary runtime palette path used by objects and extra sprite palettes

### 2. Gameplay vertex green multiplier

Gameplay also applies a vertex color multiplier that scales the green channel to 90%:

    mulli ..., ..., 0x5A

0x5A is 90 in decimal.

Changing this alone to 100% makes some colors worse, because the palette issue is still present. However, once the palette/TLUT high-bit issue is removed, the 90% green multiplier is no longer needed. The patch restores it to neutral 100%:

    0x5A -> 0x64

So the corrected behavior becomes:

    no unwanted palette green-bit boost
    +
    neutral 100% gameplay green vertex multiplier

Together, these changes make GameCube gameplay colors match exactly the game’s own Color Edit mode and the Naomi / Dreamcast / PS2 references.

---

## Findings

After comparing:
- gameplay captures,
- Color Edit mode output,
- memory/state data,
- FIFO captures,
- and debugger traces,

the issue appears to be internal to the game’s rendering path rather than a Dolphin-specific bug.

### Important observation

The game’s own **Color Edit mode** is the clearest internal reference for the intended colors.

For example:
- **Ryu** in Color Edit mode matches the gameplay of the Naomi/DC/PS2 but not its own GC's gameplay which is weird.

So this is not just “subjective color preference”, the game itself exposes a cleaner reference path.

---

## Theory / likely explanation

This looks like an internal GameCube porting issue rather than a Dolphin bug or a display/output problem.

The exact reason this shipped in the retail GameCube version is impossible to know without Capcom’s original development notes, but two explanations seem plausible:

### Theory 1: Capcom could not fully fix it in time

Capcom may have noticed that the GameCube gameplay colors were too green/yellow late in development, but the real issue was buried in several gameplay palette/TLUT paths.

Instead of safely rewriting all of those paths before release, they may have added a global 90% green multiplier as a quick mitigation. That reduced the visible tint, but it did not actually fix the underlying palette issue.

This would explain why the retail game looks partially corrected, but still does not match Color Edit, Naomi, Dreamcast, or PS2.

### Theory 2: Capcom accepted or liked the final look

Another possibility is that Capcom saw the altered GameCube gameplay colors and simply accepted the result, or even preferred the slightly different look on GameCube displays at the time.

On CRTs and analog video output, the issue may have looked less obvious than it does today in clean digital captures or Dolphin screenshots.

Either way, the final result in the retail GameCube build appears to be an **internal game bug / workaround**, not something caused by Dolphin.

---

## Why this matters

I originally bought *Capcom vs. SNK 2 EO* on GameCube when I was younger, and for a long time I honestly thought **my GameCube had a problem**, because the colors in gameplay always looked wrong.

Only much later, after comparing versions and digging into the game more deeply, it became clear that the issue was actually **inside the game itself**.

- "Just play the DC/PS2 version" Yes.... but CVS2 EO has unique balance change (Roll cancel removed, Stronger P-Groove).

- "Just play Capcom Fighting Collection 2" Yes.... but there's no "Color edit mode" 😐.

---

## Result

With the codes enabled:
- The green tint is removed, yay !
- Palette behavior becomes much more consistent so your edited colors will match perfectly in gameplay !
- The game colors matches exactly the **Naomi / DC / PS2** versions.

---

## Before / After (look at the contrast of the clothes)

**Before :** 🤮
<img width="640" height="491" alt="GEOJ08_2026-05-19_12-35-16" src="https://github.com/user-attachments/assets/ec89cb4a-7080-443f-8cb5-3aedd6aeb1aa" />
**After :** 😃
<img width="640" height="491" alt="GEOJ08_2026-05-19_12-35-58_4" src="https://github.com/user-attachments/assets/63cd9893-6870-4665-8c1d-503ed8ee6a3a" />
Color Edit Mode for references :
<img width="640" height="491" alt="Color Edit Eagle" src="https://github.com/user-attachments/assets/7266ae2c-2e16-4326-8b08-3f37c24c7114" />
<img width="640" height="491" alt="Color Edit Vice" src="https://github.com/user-attachments/assets/093d534f-23ba-4d53-8410-7ddee7516634" />

---

## Notes

These are **Gecko codes**, so they are useful both in Dolphin and on real hardware setups that support Gecko codes (tested in **Nintendon't**).

---

## Credits

This investigation and fix were worked out using:
- **Dolphin’s debugger / FIFO tools**
- a lot of manual comparison and testing
- and **ChatGPT** for assistance during the reverse-engineering / analysis process.