### PR TITLE
Android: Add RetroAchievements host override receiver

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -148,6 +148,15 @@
             android:exported="false"
             android:theme="@style/Theme.Dolphin.Main" />
 
+        <receiver
+            android:name=".features.retroachievements.RetroAchievementsHostOverrideReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+                <action android:name="${applicationId}.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".services.SyncChannelJobService"
             android:exported="false"

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/retroachievements/RetroAchievementsHostOverrideReceiver.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/retroachievements/RetroAchievementsHostOverrideReceiver.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.retroachievements
+
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import androidx.core.content.ContextCompat
+import java.net.URI
+import java.util.Locale
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
+import org.dolphinemu.dolphinemu.features.settings.model.AchievementModel
+import org.dolphinemu.dolphinemu.utils.DirectoryInitialization
+
+class RetroAchievementsHostOverrideReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action ?: return
+        val packageName = context.packageName
+        val pendingResult = goAsync()
+
+        thread {
+            try {
+                pendingResult.resultCode = handleAction(context, action, packageName, intent)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun handleAction(
+        context: Context,
+        action: String,
+        packageName: String,
+        intent: Intent
+    ): Int {
+        if (!awaitDirectoriesReady(context)) {
+            return Activity.RESULT_CANCELED
+        }
+
+        return when (action) {
+            "$packageName$ACTION_SET_HOST_OVERRIDE_SUFFIX" -> {
+                val hostUrl = normalizeHostUrl(intent.getStringExtra(EXTRA_HOST))
+                    ?: return Activity.RESULT_CANCELED
+                runOnMainThread(context) { AchievementModel.setHostOverride(hostUrl) }
+                Activity.RESULT_OK
+            }
+
+            "$packageName$ACTION_CLEAR_HOST_OVERRIDE_SUFFIX" -> {
+                runOnMainThread(context) { AchievementModel.clearHostOverride() }
+                Activity.RESULT_OK
+            }
+
+            else -> Activity.RESULT_CANCELED
+        }
+    }
+
+    private fun runOnMainThread(context: Context, block: () -> Unit) {
+        val latch = CountDownLatch(1)
+        ContextCompat.getMainExecutor(context).execute {
+            try {
+                block()
+            } finally {
+                latch.countDown()
+            }
+        }
+        latch.await()
+    }
+
+    private fun awaitDirectoriesReady(context: Context): Boolean {
+        if (DirectoryInitialization.areDolphinDirectoriesReady()) {
+            return true
+        }
+        if (DirectoryInitialization.isWaitingForWriteAccess(context)) {
+            return false
+        }
+
+        ContextCompat.getMainExecutor(context).execute { DirectoryInitialization.start(context) }
+
+        val deadline = SystemClock.elapsedRealtime() + DIRECTORY_INIT_TIMEOUT_MS
+        while (!DirectoryInitialization.areDolphinDirectoriesReady()) {
+            if (SystemClock.elapsedRealtime() > deadline) {
+                return false
+            }
+            Thread.sleep(DIRECTORY_INIT_POLL_MS)
+        }
+        return true
+    }
+
+    private fun normalizeHostUrl(value: String?): String? {
+        val trimmedValue = value?.trim().orEmpty()
+
+        if (trimmedValue.isEmpty()) {
+            return null
+        }
+
+        val candidate = if ("://" in trimmedValue) trimmedValue else "http://$trimmedValue"
+        val uri = runCatching { URI(candidate) }.getOrNull() ?: return null
+        val host = uri.host?.lowercase(Locale.US) ?: return null
+
+        if (uri.port !in 1..65535) {
+            return null
+        }
+
+        if (!uri.rawPath.isNullOrEmpty() && uri.rawPath != "/") {
+            return null
+        }
+
+        if (uri.rawQuery != null || uri.rawFragment != null || uri.userInfo != null) {
+            return null
+        }
+
+        return "$host:${uri.port}"
+    }
+
+    companion object {
+        private const val ACTION_SET_HOST_OVERRIDE_SUFFIX =
+            ".action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE"
+        private const val ACTION_CLEAR_HOST_OVERRIDE_SUFFIX =
+            ".action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE"
+
+        private const val DIRECTORY_INIT_TIMEOUT_MS = 9000L
+        private const val DIRECTORY_INIT_POLL_MS = 50L
+
+        const val EXTRA_HOST = "host"
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AchievementModel.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AchievementModel.kt
@@ -9,6 +9,30 @@ object AchievementModel {
     @JvmStatic
     external fun init()
 
+    fun setHostOverride(hostUrl: String) {
+        if (!BooleanSetting.ACHIEVEMENTS_HARDCORE_RESTORE.existsInLayer(NativeConfig.LAYER_BASE)) {
+            BooleanSetting.ACHIEVEMENTS_HARDCORE_RESTORE.setBoolean(
+                NativeConfig.LAYER_BASE,
+                BooleanSetting.ACHIEVEMENTS_HARDCORE_ENABLED.boolean
+            )
+        }
+        StringSetting.ACHIEVEMENTS_HOST_URL.setString(NativeConfig.LAYER_BASE, hostUrl)
+        BooleanSetting.ACHIEVEMENTS_HARDCORE_ENABLED.setBoolean(NativeConfig.LAYER_BASE, false)
+        NativeConfig.save(NativeConfig.LAYER_BASE)
+    }
+
+    fun clearHostOverride() {
+        if (BooleanSetting.ACHIEVEMENTS_HARDCORE_RESTORE.existsInLayer(NativeConfig.LAYER_BASE)) {
+            BooleanSetting.ACHIEVEMENTS_HARDCORE_ENABLED.setBoolean(
+                NativeConfig.LAYER_BASE,
+                BooleanSetting.ACHIEVEMENTS_HARDCORE_RESTORE.boolean
+            )
+            BooleanSetting.ACHIEVEMENTS_HARDCORE_RESTORE.deleteFromLayer(NativeConfig.LAYER_BASE)
+        }
+        StringSetting.ACHIEVEMENTS_HOST_URL.deleteFromLayer(NativeConfig.LAYER_BASE)
+        NativeConfig.save(NativeConfig.LAYER_BASE)
+    }
+
     suspend fun asyncLogin(password: String): Boolean {
         return withContext(Dispatchers.IO) {
             login(password)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -935,6 +935,12 @@ enum class BooleanSetting(
         "ProgressEnabled",
         false
     ),
+    ACHIEVEMENTS_HARDCORE_RESTORE(
+        Settings.FILE_ACHIEVEMENTS,
+        Settings.SECTION_ACHIEVEMENTS,
+        "HardcoreRestore",
+        true
+    ),
     NETPLAY_USE_UPNP(Settings.FILE_DOLPHIN, Settings.SECTION_INI_NETPLAY, "UseUPNP", false);
 
     override val isOverridden: Boolean
@@ -978,6 +984,10 @@ enum class BooleanSetting(
         }
         NativeConfig.setBoolean(layer, file, section, key, newValue)
     }
+
+    fun existsInLayer(layer: Int): Boolean = NativeConfig.exists(layer, file, section, key)
+
+    fun deleteFromLayer(layer: Int): Boolean = NativeConfig.deleteKey(layer, file, section, key)
 
     companion object {
         private val NOT_RUNTIME_EDITABLE_ARRAY = arrayOf(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -947,6 +947,12 @@ enum class BooleanSetting(
         "ProgressEnabled",
         false
     ),
+    ACHIEVEMENTS_HARDCORE_RESTORE(
+        Settings.FILE_ACHIEVEMENTS,
+        Settings.SECTION_ACHIEVEMENTS,
+        "HardcoreRestore",
+        true
+    ),
     NETPLAY_USE_UPNP(Settings.FILE_DOLPHIN, Settings.SECTION_INI_NETPLAY, "UseUPNP", false),
     NETPLAY_SKIP_DUAL_CORE_WARNING(Settings.FILE_DOLPHIN, Settings.SECTION_INI_NETPLAY, "SkipDualCoreWarning", false);
 
@@ -991,6 +997,10 @@ enum class BooleanSetting(
         }
         NativeConfig.setBoolean(layer, file, section, key, newValue)
     }
+
+    fun existsInLayer(layer: Int): Boolean = NativeConfig.exists(layer, file, section, key)
+
+    fun deleteFromLayer(layer: Int): Boolean = NativeConfig.deleteKey(layer, file, section, key)
 
     companion object {
         private val NOT_RUNTIME_EDITABLE_ARRAY = arrayOf(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
@@ -102,6 +102,12 @@ enum class StringSetting(
         "ApiToken",
         ""
     ),
+    ACHIEVEMENTS_HOST_URL(
+        Settings.FILE_ACHIEVEMENTS,
+        Settings.SECTION_ACHIEVEMENTS,
+        "HostUrl",
+        ""
+    ),
     NETPLAY_TRAVERSAL_CHOICE(
         Settings.FILE_DOLPHIN,
         Settings.SECTION_INI_NETPLAY,
@@ -146,6 +152,8 @@ enum class StringSetting(
     fun setString(layer: Int, newValue: String) {
         NativeConfig.setString(layer, file, section, key, newValue)
     }
+
+    fun deleteFromLayer(layer: Int): Boolean = NativeConfig.deleteKey(layer, file, section, key)
 
     companion object {
         private val NOT_RUNTIME_EDITABLE_ARRAY = arrayOf(

--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -70,15 +70,15 @@ void AchievementManager::Init(void* hwnd)
       std::lock_guard lg{m_lock};
       m_client = rc_client_create(MemoryPeeker, Request);
     }
-    std::string host_url = Config::Get(Config::RA_HOST_URL);
-    if (!host_url.empty())
-      rc_client_set_host(m_client, host_url.c_str());
+    m_host_url = Config::Get(Config::RA_HOST_URL);
+    rc_client_set_host(m_client, m_host_url.c_str());
     rc_client_set_event_handler(m_client, EventHandler);
     rc_client_enable_logging(m_client, RC_CLIENT_LOG_LEVEL_VERBOSE,
                              [](const char* message, const rc_client_t* client) {
                                INFO_LOG_FMT(ACHIEVEMENTS, "{}", message);
                              });
-    m_config_changed_callback_id = Config::AddConfigChangedCallback([this] { SetHardcoreMode(); });
+    m_config_changed_callback_id =
+        Config::AddConfigChangedCallback([this] { HandleConfigChanged(); });
     SetHardcoreMode();
     m_queue.Reset("AchievementManagerQueue");
     m_image_queue.Reset("AchievementManagerImageQueue");
@@ -410,6 +410,20 @@ void AchievementManager::DoIdle()
 std::recursive_mutex& AchievementManager::GetLock()
 {
   return m_lock;
+}
+
+void AchievementManager::HandleConfigChanged()
+{
+  const std::string host_url = Config::Get(Config::RA_HOST_URL);
+  if (host_url != m_host_url)
+  {
+    m_host_url = host_url;
+    rc_client_set_host(m_client, m_host_url.c_str());
+    if (HasAPIToken())
+      Login("");
+  }
+
+  SetHardcoreMode();
 }
 
 void AchievementManager::SetHardcoreMode()

--- a/Source/Core/Core/AchievementManager.h
+++ b/Source/Core/Core/AchievementManager.h
@@ -211,6 +211,7 @@ private:
   void DisplayWelcomeMessage();
 
   void SetHardcoreMode();
+  void HandleConfigChanged();
 
   template <typename T>
   void FilterApprovedIni(std::vector<T>& codes, std::string_view game_id, u16 revision) const;
@@ -257,6 +258,7 @@ private:
 #endif  // RC_CLIENT_SUPPORTS_RAINTEGRATION
 
   rc_client_t* m_client{};
+  std::string m_host_url;
   std::atomic<Core::System*> m_system{};
   std::unique_ptr<DiscIO::Volume> m_loading_volume;
   Config::ConfigChangedCallbackID m_config_changed_callback_id;


### PR DESCRIPTION
[RAOfflineProxy](https://raofflineproxy.com/) is an Android app that proxies RetroAchievements traffic through `127.0.0.1`, enabling offline softcore achievement play through local caching and later sync.

This makes the override controllable by the app at runtime instead of requiring external tools to patch `RetroAchievements.ini` directly, which is more brittle and harder to integrate cleanly on Android.

## Summary
- add an Android broadcast receiver for setting and clearing the RetroAchievements host override
- persist the override to Dolphin's RetroAchievements config and disable hardcore while active
- reload the achievement manager after config changes so the override takes effect without manual file edits

## Testing
- built `:app:assembleDebug`
- installed the debug APK on device via `adb`
- verified `SET_RETROACHIEVEMENTS_HOST_OVERRIDE` patches `RetroAchievements.ini` to `HostUrl = 127.0.0.1:8080` and sets `HardcoreEnabled = False`
- verified traffic then routes through the local proxy
- verified `CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE` resets `HostUrl =`

## Related
- mirrors the same Android broadcast-driven host override already merged for [PPSSPP](https://github.com/hrydgard/ppsspp/pull/21760), planned for the upcoming release
- mirrors the same integration already merged for [flycast](https://github.com/flyinghead/flycast/pull/2371), planned for the upcoming release
- mirrors the same integration already merged for [ARMSX2](https://github.com/ARMSX2/ARMSX2/pull/164) and shipped in the current build, and inherited by [ARMSX1](https://github.com/ARMSX2/ARMSX1)
- mirrors the same integration already merged for [mupen64plus-ae](https://github.com/JoeysRetroHandhelds/mupen64plus-ae-retroachievements/pull/1)
- mirrors the same integration already shipped in [WatermelonDS](https://github.com/SapphireRhodonite/WatermelonDS), with [SeedlessDS](https://github.com/SapphireRhodonite/SeedlessDS) pending
- follows the same goal as the open PRs for [RetroArch](https://github.com/libretro/RetroArch/pull/19093) and [NetherSX2](https://github.com/Trixarian/NetherSX2-patch/pull/343)
