### PR TITLE
Android: Set USAGE_MEDIA for rumble

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
@@ -160,6 +160,7 @@ object ControllerInterface {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             DolphinVibratorManagerPassthrough(device.vibratorManager)
         } else {
+            @Suppress("DEPRECATION")
             DolphinVibratorManagerCompat(device.vibrator)
         }
     }
@@ -174,6 +175,7 @@ object ControllerInterface {
                 return DolphinVibratorManagerPassthrough(vibratorManager)
             }
         }
+        @Suppress("DEPRECATION")
         val vibrator = DolphinApplication.getAppContext()
             .getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
         return DolphinVibratorManagerCompat(vibrator)
@@ -190,11 +192,13 @@ object ControllerInterface {
         } else {
             val attributes = AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_MEDIA).build()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                @Suppress("DEPRECATION")
                 vibrator.vibrate(
                     VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE),
                     attributes
                 )
             } else {
+                @Suppress("DEPRECATION")
                 vibrator.vibrate(100, attributes)
             }
         }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
@@ -4,10 +4,12 @@ package org.dolphinemu.dolphinemu.features.input.model
 
 import android.content.Context
 import android.hardware.input.InputManager
+import android.media.AudioAttributes
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
+import android.os.VibrationAttributes
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
@@ -180,10 +182,21 @@ object ControllerInterface {
     @Keep
     @JvmStatic
     private fun vibrate(vibrator: Vibrator) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE))
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            vibrator.vibrate(
+                VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE),
+                VibrationAttributes.Builder().setUsage(VibrationAttributes.USAGE_MEDIA).build()
+            )
         } else {
-            vibrator.vibrate(100)
+            val attributes = AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_MEDIA).build()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                vibrator.vibrate(
+                    VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE),
+                    attributes
+                )
+            } else {
+                vibrator.vibrate(100, attributes)
+            }
         }
     }
 


### PR DESCRIPTION
This lets rumble work even if the user has turned off the Android setting Sound and vibration > Vibration and haptics > Interactive haptics > Touch feedback. Rumble can still be disabled through Dolphin's controller bindings and through in-game settings (GameCube) or SYSCONF (Wii).

Fixes https://bugs.dolphin-emu.org/issues/14075.