### PR TITLE
GameSettings: Add Game Boy Interface

### DIFF
--- a/Data/Sys/GameSettings/ID-gbi.ini
+++ b/Data/Sys/GameSettings/ID-gbi.ini
@@ -1,0 +1,11 @@
+[Core]
+# Attach Game Boy Player hardware.
+HSPDevice = 2
+# DSP HLE doesn't work with this homebrew's ucode.
+DSPHLE = False
+[DSP]
+# Make sure we get DSP LLE recompiler and not DSP LLE interpreter, for performance.
+EnableJIT = True
+[Video_Settings]
+# Fixes old frames being shown when a game only updates a small part of the screen. Examples include gradually revealed text and the HP bars in Pokémon.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/ID-gbihf.ini
+++ b/Data/Sys/GameSettings/ID-gbihf.ini
@@ -1,0 +1,11 @@
+[Core]
+# Attach Game Boy Player hardware.
+HSPDevice = 2
+# DSP HLE doesn't work with this homebrew's ucode.
+DSPHLE = False
+[DSP]
+# Make sure we get DSP LLE recompiler and not DSP LLE interpreter, for performance.
+EnableJIT = True
+[Video_Settings]
+# Fixes old frames being shown when a game only updates a small part of the screen. Examples include gradually revealed text and the HP bars in Pokémon.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/ID-gbisr.ini
+++ b/Data/Sys/GameSettings/ID-gbisr.ini
@@ -1,0 +1,14 @@
+[Core]
+# Attach Game Boy Player hardware.
+HSPDevice = 2
+# DSP HLE doesn't work with this homebrew's ucode.
+DSPHLE = False
+[DSP]
+# Make sure we get DSP LLE recompiler and not DSP LLE interpreter, for performance.
+EnableJIT = True
+[Video_Settings]
+# Fixes old frames being shown when a game only updates a small part of the screen. Examples include gradually revealed text and the HP bars in Pokémon.
+SafeTextureCacheColorSamples = 0
+[Video_Hacks]
+# Fixes the entire screen being magenta. (ImmediateXFBEnable = True also solves the problem, but XFBToTextureEnable = False is more accurate and there doesn't seem to be a significant performance difference.)
+XFBToTextureEnable = False


### PR DESCRIPTION
Maybe this sets a bad precedent that we should be creating game INIs for homebrew, but I think if there's any homebrew that deserves it, it's Game Boy Interface. It's a great replacement to the very expensive Game Boy Player Start-Up Disc, and how to manually set the settings it needs is super non-obvious. I'll leave the decision to you reviewers.