### PR TITLE
Externals/glslang: fix compilation on Visual Studio 2026

### DIFF
--- a/Externals/glslang/glslang.vcxproj
+++ b/Externals/glslang/glslang.vcxproj
@@ -32,10 +32,10 @@
     <DevCmdArch Condition="'$(Platform)'=='x64'">amd64</DevCmdArch>
 	<DevCmdArch Condition="'$(Platform)'=='ARM64'">arm64</DevCmdArch>
     <CmakeReleaseCLI>call vsdevcmd.bat -arch=$(DevCmdArch)
-      cmake -G $(CmakeGenerator) -A $(Platform) -DCMAKE_BUILD_TYPE="Release" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DGLSLANG_TESTS=OFF -DENABLE_GLSLANG_BINARIES=OFF -DBUILD_EXTERNAL=OFF -DENABLE_SPVREMAPPER=OFF -DENABLE_HLSL=OFF -DENABLE_OPT=OFF -DENABLE_EXCEPTIONS=OFF -S glslang -B "$(BuildRootDir)tmp\$(ProjectName)-$(Configuration)-$(Platform)"
+      cmake -G $(CmakeGenerator) -A $(Platform) -T $(PlatformToolset) -DCMAKE_BUILD_TYPE="Release" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DGLSLANG_TESTS=OFF -DENABLE_GLSLANG_BINARIES=OFF -DBUILD_EXTERNAL=OFF -DENABLE_SPVREMAPPER=OFF -DENABLE_HLSL=OFF -DENABLE_OPT=OFF -DENABLE_EXCEPTIONS=OFF -S glslang -B "$(BuildRootDir)tmp\$(ProjectName)-$(Configuration)-$(Platform)"
     </CmakeReleaseCLI>
     <CmakeDebugCLI>call vsdevcmd.bat -arch=$(DevCmdArch)
-      cmake -G $(CmakeGenerator) -A $(Platform) -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug -DGLSLANG_TESTS=OFF -DENABLE_GLSLANG_BINARIES=OFF -DBUILD_EXTERNAL=OFF -DENABLE_SPVREMAPPER=OFF -DENABLE_HLSL=OFF -DENABLE_OPT=OFF -DENABLE_EXCEPTIONS=OFF -S glslang -B "$(BuildRootDir)tmp\$(ProjectName)-$(Configuration)-$(Platform)"
+      cmake -G $(CmakeGenerator) -A $(Platform) -T $(PlatformToolset) -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug -DGLSLANG_TESTS=OFF -DENABLE_GLSLANG_BINARIES=OFF -DBUILD_EXTERNAL=OFF -DENABLE_SPVREMAPPER=OFF -DENABLE_HLSL=OFF -DENABLE_OPT=OFF -DENABLE_EXCEPTIONS=OFF -S glslang -B "$(BuildRootDir)tmp\$(ProjectName)-$(Configuration)-$(Platform)"
     </CmakeDebugCLI>
     <CmakeCopyCLI>
       echo Copying..


### PR DESCRIPTION
With the release of Visual Studio 2026, it's no longer possible to freshly install Visual Studio 2022, which is the version Dolphin currently targets for building on Windows. The official "workaround" is installing the build tools from VS 2022 and using them when compiling in Visual Studio 2026, or to retarget all solutions to the VS 2026 toolset (a bit annoying as this generates a lot of git noise, since it touches several files from the repo).

By going with the first route, everything is compiled with the VS2022 toolset, except for glslang, which ignores the selected toolset, always defaulting to the most recent available. Initial compilation succeeds, but the linking step fails due to missing symbols, caused by the mismatched VC++ runtimes targeted between glslang and the rest of the code. In the end, the build fails.

This PR fixes that by appending the `$(PlatformToolset)` variable to the CMake command used during the build process of glslang, making sure the proper toolset is always passed to the subprocess, also ensuring this doesn't break in the future if we move to Visual Studio 2026 at some point.