### PR TITLE
Android: Fix release build

### DIFF
--- a/Source/Android/app/build.gradle.kts
+++ b/Source/Android/app/build.gradle.kts
@@ -169,8 +169,8 @@ dependencies {
     implementation(libs.androidx.compose.material3.adaptive)
     implementation(libs.androidx.compose.runtime.livedata)
     implementation(libs.androidx.compose.ui)
-    debugImplementation(libs.androidx.compose.ui.tooling)
-    debugImplementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
 }
 
 fun getGitVersion(): String {


### PR DESCRIPTION
We don't need to see Compose previews when making a release build, but `androidx.compose.ui.tooling.preview.Preview` is referenced in the source code nonetheless, so the build system needs to know what it is.