### PR TITLE
GameSettings: Remove SafeTextureCacheColorSamples from gbihf

### DIFF
--- a/Data/Sys/GameSettings/ID-gbihf.ini
+++ b/Data/Sys/GameSettings/ID-gbihf.ini
@@ -6,6 +6,3 @@ DSPHLE = False
 [DSP]
 # Make sure we get DSP LLE recompiler and not DSP LLE interpreter, for performance.
 EnableJIT = True
-[Video_Settings]
-# Fixes old frames being shown when a game only updates a small part of the screen. Examples include gradually revealed text and the HP bars in Pokémon.
-SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
Extrems said that it's unnecessary because GBIHF doesn't use the GPU. Video output doesn't work in GBIHF in Dolphin regardless of this setting, so I can't actually test it.