### PR TITLE
Fix cheatsmanager crash

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -57,16 +57,26 @@ void CheatsManager::OnStateChanged(Core::State state)
 
 void CheatsManager::OnFrameEnd()
 {
-  if (!isVisible())
+  if (m_frame_end_update_queued.exchange(true))
     return;
 
-  auto* const selected_cheat_search_widget =
-      qobject_cast<CheatSearchWidget*>(m_tab_widget->currentWidget());
-  if (selected_cheat_search_widget != nullptr)
-  {
-    selected_cheat_search_widget->UpdateTableVisibleCurrentValues(
-        CheatSearchWidget::UpdateSource::Auto);
-  }
+  QMetaObject::invokeMethod(
+      this,
+      [this] {
+        m_frame_end_update_queued = false;
+
+        if (!isVisible())
+          return;
+
+        auto* const selected_cheat_search_widget =
+            qobject_cast<CheatSearchWidget*>(m_tab_widget->currentWidget());
+        if (selected_cheat_search_widget != nullptr)
+        {
+          selected_cheat_search_widget->UpdateTableVisibleCurrentValues(
+              CheatSearchWidget::UpdateSource::Auto);
+        }
+      },
+      Qt::QueuedConnection);
 }
 
 void CheatsManager::UpdateAllCheatSearchWidgetCurrentValues()

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -75,4 +76,5 @@ private:
   CheatSearchFactoryWidget* m_cheat_search_new = nullptr;
 
   Common::EventHook m_VI_end_field_event;
+  std::atomic<bool> m_frame_end_update_queued = false;
 };


### PR DESCRIPTION
`OnFrameEnd` is called from the CPU thread and starts calling methods on widgets. When searching memory for values, this caused Dolphin to crash a lot for me. Reproduced relatively reliably by having the game running, memory values auto-updating and trying to edit an address' description. 

The fix just moves work onto the GUI thread, with an atomic flag to avoid posting events every frame if the GUI thread was to fall behind. 

I tested this for around 4 hours making some cheat codes for newer smbw. No crashes thus far.

AI was used to examine crash logs.