### PR TITLE
Jit64: Early flush in ComputeRC even when `needs_test`

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -182,23 +182,14 @@ void Jit64::ComputeRC(preg_t preg, bool needs_test, bool needs_sext)
 
   if (CheckMergedBranch(0))
   {
+    // If the output operand to the cmp/rc op we're merging with the branch isn't used anymore, it'd
+    // be better to flush it here so that we don't have to flush it on both sides of the branch.
+    // The flush is before the TEST so that it can macro-op fusion with the conditional branch.
+    gpr.Flush(~js.op->gprWillBeWritten & js.op->regsOut, RegCache::FlushMode::Undirty);
     if (needs_test)
-    {
       TEST(32, arg, arg);
-      arg.Unlock();
-    }
-    else
-    {
-      // If an operand to the cmp/rc op we're merging with the branch isn't used anymore, it'd be
-      // better to flush it here so that we don't have to flush it on both sides of the branch.
-      // We don't want to do this if a test is needed though, because it would interrupt macro-op
-      // fusion.
-      arg.Unlock();
-      gpr.Flush(~(js.op->gprWillBeRead | js.op->gprWillBeWritten) &
-                    (js.op->regsIn | js.op->regsOut),
-                RegCache::FlushMode::Full);
-      gpr.Flush(~js.op->gprWillBeWritten & js.op->regsOut, RegCache::FlushMode::Undirty);
-    }
+
+    arg.Unlock();
     DoMergedBranchCondition();
   }
 }

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -338,8 +338,8 @@ void RegCache::Flush(BitSet32 pregs, FlushMode mode,
 
   for (preg_t i : pregs)
   {
-    ASSERT_MSG(DYNA_REC, !m_regs[i].IsLocked(), "Someone forgot to unlock PPC reg {} (X64 reg {}).",
-               i, std::to_underlying(RX(i)));
+    ASSERT_MSG(DYNA_REC, mode != FlushMode::Full || !m_regs[i].IsLocked(),
+               "Someone forgot to unlock PPC reg {} (X64 reg {}).", i, std::to_underlying(RX(i)));
     ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress for {}!",
                i);
 


### PR DESCRIPTION
Example:
```
nand. r1, r2, r3
```
Assuming that none of these registers will be used again:
- Before #14278, all of them would be flushed on both sides of the branch.
- After #14278, r2 and r3 would have been flushed earlier, but r1 won't.
- With this, r1 is flushed in ComputeRC.