### PR TITLE
Fix uninitialized variable warning in ZeldaAudioRenderer::ApplyReverb

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -1085,7 +1085,7 @@ void ZeldaAudioRenderer::ApplyReverb(bool post_rendering)
   auto& memory = m_system.GetMemory();
   for (u16 rpb_idx = 0; rpb_idx < 4; ++rpb_idx)
   {
-    ReverbPB rpb;
+    ReverbPB rpb{};
     u32 rpb_addr = m_reverb_pb_base_addr + rpb_idx * sizeof(ReverbPB);
     memory.CopyFromEmuSwapped(reinterpret_cast<u16*>(&rpb), rpb_addr, sizeof(ReverbPB));
 


### PR DESCRIPTION
If CopyFromEmuSwapped considers the address to be invalid, nothing will be written to the passed-in pointer.