### PR TITLE
Android: Fix mixup between Vibrator id and index

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -584,14 +584,14 @@ private:
 class AndroidMotor : public Core::Device::Output
 {
 public:
-  AndroidMotor(JNIEnv* env, jobject vibrator, jint id)
-      : m_vibrator(env->NewGlobalRef(vibrator)), m_id(id)
+  AndroidMotor(JNIEnv* env, jobject vibrator, jint index)
+      : m_vibrator(env->NewGlobalRef(vibrator)), m_index(index)
   {
   }
 
   ~AndroidMotor() { IDCache::GetEnvForThread()->DeleteGlobalRef(m_vibrator); }
 
-  std::string GetName() const override { return "Motor " + std::to_string(m_id); }
+  std::string GetName() const override { return "Motor " + std::to_string(m_index); }
 
   void SetState(ControlState state) override
   {
@@ -606,7 +606,7 @@ public:
 
 private:
   const jobject m_vibrator;
-  const jint m_id;
+  const jint m_index;
   std::atomic<ControlState> m_state = 0;
 };
 
@@ -793,8 +793,8 @@ private:
     jint size = env->GetArrayLength(j_vibrator_ids);
     for (jint i = 0; i < size; ++i)
     {
-      jobject vibrator =
-          env->CallObjectMethod(vibrator_manager, s_dolphin_vibrator_manager_get_vibrator, i);
+      jobject vibrator = env->CallObjectMethod(
+          vibrator_manager, s_dolphin_vibrator_manager_get_vibrator, vibrator_ids[i]);
       AddOutput(new AndroidMotor(env, vibrator, i));
       env->DeleteLocalRef(vibrator);
     }


### PR DESCRIPTION
This fixes https://bugs.dolphin-emu.org/issues/14076. The issue report more or less already says it all, but to provide a shorter summary: We were fetching a list of vibrator IDs, but instead of passing the vibrator ID to the vibrator manager, we passed the index of the ID in the list. This happened to work fine on many devices, including all devices that use DolphinVibratorManagerCompat, due to the only Vibrator having both an index and ID of 0. But on some devices, it failed due to the ID of the Vibrator being 1.

This fix makes us correctly pass the ID to the vibrator manager. We still use indices in controller INI files, both for compatibility with the controller mappings shipped with Dolphin (which use index 0) and for backwards compatibility with older controller INI files.