### PR TITLE
Externals/miniupnpc: Disable warnings

### DIFF
--- a/Externals/miniupnpc/CMakeLists.txt
+++ b/Externals/miniupnpc/CMakeLists.txt
@@ -5,5 +5,6 @@ set(UPNPC_BUILD_SAMPLE OFF)
 set(UPNPC_NO_INSTALL ON)
 
 add_subdirectory(miniupnp/miniupnpc)
+dolphin_disable_warnings(libminiupnpc-static)
 
 add_library(Miniupnpc::miniupnpc ALIAS libminiupnpc-static)


### PR DESCRIPTION
This would create a warning that was interpreted as an error when cross-compiling to ARM64 on Windows 