### PR TITLE
Android: Route DolphinBar Balance Board to the Balance Board slot

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOAndroid.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOAndroid.cpp
@@ -46,10 +46,12 @@ auto WiimoteScannerAndroid::FindAttachedWiimotes() -> FindResults
       if (!wiimote->ConnectInternal())
         continue;
 
-      // TODO: We make no attempt to differentiate balance boards here.
-      // wiimote->IsBalanceBoard() would probably be enough to do that.
-
-      results.wii_remotes.emplace_back(std::move(wiimote));
+      // Differentiate balance boards so they are routed to the balance
+      // board results rather than being treated as a regular Wii Remote.
+      if (wiimote->IsBalanceBoard())
+        results.balance_boards.emplace_back(std::move(wiimote));
+      else
+        results.wii_remotes.emplace_back(std::move(wiimote));
     }
   }
 


### PR DESCRIPTION
## Summary

`WiimoteScannerAndroid::FindAttachedWiimotes()` added every device connected through the DolphinBar to the Wii Remote results, with a `TODO` noting that balance boards were not differentiated. As a result, a Wii Balance Board connected through the DolphinBar on Android was always assigned to a Wii Remote slot (Player 1), so games that request a Balance Board (e.g. Wii Fit / Wii Fit Plus) never detected it.

This change uses `Wiimote::IsBalanceBoard()` to route balance boards into the `balance_boards` results, matching the behavior of the Linux and Windows scanner backends. This resolves the in-code `TODO` (`wiimote->IsBalanceBoard() would probably be enough to do that.`).

## Test plan

- Hardware: AYN Thor (Android 13), Mayflash DolphinBar in Mode 4, official Nintendo Wii Balance Board (RVL-WBC-01).
- Set Balance Board source to `Real Balance Board` with continuous scanning enabled.
- Before: syncing the board connected it as Wii Remote 1; Wii Fit Plus kept asking to sync the board.
- After: the board is detected in the Balance Board slot and Wii Fit Plus recognizes and uses it for gameplay.
- A regular Wii Remote connected through the same DolphinBar still connects as a Wii Remote as before.

Made with [Cursor](https://cursor.com)