### PR TITLE
fmt: Allow building with version >=12.2.0 

### DIFF
--- a/Source/Core/Common/Crypto/AES.cpp
+++ b/Source/Core/Common/Crypto/AES.cpp
@@ -4,6 +4,7 @@
 #include "Common/Crypto/AES.h"
 
 #include <array>
+#include <cstring>
 #include <memory>
 
 #include <mbedtls/aes.h>

--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -103,8 +103,9 @@ void GenericLogFmt(LogLevel level, LogType type, const char* file, int line, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-
-#if FMT_VERSION >= 110000
+#if FMT_VERSION >= 110000 && FMT_VERSION < 120200
+  // fmt 11 made fmt::string_view no longer directly constructible from compile-time strings.
+  // In fmt 12.2+, compile-time strings are plain string literals, so this is no longer needed.
   auto&& format_str = fmt::format_string<Args...>(format);
 #else
   auto&& format_str = format;

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -39,7 +39,10 @@ bool MsgAlertFmt(bool yes_no, MsgType style, Common::Log::LogType log_type, cons
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 110000
+
+#if FMT_VERSION >= 120200
+  auto&& format_str = format;
+#elif FMT_VERSION >= 110000
   static_assert(std::is_base_of_v<fmt::detail::compile_string, S>);
   auto&& format_str = fmt::format_string<Args...>(format);
 #elif FMT_VERSION >= 90000
@@ -63,13 +66,14 @@ bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 110000
-  static_assert(std::is_base_of_v<fmt::detail::compile_string, S>);
-#elif FMT_VERSION >= 90000
-  static_assert(fmt::detail::is_compile_string<S>::value);
-#else
+#if FMT_VERSION < 90000
   static_assert(fmt::is_compile_string<S>::value);
+#elif FMT_VERSION < 110000
+  static_assert(fmt::detail::is_compile_string<S>::value);
+#elif FMT_VERSION < 120200
+  static_assert(std::is_base_of_v<fmt::detail::compile_string, S>);
 #endif
+  // FMT 12.2+ guarantees this will be a compile-time string
   auto arg_list = fmt::make_format_args(args...);
   return MsgAlertFmtImpl(yes_no, style, log_type, file, line, translated_format, arg_list);
 }

--- a/Source/Core/Common/TimeUtil.cpp
+++ b/Source/Core/Common/TimeUtil.cpp
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "Common/TimeUtil.h"
-#include "Common/Logging/Log.h"
 
+#include <cstring>
 #include <ctime>
 #include <optional>
+
+#include "Common/Logging/Log.h"
 
 namespace Common
 {

--- a/Source/Core/VideoBackends/OGL/OGLBoundingBox.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLBoundingBox.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoBackends/OGL/OGLBoundingBox.h"
 
+#include <cstring>
+
 #include "VideoBackends/OGL/OGLGfx.h"
 #include "VideoCommon/DriverDetails.h"
 


### PR DESCRIPTION
This [change](https://github.com/fmtlib/fmt/releases/tag/12.2.0) was causing some issues:

> Made FMT_STRING a no-op when FMT_USE_CONSTEVAL is enabled, since the consteval format-string constructor already provides compile-time validation (https://github.com/dolphin-emu/dolphin/pull/4611, https://github.com/dolphin-emu/dolphin/pull/4612). Thanks @friedkeenan.

A few includes were also missing due to indirectly using them. I'm not sure if this is because of the fmt update or gcc 16, but Dolphin wouldn't build for me without adding them either way. If this is only a me problem, I can take it out of this PR.