### PR TITLE
Android: Enable USE_UPNP in android builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,7 +447,6 @@ if(ANDROID)
     # but not as a shared library. We want an executable.
     set(ANDROID 0)
   endif()
-  set(USE_UPNP 0)
   set(ENABLE_QT 0)
   set(USE_DISCORD_PRESENCE 0)
 


### PR DESCRIPTION
The UI already exists in the Android netplay menu so just need to enable it in the build.

Testing performed:
- remove custom port forwarding rules and enable upnp on the router. 
- host android device connected to the router, client android device using cellular
- select "use upnp" when hosting and ensure client connects
- unselect "use upnp" when hosting and ensure client fails to connect
- test with traversal server and internal ip address and ensure they are unaffected by the "use upnp" setting
- disable upnp on the router and ensure client fails to connect
- a few more combinations "use upnp" setting, router settings, connection type settings and ensure they all produce the expected result.