### PR TITLE
DSP: add swi instruction (software interrupt)

### DIFF
--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -135,11 +135,12 @@ void Analyzer::FindInstructionStarts(const SDSP& dsp, u16 start_addr, u16 end_ad
 
     // If an instruction potentially raises exceptions, mark the following
     // instruction as needing to check for exceptions
-    if (opcode->opcode == 0x00c0 || opcode->opcode == 0x00e0 || opcode->opcode == 0x1600 ||
-        opcode->opcode == 0x1800 || opcode->opcode == 0x1880 || opcode->opcode == 0x1900 ||
-        opcode->opcode == 0x1980 || opcode->opcode == 0x1a00 || opcode->opcode == 0x1a80 ||
-        opcode->opcode == 0x1b00 || opcode->opcode == 0x1b80 || opcode->opcode == 0x2000 ||
-        opcode->opcode == 0x2800 || opcode->opcode == 0x2c00 || opcode->extended)
+    if (opcode->opcode == 0x0020 || opcode->opcode == 0x00c0 || opcode->opcode == 0x00e0 ||
+        opcode->opcode == 0x1600 || opcode->opcode == 0x1800 || opcode->opcode == 0x1880 ||
+        opcode->opcode == 0x1900 || opcode->opcode == 0x1980 || opcode->opcode == 0x1a00 ||
+        opcode->opcode == 0x1a80 || opcode->opcode == 0x1b00 || opcode->opcode == 0x1b80 ||
+        opcode->opcode == 0x2000 || opcode->opcode == 0x2800 || opcode->opcode == 0x2c00 ||
+        opcode->extended)
     {
       m_code_flags[static_cast<u16>(addr + opcode->size)] |= CODE_CHECK_EXC;
     }

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -205,7 +205,7 @@ void SDSP::FreeMemoryPages()
 
 void SDSP::SetException(ExceptionType exception)
 {
-  exceptions |= 1 << static_cast<std::underlying_type_t<ExceptionType>>(exception);
+  exceptions |= 1u << static_cast<std::underlying_type_t<ExceptionType>>(exception);
 }
 
 void SDSP::SetExternalInterrupt(bool val)
@@ -232,10 +232,12 @@ bool SDSP::CheckExceptions()
 
   for (int i = 7; i > 0; i--)
   {
-    // Seems exp int are not masked by sr_int_enable
+    // Seems some interrupts are not masked by SR_INT_ENABLE.
     if ((exceptions & (1U << i)) != 0)
     {
-      if (IsSRFlagSet(SR_INT_ENABLE) || i == static_cast<int>(ExceptionType::ExternalInterrupt))
+      const auto irq = static_cast<ExceptionType>(i);
+      if (IsSRFlagSet(SR_INT_ENABLE) || irq == ExceptionType::ExternalInterrupt ||
+          irq == ExceptionType::SoftwareInterrupt)
       {
         // store pc and sr until RTI
         StoreStack(StackRegister::Call, pc);
@@ -243,9 +245,10 @@ bool SDSP::CheckExceptions()
 
         pc = static_cast<u16>(i * 2);
         exceptions &= ~(1 << i);
-        if (i == 7)
+        // Not entirely sure about this.
+        if (irq == ExceptionType::ExternalInterrupt)
           r.sr &= ~SR_EXT_INT_ENABLE;
-        else
+        else if (irq != ExceptionType::SoftwareInterrupt)
           r.sr &= ~SR_INT_ENABLE;
         return true;
       }

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -224,10 +224,10 @@ enum : u16
 };
 
 // Exception vectors
-enum class ExceptionType
+enum class ExceptionType : u8
 {
   StackOverflow = 1,                  // 0x0002 stack under/over flow
-  EXP_2 = 2,                          // 0x0004
+  SoftwareInterrupt = 2,              // 0x0004 software interrupt (swi instruction)
   AcceleratorRawReadOverflow = 3,     // 0x0006 accelerator raw read address overflow
   AcceleratorRawWriteOverflow = 4,    // 0x0008 accelerator raw write address overflow
   AcceleratorSampleReadOverflow = 5,  // 0x000a accelerator sample reads address overflow

--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -20,7 +20,7 @@
 namespace DSP
 {
 // clang-format off
-const std::array<DSPOPCTemplate, 230> s_opcodes =
+const std::array<DSPOPCTemplate, 231> s_opcodes =
 {{
   //              # of parameters----+   {type, size, loc, lshift, mask}                                                               branch        reads PC       // instruction approximation
   // name      opcode  mask  size-V  V   param 1                       param 2                       param 3                    extendable    uncond.       updates SR
@@ -31,6 +31,7 @@ const std::array<DSPOPCTemplate, 230> s_opcodes =
   {"SUBARN",   0x000c, 0xfffc,    1, 1, {{P_REG, 1, 0, 0, 0x0003}},                                                             false, false, false, false, false}, // $arD -= $ixS
   {"ADDARN",   0x0010, 0xfff0,    1, 2, {{P_REG, 1, 0, 0, 0x0003},     {P_REG04, 1, 0, 2, 0x000c}},                             false, false, false, false, false}, // $arD += $ixS
 
+  {"SWI",      0x0020, 0xffff,    1, 0, {},                                                                                     false, true, true, true, false}, // call 0x0004
   {"HALT",     0x0021, 0xffff,    1, 0, {},                                                                                     false, true, true, false, false}, // halt until reset
 
   {"RETGE",    0x02d0, 0xffff,    1, 0, {},                                                                                     false, true, false, true, false}, // return if greater or equal

--- a/Source/Core/Core/DSP/Interpreter/DSPIntBranch.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntBranch.cpp
@@ -121,6 +121,15 @@ void Interpreter::rti(const UDSPInstruction opc)
   state.pc = state.PopStack(StackRegister::Call);
 }
 
+// SWI
+// 0000 0000 0010 0000
+// Software interrupt. Will call 0x0004.
+void Interpreter::swi(const UDSPInstruction)
+{
+  auto& state = m_dsp_core.DSPState();
+  state.SetException(ExceptionType::SoftwareInterrupt);
+}
+
 // HALT
 // 0000 0000 0010 0001
 // Stops execution of DSP code. Sets bit DSP_CR_HALT in register DREG_CR.

--- a/Source/Core/Core/DSP/Interpreter/DSPIntTables.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntTables.cpp
@@ -19,7 +19,7 @@ struct InterpreterOpInfo
 };
 
 // clang-format off
-constexpr std::array<InterpreterOpInfo, 125> s_opcodes
+constexpr std::array<InterpreterOpInfo, 126> s_opcodes
 {{
   {0x0000, 0xfffc, &Interpreter::nop},
 
@@ -28,6 +28,7 @@ constexpr std::array<InterpreterOpInfo, 125> s_opcodes
   {0x000c, 0xfffc, &Interpreter::subarn},
   {0x0010, 0xfff0, &Interpreter::addarn},
 
+  {0x0020, 0xffff, &Interpreter::swi},
   {0x0021, 0xffff, &Interpreter::halt},
 
   {0x02d0, 0xfff0, &Interpreter::ret},

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.h
@@ -155,6 +155,7 @@ public:
   void subax(UDSPInstruction opc);
   void subp(UDSPInstruction opc);
   void subr(UDSPInstruction opc);
+  void swi(UDSPInstruction opc);
   void tst(UDSPInstruction opc);
   void tstaxh(UDSPInstruction opc);
   void tstprod(UDSPInstruction opc);

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.h
@@ -81,6 +81,7 @@ public:
   void ifcc(UDSPInstruction opc);
   void ret(UDSPInstruction opc);
   void rti(UDSPInstruction opc);
+  void swi(UDSPInstruction opc);
   void halt(UDSPInstruction opc);
   void loop(UDSPInstruction opc);
   void loopi(UDSPInstruction opc);

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitBranch.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitBranch.cpp
@@ -299,6 +299,17 @@ void DSPEmitter::rti(const UDSPInstruction opc)
   ReJitConditional(opc, &DSPEmitter::r_rti);
 }
 
+// SWI
+// 0000 0000 0010 0000
+// Software interrupt.
+void DSPEmitter::swi(const UDSPInstruction)
+{
+  MOV(16, M_SDSP_pc(), Imm16(m_compile_pc + 1));
+  const u8 irq_bit = 1u << static_cast<u8>(ExceptionType::SoftwareInterrupt);
+  OR(8, M_SDSP_exceptions(), Imm8(irq_bit));
+  WriteBranchExit();
+}
+
 // HALT
 // 0000 0000 0010 0001
 // Stops execution of DSP code. Sets bit DSP_CR_HALT in register DREG_CR.

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitTables.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitTables.cpp
@@ -19,7 +19,7 @@ struct JITOpInfo
 };
 
 // clang-format off
-const std::array<JITOpInfo, 125> s_opcodes =
+const std::array<JITOpInfo, 126> s_opcodes =
 {{
   {0x0000, 0xfffc, &DSPEmitter::nop},
 
@@ -28,6 +28,7 @@ const std::array<JITOpInfo, 125> s_opcodes =
   {0x000c, 0xfffc, &DSPEmitter::subarn},
   {0x0010, 0xfff0, &DSPEmitter::addarn},
 
+  {0x0020, 0xffff, &DSPEmitter::swi},
   {0x0021, 0xffff, &DSPEmitter::halt},
 
   {0x02d0, 0xfff0, &DSPEmitter::ret},


### PR DESCRIPTION
Found this by accident, it's not used by anything afaik.

No update to the DSP doc (yet).