### PR TITLE
State: Fix Use After Move In LoadAsFromCore

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -15,6 +15,7 @@
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <lz4.h>
 #include <lzo/lzo1x.h>
@@ -463,7 +464,7 @@ static void CompressAndDumpState(Core::System& system, const CompressAndDumpStat
   else
   {
     const std::filesystem::path temp_path(filename);
-    Core::DisplayMessage(fmt::format("Saved State to {}", temp_path.filename().string()), 2000);
+    Core::DisplayMessage(fmt::format("Saved State to {}", temp_path.filename()), 2000);
   }
 }
 
@@ -840,9 +841,8 @@ static void LoadAsFromCore(Core::System& system, std::string filename)
   {
     if (loaded_successfully)
     {
-      std::filesystem::path temp_filename(std::move(filename));
-      Core::DisplayMessage(fmt::format("Loaded State from {}", temp_filename.filename().string()),
-                           2000);
+      const std::filesystem::path temp_filename(filename);
+      Core::DisplayMessage(fmt::format("Loaded State from {}", temp_filename.filename()), 2000);
       if (File::Exists(filename + ".dtm"))
       {
         movie.LoadInput(filename + ".dtm");


### PR DESCRIPTION
This use-after-move error inhibits the use of savestates during the Dolphin TAS Movie creation process, because `filename + ".dtm"` will always be `"" + ".dtm"` due to the `filename` string being moved from. The breaking change was done in https://github.com/dolphin-emu/dolphin/commit/dd2b94cd4a71fb6abda72f58d27434ef2d8b0a5f during a broader code cleanup.  I also improved the string formatting to not require an intermediate temporary string.