### PR TITLE
GameSettings: Update Mario Party games

### DIFF
--- a/Data/Sys/GameSettings/GMP.ini
+++ b/Data/Sys/GameSettings/GMP.ini
@@ -1,0 +1,5 @@
+# GMPP01, GMPJ01, GMPE01 - Mario Party 4
+
+[Video_Enhancements]
+# Prevent corrupted message boxes.
+ForceTextureFiltering = 0

--- a/Data/Sys/GameSettings/GP5.ini
+++ b/Data/Sys/GameSettings/GP5.ini
@@ -1,13 +1,15 @@
 # GP5E01, GP5J01, GP5P01 - Mario Party 5
 
-[Core]
-# Values set here will override the main Dolphin settings.
+[Video_Enhancements]
+# Prevent corrupted message boxes.
+ForceTextureFiltering = 0
 
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
+[Video_Settings]
+# Update Bus Buffer paint properly.
+# (Not default because it's very minor: only a trace visually remains at the end.
+# Medium is better than Fast, but unlike Safe it can still leave a (even smaller) trace.)
+#SafeTextureCacheColorSamples = 0
 
 [Video_Hacks]
+# Fix Pushy Penguins being drawn in black rectangles.
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GP6.ini
+++ b/Data/Sys/GameSettings/GP6.ini
@@ -1,16 +1,13 @@
 # GP6E01, GP6J01, GP6P01 - Mario Party 6
 
-[Core]
-# Values set here will override the main Dolphin settings.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
+[Video_Enhancements]
+# Prevent corrupted message boxes.
+ForceTextureFiltering = 0
 
 [Video_Hacks]
+# Needed to show the mini-games preview in the Mini-game Tour Bus.
 EFBEmulateFormatChanges = True
 
 [Video_Settings]
+# Update ground properly in Mowtown.
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GP7.ini
+++ b/Data/Sys/GameSettings/GP7.ini
@@ -1,0 +1,5 @@
+# GP7E01, GP7P01, GP7J01 - Mario Party 7
+
+[Video_Enhancements]
+# Prevent corrupted message boxes.
+ForceTextureFiltering = 0


### PR DESCRIPTION
The only game I can test is 5. For the others, I gathered from the web.
(Does Mario Party 6 need `ForceTextureFiltering = 0`? What about MP8?)

I didn't add (commented out) `FastTextureSampling = False`. Should I?  For reference: https://bugs.dolphin-emu.org/issues/13347
(In 5, I couldn't notice any seams at native resolution with `FastTextureSampling = True`, meaning that setting it to `False` is only useful at higher resolutions.)

And what about the other "optional" settings described in [MP4](https://wiki.dolphin-emu.org/index.php?title=Mario_Party_4)?

(After this is merged, the wiki pages need to be updated.)