### PR TITLE
OnScreenDisplayPane: Remove Show Internal Resolution checkbox and strings

### DIFF
--- a/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.cpp
+++ b/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.cpp
@@ -43,8 +43,6 @@ void OnScreenDisplayPane::CreateLayout()
   performance_box->setLayout(performance_layout);
 
   m_show_fps = new ConfigBool(tr("Show FPS"), Config::GFX_SHOW_FPS);
-  m_show_internal_resolution =
-      new ConfigBool(tr("Show Internal Resolution"), Config::GFX_SHOW_INTERNAL_RESOLUTION);
   m_show_ftimes = new ConfigBool(tr("Show Frame Times"), Config::GFX_SHOW_FTIMES);
   m_show_vps = new ConfigBool(tr("Show VPS"), Config::GFX_SHOW_VPS);
   m_show_vtimes = new ConfigBool(tr("Show VBlank Times"), Config::GFX_SHOW_VTIMES);
@@ -106,7 +104,6 @@ void OnScreenDisplayPane::CreateLayout()
 
   debug_layout->addWidget(m_show_statistics, 0, 0);
   debug_layout->addWidget(m_show_proj_statistics, 0, 1);
-  debug_layout->addWidget(m_show_internal_resolution, 1, 0);
 
   // Stack GroupBoxes
   auto* main_layout = new QVBoxLayout;
@@ -152,11 +149,6 @@ void OnScreenDisplayPane::AddDescriptions()
   static const char TR_SHOW_FPS_DESCRIPTION[] =
       QT_TR_NOOP("Shows the number of distinct frames rendered per second as a measure of "
                  "visual smoothness.<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
-
-  static const char TR_SHOW_INTERNAL_RESOLUTION_DESCRIPTION[] =
-      QT_TR_NOOP("Shows the internal resolution in pixels, as a product of "
-                 "width and height. <br><br><dolphin_emphasis>If unsure, leave this "
                  "unchecked.</dolphin_emphasis>");
   static const char TR_SHOW_FTIMES_DESCRIPTION[] =
       QT_TR_NOOP("Shows the average time in ms between each distinct rendered frame alongside "
@@ -230,7 +222,6 @@ void OnScreenDisplayPane::AddDescriptions()
   m_font_size->SetDescription(tr(TR_OSD_FONT_SIZE_DESCRIPTION));
 
   m_show_fps->SetDescription(tr(TR_SHOW_FPS_DESCRIPTION));
-  m_show_internal_resolution->SetDescription(tr(TR_SHOW_INTERNAL_RESOLUTION_DESCRIPTION));
   m_show_ftimes->SetDescription(tr(TR_SHOW_FTIMES_DESCRIPTION));
   m_show_vps->SetDescription(tr(TR_SHOW_VPS_DESCRIPTION));
   m_show_vtimes->SetDescription(tr(TR_SHOW_VTIMES_DESCRIPTION));

--- a/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.h
+++ b/Source/Core/DolphinQt/Settings/OnScreenDisplayPane.h
@@ -25,7 +25,6 @@ private:
 
   // Performance
   ConfigBool* m_show_fps;
-  ConfigBool* m_show_internal_resolution;
   ConfigBool* m_show_ftimes;
   ConfigBool* m_show_vps;
   ConfigBool* m_show_vtimes;


### PR DESCRIPTION
Remove the translated strings and associated checkbox for the `Show Internal Resolution` setting, which I [merged](https://github.com/dolphin-emu/dolphin/pull/14607) after the string freeze began.

The setting itself is still functional and can be activated by putting `ShowInternalResolution = True` in the `[Settings]` section of `GFX.ini`.