### PR TITLE
Use redump.info instead of redump.org

### DIFF
--- a/Languages/po/ar.po
+++ b/Languages/po/ar.po
@@ -2892,13 +2892,13 @@ msgid "Wii data is not public yet"
 msgstr "بيانات وي ليست عامة بعد"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Redump.org فشل الاتصال بـ"
+msgid "Failed to connect to Redump.info"
+msgstr "Redump.info فشل الاتصال بـ"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Redump.org فشل تحليل بيانات"
+msgid "Failed to parse Redump.info data"
+msgstr "Redump.info فشل تحليل بيانات"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3197,10 +3197,10 @@ msgstr "هذا تفريغ جيد"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Redump.org هذا تفريغ جيد وفقًا لموقع\n"
+"Redump.info هذا تفريغ جيد وفقًا لموقع\n"
 "لكن دولفين وجد مشاكل. قد يكون هذا خطأ في دولفين"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7214,8 +7214,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org حالة"
+msgid "Redump.info Status:"
+msgstr "Redump.info حالة"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/ca.po
+++ b/Languages/po/ca.po
@@ -2828,12 +2828,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3109,7 +3109,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7028,7 +7028,7 @@ msgid "SHA-1:"
 msgstr "SHA-1"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/cs.po
+++ b/Languages/po/cs.po
@@ -2820,12 +2820,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3101,7 +3101,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/da.po
+++ b/Languages/po/da.po
@@ -2831,13 +2831,13 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Fejl under oversættelse af Redump.org-data"
+msgid "Failed to parse Redump.info data"
+msgstr "Fejl under oversættelse af Redump.info-data"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3112,7 +3112,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7041,7 +7041,7 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/de.po
+++ b/Languages/po/de.po
@@ -3027,13 +3027,13 @@ msgid "Wii data is not public yet"
 msgstr "Wii-Daten sind noch nicht öffentlich"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Konnte nicht mit Redump.org verbinden"
+msgid "Failed to connect to Redump.info"
+msgstr "Konnte nicht mit Redump.info verbinden"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Konnte Daten von Redump.org nicht parsen"
+msgid "Failed to parse Redump.info data"
+msgstr "Konnte Daten von Redump.info nicht parsen"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3346,10 +3346,10 @@ msgstr "Dies ist ein guter Dump."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Laut Redump.org ist dies ein guter Dump, aber Dolphin hat Probleme gefunden. "
+"Laut Redump.info ist dies ein guter Dump, aber Dolphin hat Probleme gefunden. "
 "Dies könnte ein Fehler in Dolphin sein."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7523,8 +7523,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org Status:"
+msgid "Redump.info Status:"
+msgstr "Redump.info Status:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/dolphin-emu.pot
+++ b/Languages/po/dolphin-emu.pot
@@ -2814,12 +2814,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3095,7 +3095,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -6998,7 +6998,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/el.po
+++ b/Languages/po/el.po
@@ -2822,12 +2822,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3103,7 +3103,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7023,8 +7023,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org Κατάσταση:"
+msgid "Redump.info Status:"
+msgstr "Redump.info Κατάσταση:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/en.po
+++ b/Languages/po/en.po
@@ -2813,12 +2813,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3094,7 +3094,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -6997,7 +6997,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/es.po
+++ b/Languages/po/es.po
@@ -3112,13 +3112,13 @@ msgid "Wii data is not public yet"
 msgstr "Los datos de Wii todavía no son públicos"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "No se ha podido conectar con redump.org"
+msgid "Failed to connect to Redump.info"
+msgstr "No se ha podido conectar con redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "No se han podido analizar los datos de redump.org"
+msgid "Failed to parse Redump.info data"
+msgstr "No se han podido analizar los datos de redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3437,10 +3437,10 @@ msgstr "Este es un buen volcado."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Este es un buen volcado de acuerdo con Redump.org, pero Dolphin ha "
+"Este es un buen volcado de acuerdo con Redump.info, pero Dolphin ha "
 "encontrado problemas. Puede ser un bug en Dolphin."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -8028,8 +8028,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Estado de redump.org:"
+msgid "Redump.info Status:"
+msgstr "Estado de redump.info:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/fa.po
+++ b/Languages/po/fa.po
@@ -2819,12 +2819,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3100,7 +3100,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7008,7 +7008,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/fi.po
+++ b/Languages/po/fi.po
@@ -3064,13 +3064,13 @@ msgid "Wii data is not public yet"
 msgstr "Wii-data ei ole vielä julkista"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Redump.orgiin yhdistäminen epäonnistui"
+msgid "Failed to connect to Redump.info"
+msgstr "Redump.infoiin yhdistäminen epäonnistui"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Redump.org-datan jäsentäminen epäonnistui"
+msgid "Failed to parse Redump.info data"
+msgstr "Redump.info-datan jäsentäminen epäonnistui"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3378,10 +3378,10 @@ msgstr "Tämä vedos on hyvä."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Redump.orgin mukaan tämä on hyvä vedos, mutta Dolphin löysi siitä ongelmia. "
+"Redump.infoin mukaan tämä on hyvä vedos, mutta Dolphin löysi siitä ongelmia. "
 "Tämä saattaa olla vika Dolphinissa."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7917,8 +7917,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org-tila:"
+msgid "Redump.info Status:"
+msgstr "Redump.info-tila:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/fr.po
+++ b/Languages/po/fr.po
@@ -3088,13 +3088,13 @@ msgid "Wii data is not public yet"
 msgstr "Données Wii pas encore publiques"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Impossible de se connecter à Redump.org"
+msgid "Failed to connect to Redump.info"
+msgstr "Impossible de se connecter à Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Impossible de traiter les données de Redump.org"
+msgid "Failed to parse Redump.info data"
+msgstr "Impossible de traiter les données de Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3411,10 +3411,10 @@ msgstr "Ceci est un dump correct."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"C'est un bon dump, d'après le site Redump.org ; mais Dolphin a repéré des "
+"C'est un bon dump, d'après le site Redump.info ; mais Dolphin a repéré des "
 "problèmes. Ceci peut être un bug dans Dolphin."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7929,8 +7929,8 @@ msgid "SHA-1:"
 msgstr "SHA-1 :"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "État de Redump.org :"
+msgid "Redump.info Status:"
+msgstr "État de Redump.info :"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/hr.po
+++ b/Languages/po/hr.po
@@ -2817,12 +2817,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3098,7 +3098,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7006,7 +7006,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/hu.po
+++ b/Languages/po/hu.po
@@ -3028,12 +3028,12 @@ msgid "Wii data is not public yet"
 msgstr "A Wii adatok még nem nyilvánosak"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Nem sikerült kapcsolódni ehhez: Redump.org"
+msgid "Failed to connect to Redump.info"
+msgstr "Nem sikerült kapcsolódni ehhez: Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3322,10 +3322,10 @@ msgstr "Ez egy jó kimentés."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Ez a fájl a Redump.org szerint egy jó másolat, de a Dolphin problémákat "
+"Ez a fájl a Redump.info szerint egy jó másolat, de a Dolphin problémákat "
 "talált. Ez lehet, hogy a Dolphin hibája."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7344,8 +7344,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org állapot:"
+msgid "Redump.info Status:"
+msgstr "Redump.info állapot:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/it.po
+++ b/Languages/po/it.po
@@ -3076,13 +3076,13 @@ msgid "Wii data is not public yet"
 msgstr "Dati Wii non ancora pubblici"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Impossibile connettersi a Redump.org"
+msgid "Failed to connect to Redump.info"
+msgstr "Impossibile connettersi a Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Fallito parsing dei dati di Redump.org"
+msgid "Failed to parse Redump.info data"
+msgstr "Fallito parsing dei dati di Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3403,10 +3403,10 @@ msgstr "Questo è un buon dump."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Questo è un buon dump secondo Redump.org, ma Dolphin ha riscontrato dei "
+"Questo è un buon dump secondo Redump.info, ma Dolphin ha riscontrato dei "
 "problemi. Potrebbe essere un bug in Dolphin stesso."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7922,8 +7922,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Stato di Redump.org:"
+msgid "Redump.info Status:"
+msgstr "Stato di Redump.info:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/ja.po
+++ b/Languages/po/ja.po
@@ -3048,13 +3048,13 @@ msgid "Wii data is not public yet"
 msgstr "Wii data is not public yet"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Redump.org に接続できませんでした"
+msgid "Failed to connect to Redump.info"
+msgstr "Redump.info に接続できませんでした"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Redump.orgデータの解析に失敗しました。"
+msgid "Failed to parse Redump.info data"
+msgstr "Redump.infoデータの解析に失敗しました。"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3365,10 +3365,10 @@ msgstr "正常なダンプです。"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Redump.org によると、これは正常なダンプですが、Dolphinで不具合があることが判"
+"Redump.info によると、これは正常なダンプですが、Dolphinで不具合があることが判"
 "明しています。これはDolphinのバグかもしれません。"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7721,8 +7721,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.orgのステータス:"
+msgid "Redump.info Status:"
+msgstr "Redump.infoのステータス:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/ko.po
+++ b/Languages/po/ko.po
@@ -3013,13 +3013,13 @@ msgid "Wii data is not public yet"
 msgstr "Wii 데이터는 아직 공개가 아닙니다"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Redump.org 연결에 실패했습니다"
+msgid "Failed to connect to Redump.info"
+msgstr "Redump.info 연결에 실패했습니다"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Redump.org 데이터 문법분석에 실패했습니다"
+msgid "Failed to parse Redump.info data"
+msgstr "Redump.info 데이터 문법분석에 실패했습니다"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3327,10 +3327,10 @@ msgstr "이것은 좋은 덤프입니다."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Redump.org 에 따르면 이것은 좋은 덤프입니다, 하지만 돌핀이 문제를 발견했습니"
+"Redump.info 에 따르면 이것은 좋은 덤프입니다, 하지만 돌핀이 문제를 발견했습니"
 "다. 이것은 돌핀쪽 버그 일지도 모릅니다."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7698,8 +7698,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org 상태:"
+msgid "Redump.info Status:"
+msgstr "Redump.info 상태:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/ms.po
+++ b/Languages/po/ms.po
@@ -2833,12 +2833,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3114,7 +3114,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7039,7 +7039,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/nb.po
+++ b/Languages/po/nb.po
@@ -2849,12 +2849,12 @@ msgid "Wii data is not public yet"
 msgstr "Wii-data er ikke offentlige enda"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3153,7 +3153,7 @@ msgstr "Dette er en god dump."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7110,8 +7110,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "'Redump.org-'status:"
+msgid "Redump.info Status:"
+msgstr "'Redump.info-'status:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/nl.po
+++ b/Languages/po/nl.po
@@ -3041,13 +3041,13 @@ msgid "Wii data is not public yet"
 msgstr "Wii data is nog niet publiek"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Mislukt om met Redump.org te verbinden"
+msgid "Failed to connect to Redump.info"
+msgstr "Mislukt om met Redump.info te verbinden"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Ontleden van Redump.org data mislukt"
+msgid "Failed to parse Redump.info data"
+msgstr "Ontleden van Redump.info data mislukt"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3364,10 +3364,10 @@ msgstr "Dit is een goede dump."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Dit is een goede dump volgens Redump.org, maar Dolphin heeft problemen "
+"Dit is een goede dump volgens Redump.info, maar Dolphin heeft problemen "
 "gevonden. Dit is misschien een fout in Dolphin."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7624,8 +7624,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org Status:"
+msgid "Redump.info Status:"
+msgstr "Redump.info Status:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/pl.po
+++ b/Languages/po/pl.po
@@ -2838,12 +2838,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3119,7 +3119,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7051,8 +7051,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Status Redump.org:"
+msgid "Redump.info Status:"
+msgstr "Status Redump.info:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/pt.po
+++ b/Languages/po/pt.po
@@ -2820,12 +2820,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3101,7 +3101,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7009,7 +7009,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/pt_BR.po
+++ b/Languages/po/pt_BR.po
@@ -3112,13 +3112,13 @@ msgid "Wii data is not public yet"
 msgstr "Dados do Wii ainda não são públicos"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Falha na conexão com Redump.org"
+msgid "Failed to connect to Redump.info"
+msgstr "Falha na conexão com Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Falha ao processar dados do Redump.org"
+msgid "Failed to parse Redump.info data"
+msgstr "Falha ao processar dados do Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3436,10 +3436,10 @@ msgstr "Essa cópia é válida."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Essa é uma cópia válida do disco de acordo com Redump.org, no entanto o "
+"Essa é uma cópia válida do disco de acordo com Redump.info, no entanto o "
 "Dolphin encontrou problemas. Isso pode ser um bug no Dolphin."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7989,8 +7989,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Status no Redump.org:"
+msgid "Redump.info Status:"
+msgstr "Status no Redump.info:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/ro.po
+++ b/Languages/po/ro.po
@@ -2819,12 +2819,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3100,7 +3100,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7008,7 +7008,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/ru.po
+++ b/Languages/po/ru.po
@@ -3057,13 +3057,13 @@ msgid "Wii data is not public yet"
 msgstr "Данные Wii ещё не опубликованы"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Не удалось подключиться к Redump.org"
+msgid "Failed to connect to Redump.info"
+msgstr "Не удалось подключиться к Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Не удалось обработать данные с Redump.org"
+msgid "Failed to parse Redump.info data"
+msgstr "Не удалось обработать данные с Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3375,10 +3375,10 @@ msgstr "Данный дамп — хороший."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Согласно Redump.org, данный дамп — хороший, но Dolphin обнаружил в нём "
+"Согласно Redump.info, данный дамп — хороший, но Dolphin обнаружил в нём "
 "проблемы. Возможно, это баг Dolphin."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7848,8 +7848,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Статус на Redump.org:"
+msgid "Redump.info Status:"
+msgstr "Статус на Redump.info:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/sr.po
+++ b/Languages/po/sr.po
@@ -2817,12 +2817,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3098,7 +3098,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7001,7 +7001,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/sv.po
+++ b/Languages/po/sv.po
@@ -3054,13 +3054,13 @@ msgid "Wii data is not public yet"
 msgstr "Wii-data är inte offentlig än"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Misslyckades att ansluta till Redump.org"
+msgid "Failed to connect to Redump.info"
+msgstr "Misslyckades att ansluta till Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "Misslyckades att tolka data från Redump.org"
+msgid "Failed to parse Redump.info data"
+msgstr "Misslyckades att tolka data från Redump.info"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3379,10 +3379,10 @@ msgstr "Detta är en korrekt kopia."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"Detta är en korrekt kopia enligt Redump.org, men Dolphin har hittat problem. "
+"Detta är en korrekt kopia enligt Redump.info, men Dolphin har hittat problem. "
 "Detta skulle kunna vara en bugg i Dolphin."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7832,8 +7832,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org-status:"
+msgid "Redump.info Status:"
+msgstr "Redump.info-status:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/tr.po
+++ b/Languages/po/tr.po
@@ -2905,12 +2905,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "Redump.org'a bağlanılamadı."
+msgid "Failed to connect to Redump.info"
+msgstr "Redump.info'a bağlanılamadı."
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3186,7 +3186,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7268,7 +7268,7 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Languages/po/zh_CN.po
+++ b/Languages/po/zh_CN.po
@@ -2982,13 +2982,13 @@ msgid "Wii data is not public yet"
 msgstr "Wii 数据尚未公开"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
-msgstr "连接 Redump.org 失败"
+msgid "Failed to connect to Redump.info"
+msgstr "连接 Redump.info 失败"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
-msgstr "解析 Redump.org 数据失败"
+msgid "Failed to parse Redump.info data"
+msgstr "解析 Redump.info 数据失败"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
 #, c++-format
@@ -3283,10 +3283,10 @@ msgstr "这是一个正确的转储。"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
-"依据 Redump.org，这是一个正确的转储，但 Dolphin 发现了问题。这可能是 Dolphin "
+"依据 Redump.info，这是一个正确的转储，但 Dolphin 发现了问题。这可能是 Dolphin "
 "中的错误。"
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1400
@@ -7560,8 +7560,8 @@ msgid "SHA-1:"
 msgstr "SHA-1:"
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
-msgstr "Redump.org 状态："
+msgid "Redump.info Status:"
+msgstr "Redump.info 状态："
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101
 msgid "Verify Integrity"

--- a/Languages/po/zh_TW.po
+++ b/Languages/po/zh_TW.po
@@ -2822,12 +2822,12 @@ msgid "Wii data is not public yet"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:110
-msgid "Failed to connect to Redump.org"
+msgid "Failed to connect to Redump.info"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:222
 #: Source/Core/DiscIO/VolumeVerifier.cpp:321
-msgid "Failed to parse Redump.org data"
+msgid "Failed to parse Redump.info data"
 msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:317
@@ -3103,7 +3103,7 @@ msgstr ""
 
 #: Source/Core/DiscIO/VolumeVerifier.cpp:1392
 msgid ""
-"This is a good dump according to Redump.org, but Dolphin has found problems. "
+"This is a good dump according to Redump.info, but Dolphin has found problems. "
 "This might be a bug in Dolphin."
 msgstr ""
 
@@ -7009,7 +7009,7 @@ msgid "SHA-1:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:87
-msgid "Redump.org Status:"
+msgid "Redump.info Status:"
 msgstr ""
 
 #: Source/Core/DolphinQt/Config/VerifyWidget.cpp:101

--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -19,6 +19,12 @@ namespace Common
 #define BUILD_TYPE_STR ""
 #endif
 
+const std::string& GetEmulatorName()
+{
+  static const std::string emulator_name = EMULATOR_NAME;
+  return emulator_name;
+}
+
 const std::string& GetScmRevStr()
 {
   static const std::string scm_rev_str = EMULATOR_NAME " "

--- a/Source/Core/Common/Version.h
+++ b/Source/Core/Common/Version.h
@@ -7,6 +7,7 @@
 
 namespace Common
 {
+const std::string& GetEmulatorName();
 const std::string& GetScmDescStr();
 const std::string& GetScmBranchStr();
 const std::string& GetScmRevStr();

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -96,7 +96,7 @@ void RedumpVerifier::Start(const Volume& volume)
     switch (download_state->status)
     {
     case DownloadStatus::FailButOldCacheAvailable:
-      ERROR_LOG_FMT(DISCIO, "Failed to fetch data from Redump.org, using old cached data instead");
+      ERROR_LOG_FMT(DISCIO, "Failed to fetch data from Redump.info, using old cached data instead");
       [[fallthrough]];
     case DownloadStatus::Success:
       return ScanDatfile(ReadDatfile(system), system);
@@ -107,7 +107,7 @@ void RedumpVerifier::Start(const Volume& volume)
 
     case DownloadStatus::Fail:
     default:
-      m_result = {Status::Error, Common::GetStringT("Failed to connect to Redump.org")};
+      m_result = {Status::Error, Common::GetStringT("Failed to connect to Redump.info")};
       return {};
     }
   });
@@ -127,7 +127,7 @@ RedumpVerifier::DownloadStatus RedumpVerifier::DownloadDatfile(const std::string
   Common::HttpRequest request;
 
   const std::optional<std::vector<u8>> result =
-      request.Get("http://redump.org/datfile/" + system + "/serial,version",
+      request.Get("https://redump.info/datfile/" + system + "/serial,version",
                   {{"User-Agent", Common::GetScmRevStr()}});
 
   const std::string output_path = GetPathForSystem(system);
@@ -219,7 +219,7 @@ std::vector<RedumpVerifier::PotentialMatch> RedumpVerifier::ScanDatfile(std::spa
   pugi::xml_document doc;
   if (!doc.load_buffer(data.data(), data.size()))
   {
-    m_result = {Status::Error, Common::GetStringT("Failed to parse Redump.org data")};
+    m_result = {Status::Error, Common::GetStringT("Failed to parse Redump.info data")};
     return {};
   }
 
@@ -317,8 +317,8 @@ std::vector<RedumpVerifier::PotentialMatch> RedumpVerifier::ScanDatfile(std::spa
         "Serial and/or version data is missing from {0}\n"
         "Please append \"{1}\" (without the quotes) to the datfile URL when downloading\n"
         "Example: {2}",
-        GetPathForSystem(system), "serial,version", "http://redump.org/datfile/gc/serial,version");
-    m_result = {Status::Error, Common::GetStringT("Failed to parse Redump.org data")};
+        GetPathForSystem(system), "serial,version", "http://redump.info/datfile/gc/serial,version");
+    m_result = {Status::Error, Common::GetStringT("Failed to parse Redump.info data")};
     return {};
   }
 
@@ -1389,7 +1389,7 @@ void VolumeVerifier::Finish()
     else
     {
       m_result.summary_text =
-          Common::GetStringT("This is a good dump according to Redump.org, but Dolphin has found "
+          Common::GetStringT("This is a good dump according to Redump.info, but Dolphin has found "
                              "problems. This might be a bug in Dolphin.");
     }
     return;

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -101,10 +101,6 @@ void RedumpVerifier::Start(const Volume& volume)
     case DownloadStatus::Success:
       return ScanDatfile(ReadDatfile(system), system);
 
-    case DownloadStatus::SystemNotAvailable:
-      m_result = {Status::Error, Common::GetStringT("Wii data is not public yet")};
-      return {};
-
     case DownloadStatus::Fail:
     default:
       m_result = {Status::Error, Common::GetStringT("Failed to connect to Redump.info")};
@@ -121,7 +117,7 @@ static std::string GetPathForSystem(const std::string& system)
 RedumpVerifier::DownloadStatus RedumpVerifier::DownloadDatfile(const std::string& system,
                                                                DownloadStatus old_status)
 {
-  if (old_status == DownloadStatus::Success || old_status == DownloadStatus::SystemNotAvailable)
+  if (old_status == DownloadStatus::Success)
     return old_status;
 
   Common::HttpRequest request;
@@ -141,13 +137,8 @@ RedumpVerifier::DownloadStatus RedumpVerifier::DownloadDatfile(const std::string
   if (result->size() > 1 && (*result)[0] == '<' && (*result)[1] == '!')
   {
     // This is an HTML page, not a zip file like we want
-
-    if (File::Exists(output_path))
-      return DownloadStatus::FailButOldCacheAvailable;
-
-    const bool system_not_available_match =
-        Common::ContainsSubrange(*result, "System \"" + system + "\" doesn't exist.");
-    return system_not_available_match ? DownloadStatus::SystemNotAvailable : DownloadStatus::Fail;
+    return File::Exists(output_path) ? DownloadStatus::FailButOldCacheAvailable :
+                                       DownloadStatus::Fail;
   }
 
   File::CreateFullPath(output_path);

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -128,7 +128,7 @@ RedumpVerifier::DownloadStatus RedumpVerifier::DownloadDatfile(const std::string
 
   const std::optional<std::vector<u8>> result =
       request.Get("https://redump.info/datfile/" + system + "/serial,version",
-                  {{"User-Agent", Common::GetScmRevStr()}});
+                  {{"User-Agent", Common::GetEmulatorName()}});
 
   const std::string output_path = GetPathForSystem(system);
 

--- a/Source/Core/DiscIO/VolumeVerifier.h
+++ b/Source/Core/DiscIO/VolumeVerifier.h
@@ -68,7 +68,6 @@ private:
     Success,
     Fail,
     FailButOldCacheAvailable,
-    SystemNotAvailable,
   };
 
   struct DownloadState

--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -84,7 +84,7 @@ void VerifyWidget::CreateWidgets()
   if (DiscIO::IsDisc(m_volume->GetVolumeType()))
   {
     std::tie(m_redump_checkbox, m_redump_line_edit) =
-        AddHashLine(m_redump_layout, tr("Redump.org Status:"));
+        AddHashLine(m_redump_layout, tr("Redump.info Status:"));
     m_redump_checkbox->setChecked(CanVerifyRedump());
     UpdateRedumpEnabled();
   }


### PR DESCRIPTION
All the staff of Redump (except the absentee sysadmin) have decided to start a new version of the website at redump.info. It has every disc from the old site, it has HTTPS, it isn't buckling under the load of AI scrapers, and moving forward, all adding and verifying of discs is going to be happening on the new website only. Let's move over.

I've taken the unusual step of updating the translation files manually. This is because we're very close to a release and because the change is simple enough that I feel that I can make the change to languages I don't speak. (I double checked that the Korean translation doesn't ever follow "Redump.org" by a particle that has a different form depending on whether there's a final consonant.)