### PR TITLE
GameSettings: fix pony not showing up in Pony Friends 2

### DIFF
--- a/Data/Sys/GameSettings/R2R.ini
+++ b/Data/Sys/GameSettings/R2R.ini
@@ -2,3 +2,7 @@
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+
+[Video_Hacks]
+# Required to show pony for grooming.
+EFBToTextureEnable = False


### PR DESCRIPTION
EFB-to-RAM needs to be enabled at the start of grooming.

This is what it looks like otherwise:
https://youtu.be/AvFk0ufBGBQ?t=345