### PR TITLE
DiscIO: Add DTK alignment comment in DirectoryBlob

### DIFF
--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -1252,6 +1252,9 @@ void DirectoryBlobPartition::WriteDirectory(std::vector<u8>* fst_data,
                        std::move(content.m_source));
       }
 
+      // For most files, an alignment of 0x20 is enough. But some files need 0x8000,
+      // in particular all DTK audio files in GameCube games.
+      // TODO: Do any Wii games need 0x8000 alignment?
       const u64 data_alignment = m_is_triforce ? 0x20ull : 0x8000ull;
       *data_offset = Common::AlignUp(*data_offset + entry.m_size, data_alignment);
     }


### PR DESCRIPTION
This requirement came up in the review of PR #14599. Instead of just removing the comment like PR #14599 did, let's add a more detailed comment.