### PR TITLE
TAPServerConnection: Fix builds with LLVM toolchain

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA/TAPServerConnection.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAPServerConnection.cpp
@@ -11,6 +11,7 @@
 #include <ws2ipdef.h>
 #else
 #include <netinet/in.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>


### PR DESCRIPTION
On an Alpine system using a full LLVM toolchain, building fails because `fd_set`/`timeval` are undefined.