### PR TITLE
NetPlayServer: Fix remote crash via invalid pad index

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -192,6 +192,12 @@ static void ClearPeerPlayerId(ENetPeer* peer)
   }
 }
 
+template <typename T>
+static bool IsValidPadIndex(const T& map_array, PadIndex index)
+{
+  return index >= 0 && static_cast<size_t>(index) < map_array.size();
+}
+
 void NetPlayServer::SetupIndex()
 {
   if (!Config::Get(Config::NETPLAY_USE_INDEX) || Config::Get(Config::NETPLAY_INDEX_NAME).empty() ||
@@ -814,7 +820,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 
       // If the data is not from the correct player,
       // then disconnect them.
-      if (m_pad_map.at(map) != player.pid)
+      if (!IsValidPadIndex(m_pad_map, map) || m_pad_map.at(map) != player.pid)
       {
         return 1;
       }
@@ -862,6 +868,9 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
       PadIndex map;
       packet >> map;
 
+      if (!IsValidPadIndex(m_pad_map, map))
+        return 1;
+
       GCPadStatus pad;
       packet >> pad.button;
       spac << map << pad.button;
@@ -895,7 +904,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 
       // If the data is not from the correct player,
       // then disconnect them.
-      if (m_wiimote_map.at(map) != player.pid)
+      if (!IsValidPadIndex(m_wiimote_map, map) || m_wiimote_map.at(map) != player.pid)
       {
         return 1;
       }

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -539,6 +539,21 @@ unsigned int NetPlayServer::OnDisconnect(const Client& player)
         break;
       }
     }
+
+    for (PlayerId& mapping : m_wiimote_map)
+    {
+      if (m_is_running && mapping == pid && pid != 1)
+      {
+        std::lock_guard lkg(m_crit.game);
+        m_is_running = false;
+
+        sf::Packet spac;
+        spac << MessageID::DisableGame;
+        // this thread doesn't need players lock
+        SendToClients(spac);
+        break;
+      }
+    }
   }
 
   if (m_start_pending)


### PR DESCRIPTION
A malicious or broken client can crash a netplay host by sending a GameCube (`PadData/PadHostData`) or Wii (`WiimoteData`) controller packet with an out-of-range `PadIndex`. The unchecked index hits `.at()` on the pad/GBA/wiimote arrays, and the unhandled `std::out_of_range` takes down the host, a remote DoS.

This PR includes two fixes:
1. Bounds-check packet indices and disconnect the offending client.
2. Stop the game when a Wiimote-mapped player disconnects (mirroring the existing GC pad logic), otherwise the host stalls waiting on input from the disconnected client and crashes anyway.

**Testing**: Reproduced with a faulty client sending `static_cast<PadIndex>(-1)` for both GameCube and Wii controllers. Crashes unpatched `master`, with both fixes, the host disconnects the faulty client and cleanly stops the game instead of stalling.