### PR TITLE
Fix Riivolution Patcher Using Incorrect File Separator on Win

### DIFF
--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -69,7 +69,8 @@ FileDataLoaderHostFS::MakeAbsoluteFromRelative(std::string_view external_relativ
   std::string_view work = external_relative_path;
 
   // Remove trailing path separators; D_RIIVOLUTION_IDX can have a trailing slash.
-  // When appending the first path element below, this would create root//element which fails on Windows.
+  // When appending the first path element below, this would create root//element which fails on
+ // Windows.
   while (result.ends_with('/'))
     result.pop_back();
 

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -69,8 +69,8 @@ FileDataLoaderHostFS::MakeAbsoluteFromRelative(std::string_view external_relativ
   std::string_view work = external_relative_path;
 
   // Remove trailing path separators; D_RIIVOLUTION_IDX can have a trailing slash.
- // When appending the first path element below, this would create root//element which fails on
- // Windows.
+  // When appending the first path element below, this would create root//element which fails on
+  // Windows.
   while (result.ends_with('/'))
     result.pop_back();
 

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -69,7 +69,7 @@ FileDataLoaderHostFS::MakeAbsoluteFromRelative(std::string_view external_relativ
   std::string_view work = external_relative_path;
 
   // Remove trailing path separators; D_RIIVOLUTION_IDX can have a trailing slash.
-  // When appending the first path element below, this would create root//element which fails on
+ // When appending the first path element below, this would create root//element which fails on
  // Windows.
   while (result.ends_with('/'))
     result.pop_back();

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -68,6 +68,11 @@ FileDataLoaderHostFS::MakeAbsoluteFromRelative(std::string_view external_relativ
   std::string result = root;
   std::string_view work = external_relative_path;
 
+  // Remove trailing path separators; D_RIIVOLUTION_IDX can have a trailing slash.
+  // When appending the first path element below, this would create root//element which fails on Windows.
+  while (result.ends_with('/'))
+    result.pop_back();
+
   // Strip away all leading and trailing path separators.
   while (work.starts_with('/'))
     work.remove_prefix(1);

--- a/Source/UnitTests/Core/CMakeLists.txt
+++ b/Source/UnitTests/Core/CMakeLists.txt
@@ -16,6 +16,8 @@ add_dolphin_test(ESFormatsTest IOS/ES/FormatsTest.cpp)
 
 add_dolphin_test(FileSystemTest IOS/FS/FileSystemTest.cpp)
 
+add_dolphin_test(RiivolutionPatcherTest DiscIO/RiivolutionPatcherTest.cpp)
+
 add_dolphin_test(SkylandersTest IOS/USB/SkylandersTest.cpp)
 
 if(_M_X86_64)

--- a/Source/UnitTests/Core/DiscIO/RiivolutionPatcherTest.cpp
+++ b/Source/UnitTests/Core/DiscIO/RiivolutionPatcherTest.cpp
@@ -1,0 +1,49 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "Common/FileUtil.h"
+#include "DiscIO/RiivolutionPatcher.h"
+
+namespace
+{
+constexpr char kSubdir[] = "test";
+constexpr char kRelativePath[] = "/test";
+}
+
+class RiivolutionPatcherTest : public testing::Test
+{
+protected:
+  RiivolutionPatcherTest()
+      : m_sd_root(File::CreateTempDir()), m_subdir(m_sd_root + "/" + kSubdir),
+        m_xml_path(m_subdir + "/patch.xml")
+  {
+  }
+
+  ~RiivolutionPatcherTest() override
+  {
+    if (!m_sd_root.empty())
+      File::DeleteDirRecursively(m_sd_root);
+  }
+
+  void SetUp() override
+  {
+    ASSERT_FALSE(m_sd_root.empty());
+    ASSERT_TRUE(File::CreateDir(m_subdir));
+    ASSERT_TRUE(File::CreateEmptyFile(m_xml_path));
+  }
+
+  const std::string m_sd_root;
+  const std::string m_subdir;
+  const std::string m_xml_path;
+};
+
+TEST_F(RiivolutionPatcherTest, ResolvesAbsolutePathWhenSdRootHasTrailingSlash)
+{
+  // D_RIIVOLUTION_IDX always ends with '/'
+  DiscIO::Riivolution::FileDataLoaderHostFS loader(m_sd_root + "/", m_xml_path, {});
+  EXPECT_EQ(loader.GetFolderContents(kRelativePath).size(), 1u);
+}

--- a/Source/UnitTests/Core/DiscIO/RiivolutionPatcherTest.cpp
+++ b/Source/UnitTests/Core/DiscIO/RiivolutionPatcherTest.cpp
@@ -12,7 +12,7 @@ namespace
 {
 constexpr char kSubdir[] = "test";
 constexpr char kRelativePath[] = "/test";
-}
+}  // namespace
 
 class RiivolutionPatcherTest : public testing::Test
 {


### PR DESCRIPTION
# Summary

The Riivolution patcher manually manipulated file paths in a way that caused two directory separators to be appended to any subdirectory of a patch, causing riivolution patches to fail to load on windows Dolphin (tested on various versions.)

# Repro

The following is a sure-fire way to repro the issue

1. Obtain a legal copy of SM Galaxy 2 Using your Console & Disk
2. Download the Super Mario Spectral Mod https://gamebanana.com/mods/387438 and extract it into the riivolution folder(s) (Note: I dont own this mod nor can I confirm it is okay to download, and probably other mods work well too)
3. Try to open the mod on windows, dolphin (latest, dolphin stable, or even dolphin 2024 stable build), by right clicking the .iso or other file extension type, 'Start with Riivolution Patches'
4. Observe in the logs that the following error occurs, and the mod receives a black screen:
```
 Common\FileUtil.cpp:512 E[COMMON]: ScanDirectoryTree error on C:/Users/REDACTED/Documents/Dolphin Emulator/Load/Riivolution//Spectral/LocalizeData: The system cannot find the path specified.
```

5. Observe that there are two slashes in the file path which on windows causes an invalid path, assuming the path is functional without the slash. This is not an issue with the configuration of the Riivolution patch XML but an issue with Dolphin.

> ⚠️  Dolphin also does not respect the preferred windows directory separator char and uses the unix separator but Windows permits this.

# Alternative Fixes Considered & Breaking Change

1. For some reason when the riivolution folder is cached / auto-populated, Dolphin ingests a / at the end, but if you open the file explorer and choose the location, the / is removed at the end. 
<img width="590" height="279" alt="image_2026-05-25_22-04-50" src="https://github.com/user-attachments/assets/12e17c0e-db67-4888-9607-ff8c09c416ed" />

It might be worthwhile to fix the bug there, but I didn't want to modify this as it could have other downstream effects and I aimed to have the minimal subset of changes possible.

2. Ideally we'd avoid manually modifying the file paths ... as this old comment in the source code used to suggest: https://github.com/hoogmin/dolphin/commit/7ca8dc376745818ab1b1ef3a7092d5f69775b54a, however I decided to make the minimal change possible.

This introduces a behavioral change in that, when external_relative_path is empty (or only slashes), the returned path no longer carries a trailing / even if m_sd_root did. I couldn't find any dependency on the function or implementation that would break due to this, but I don't know this codebase well.

# Testing

I created a build of Dolphin and confirmed the fix worked and the riivolution patch now correctly loaded without the errors in the log:
<img width="729" height="572" alt="image" src="https://github.com/user-attachments/assets/8aad8796-7d7b-432b-9daa-6b54b50c32e4" />

Unit tests are also included.

Note, to build Dolphin I modified QT to include this instead of the _MSC_VER constraints. 
```
# define QT_MAKE_UNCHECKED_ARRAY_ITERATOR(x) (x)
#  define QT_MAKE_CHECKED_ARRAY_ITERATOR(x, N) (x)
```

