### PR TITLE
Android: Add configurable user data storage location

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA"/>
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA"/>

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/AnalyticsDialog.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/AnalyticsDialog.kt
@@ -3,10 +3,12 @@
 package org.dolphinemu.dolphinemu.dialogs
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.ui.main.MainActivity
 import org.dolphinemu.dolphinemu.utils.Analytics
 
 class AnalyticsDialog : DialogFragment() {
@@ -21,6 +23,13 @@ class AnalyticsDialog : DialogFragment() {
                 Analytics.firstAnalyticsAdd(false)
             }
         return dialog.create()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        // The migration prompt is held back while this dialog is up — check again now instead
+        // of waiting for the next onResume.
+        (activity as? MainActivity)?.checkMigration()
     }
 
     companion object {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -3,11 +3,14 @@
 package org.dolphinemu.dolphinemu.features.settings.ui
 
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Process
 import android.text.TextUtils
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.collection.ArraySet
 import kotlinx.coroutines.CoroutineScope
@@ -211,6 +214,53 @@ class SettingsFragmentPresenter(
     }
 
     private fun addGeneralSettings(sl: ArrayList<SettingsItem>) {
+        val hasSdCard = DirectoryInitialization.hasSdCard(context)
+        sl.add(
+            SingleChoiceSetting(
+                context,
+                object : AbstractIntSetting {
+                    override val isOverridden: Boolean = false
+                    override val isRuntimeEditable: Boolean = true
+                    override fun delete(settings: Settings): Boolean {
+                        DirectoryInitialization.setStorageMode(
+                            context,
+                            DirectoryInitialization.USER_DIR_MODE_SCOPED
+                        )
+                        showRestartDialog()
+                        return true
+                    }
+                    override val int: Int
+                        get() = DirectoryInitialization.getStorageMode(context)
+                    override fun setInt(settings: Settings, newValue: Int) {
+                        DirectoryInitialization.setStorageMode(context, newValue)
+                        showRestartDialog()
+                    }
+                    private fun showRestartDialog() {
+                        AlertDialog.Builder(context)
+                            .setTitle(R.string.storage_restart_title)
+                            .setMessage(R.string.storage_restart_message)
+                            .setPositiveButton(R.string.storage_restart_button) { _, _ ->
+                                val launchIntent = context.packageManager
+                                    .getLaunchIntentForPackage(context.packageName)
+                                    ?.apply {
+                                        addFlags(
+                                            Intent.FLAG_ACTIVITY_NEW_TASK or
+                                            Intent.FLAG_ACTIVITY_CLEAR_TASK
+                                        )
+                                    }
+                                if (launchIntent != null) context.startActivity(launchIntent)
+                                Process.killProcess(Process.myPid())
+                            }
+                            .setCancelable(false)
+                            .show()
+                    }
+                },
+                R.string.user_data_storage,
+                R.string.user_data_storage_description,
+                if (hasSdCard) R.array.userDataStorageEntries else R.array.userDataStorageEntriesNoSd,
+                if (hasSdCard) R.array.userDataStorageValues else R.array.userDataStorageValuesNoSd
+            )
+        )
         sl.add(
             SwitchSetting(
                 context,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.kt
@@ -2,13 +2,23 @@
 
 package org.dolphinemu.dolphinemu.ui.main
 
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.Settings
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
@@ -19,6 +29,7 @@ import com.google.android.material.tabs.TabLayout
 import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.adapters.PlatformPagerAdapter
 import org.dolphinemu.dolphinemu.databinding.ActivityMainBinding
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import org.dolphinemu.dolphinemu.features.settings.model.IntSetting
 import org.dolphinemu.dolphinemu.features.settings.model.NativeConfig
 import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag
@@ -44,6 +55,14 @@ class MainActivity : AppCompatActivity(), MainView, OnRefreshListener, ThemeProv
 
     private lateinit var menu: Menu
 
+    private var storagePermissionDialogShown = false
+    private var waitingForStoragePermission = false
+
+    companion object {
+        private const val KEY_STORAGE_DIALOG_SHOWN = "storagePermissionDialogShown"
+        private const val KEY_WAITING_FOR_STORAGE_PERMISSION = "waitingForStoragePermission"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen().setKeepOnScreenCondition { !DirectoryInitialization.areDolphinDirectoriesReady() }
 
@@ -51,6 +70,9 @@ class MainActivity : AppCompatActivity(), MainView, OnRefreshListener, ThemeProv
         enableEdgeToEdge()
 
         super.onCreate(savedInstanceState)
+
+        storagePermissionDialogShown = savedInstanceState?.getBoolean(KEY_STORAGE_DIALOG_SHOWN) ?: false
+        waitingForStoragePermission = savedInstanceState?.getBoolean(KEY_WAITING_FOR_STORAGE_PERMISSION) ?: false
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -94,13 +116,157 @@ class MainActivity : AppCompatActivity(), MainView, OnRefreshListener, ThemeProv
         ThemeHelper.setCorrectTheme(this)
 
         super.onResume()
+        if (waitingForStoragePermission &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            Environment.isExternalStorageManager()
+        ) {
+            waitingForStoragePermission = false
+            val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+                ?.apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK) }
+            if (launchIntent != null) startActivity(launchIntent)
+            android.os.Process.killProcess(android.os.Process.myPid())
+            return
+        }
+        checkStoragePermission()
         if (DirectoryInitialization.shouldStart(this)) {
             DirectoryInitialization.start(this)
             AfterDirectoryInitializationRunner()
                 .runWithLifecycle(this) { setPlatformTabsAndStartGameFileCacheService() }
         }
+        AfterDirectoryInitializationRunner().runWithLifecycle(this) { checkMigration() }
 
         presenter.onResume()
+    }
+
+    fun checkMigration() {
+        // Don't stack on top of the analytics prompt. AnalyticsDialog calls this again as soon
+        // as it's dismissed, so migration still shows right away rather than waiting for the
+        // next onResume (e.g. the user backgrounding and returning to the app).
+        if (!BooleanSetting.MAIN_ANALYTICS_PERMISSION_ASKED.boolean) return
+
+        when (DirectoryInitialization.getMigrationState(this)) {
+            DirectoryInitialization.MigrationState.NONE -> return
+            DirectoryInitialization.MigrationState.CLEAN -> {
+                AlertDialog.Builder(this)
+                    .setTitle(R.string.migrate_user_data_title)
+                    .setMessage(R.string.migrate_user_data_message)
+                    .setPositiveButton(R.string.migrate_user_data_yes) { _, _ -> startMigration() }
+                    .setNegativeButton(R.string.migrate_user_data_no) { _, _ ->
+                        DirectoryInitialization.markMigrationOffered(this)
+                    }
+                    .setCancelable(false)
+                    .show()
+            }
+            DirectoryInitialization.MigrationState.CONFLICT -> {
+                AlertDialog.Builder(this)
+                    .setTitle(R.string.migrate_conflict_title)
+                    .setMessage(R.string.migrate_conflict_message)
+                    .setPositiveButton(R.string.migrate_conflict_replace) { _, _ -> startMigration() }
+                    .setNegativeButton(R.string.migrate_conflict_keep) { _, _ ->
+                        DirectoryInitialization.markMigrationOffered(this)
+                    }
+                    .setCancelable(false)
+                    .show()
+            }
+        }
+    }
+
+    private fun startMigration() {
+        val pad = resources.getDimensionPixelSize(R.dimen.spacing_large)
+
+        val progressBar = ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal).apply {
+            isIndeterminate = true
+        }
+        val progressText = TextView(this).apply {
+            setText(R.string.migrate_user_data_progress)
+            setPadding(0, pad / 2, 0, 0)
+        }
+        val container = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(pad, pad, pad, pad / 2)
+            addView(progressBar)
+            addView(progressText)
+        }
+
+        val progressDialog = AlertDialog.Builder(this)
+            .setTitle(R.string.migrate_user_data_in_progress)
+            .setView(container)
+            .setCancelable(false)
+            .show()
+
+        DirectoryInitialization.copyUserDataToNewLocation(
+            this,
+            onProgress = { copied, total ->
+                runOnUiThread {
+                    progressBar.isIndeterminate = false
+                    progressBar.max = total
+                    progressBar.progress = copied
+                    progressText.text = getString(R.string.migrate_user_data_progress_file, copied, total)
+                }
+            }
+        ) { result ->
+            runOnUiThread {
+                if (isFinishing || isDestroyed) return@runOnUiThread
+                progressDialog.dismiss()
+                when (result) {
+                    DirectoryInitialization.MigrationResult.SUCCESS -> {
+                        DirectoryInitialization.markMigrationOffered(this)
+                        AlertDialog.Builder(this)
+                            .setTitle(R.string.migrate_user_data_success_title)
+                            .setMessage(R.string.migrate_user_data_success_message)
+                            .setPositiveButton(R.string.storage_restart_button) { _, _ ->
+                                val launchIntent = packageManager
+                                    .getLaunchIntentForPackage(packageName)
+                                    ?.apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK) }
+                                if (launchIntent != null) startActivity(launchIntent)
+                                android.os.Process.killProcess(android.os.Process.myPid())
+                            }
+                            .setCancelable(false)
+                            .show()
+                    }
+                    DirectoryInitialization.MigrationResult.NOT_ENOUGH_SPACE -> {
+                        Toast.makeText(this, R.string.migrate_user_data_failed_space, Toast.LENGTH_LONG).show()
+                    }
+                    DirectoryInitialization.MigrationResult.SD_CARD_UNAVAILABLE -> {
+                        Toast.makeText(this, R.string.migrate_user_data_failed_sdcard, Toast.LENGTH_LONG).show()
+                    }
+                    DirectoryInitialization.MigrationResult.FAILED -> {
+                        Toast.makeText(this, R.string.migrate_user_data_failed, Toast.LENGTH_LONG).show()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun checkStoragePermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+        if (DirectoryInitialization.getStorageMode(this) == DirectoryInitialization.USER_DIR_MODE_SCOPED) return
+        if (Environment.isExternalStorageManager()) return
+        if (storagePermissionDialogShown) return
+
+        storagePermissionDialogShown = true
+        AlertDialog.Builder(this)
+            .setTitle(R.string.storage_permission_title)
+            .setMessage(R.string.storage_permission_needed)
+            .setPositiveButton(R.string.storage_permission_grant) { _, _ ->
+                waitingForStoragePermission = true
+                val intent = Intent(
+                    Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                    Uri.parse("package:$packageName")
+                )
+                startActivity(intent)
+            }
+            .setNegativeButton(R.string.storage_permission_use_scoped) { _, _ ->
+                DirectoryInitialization.setStorageMode(this, DirectoryInitialization.USER_DIR_MODE_SCOPED)
+            }
+            .setCancelable(false)
+            .show()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_STORAGE_DIALOG_SHOWN, storagePermissionDialogShown)
+        outState.putBoolean(KEY_WAITING_FOR_STORAGE_PERMISSION, waitingForStoragePermission)
     }
 
     override fun onStop() {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.kt
@@ -6,8 +6,11 @@
 package org.dolphinemu.dolphinemu.utils
 
 import android.content.Context
+import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.os.storage.StorageManager
+import android.provider.DocumentsContract
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
@@ -36,6 +39,14 @@ import kotlin.system.exitProcess
  * - Running the native code's init steps (which include things like populating the User directory)
  */
 object DirectoryInitialization {
+    const val PREF_USER_DIR_MODE = "userDirectoryMode"
+    const val USER_DIR_MODE_SCOPED = 0
+    const val USER_DIR_MODE_INTERNAL = 1
+    const val USER_DIR_MODE_SDCARD = 2
+
+    private const val PREF_MIGRATION_OFFERED = "userDataMigrationOffered"
+    private const val PREF_PREVIOUS_USER_DIR_MODE = "previousUserDirMode"
+
     private val directoryState = MutableLiveData(DirectoryInitializationState.NOT_YET_INITIALIZED)
 
     @Volatile
@@ -44,6 +55,7 @@ object DirectoryInitialization {
     private lateinit var userPath: String
     private lateinit var driverPath: String
     private var usingLegacyUserDirectory = false
+    private var userDirectoryWasPreExisting = false
 
     enum class DirectoryInitializationState {
         NOT_YET_INITIALIZED, INITIALIZING, DOLPHIN_DIRECTORIES_INITIALIZED
@@ -75,6 +87,38 @@ object DirectoryInitialization {
             return
         }
 
+        // Record before Initialize() creates default folders, so migration can distinguish
+        // a pre-existing user directory from one Dolphin just scaffolded fresh
+        userDirectoryWasPreExisting = File(userPath).let { it.exists() && it.listFiles()?.isNotEmpty() == true }
+
+        // A storage location change restarts into this directory before the user has decided
+        // (or before the copy has run), so handle both the "Keep Existing" conflict case and the
+        // fresh/empty clean-migration case before anything else reads this directory's config.
+        run {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            if (!prefs.getBoolean(PREF_MIGRATION_OFFERED, false)) {
+                val prevMode = prefs.getInt(PREF_PREVIOUS_USER_DIR_MODE, -1)
+                val currentMode = getStorageMode(context)
+                if (prevMode != -1 && prevMode != currentMode) {
+                    getPathForMode(context, prevMode)?.let { source ->
+                        if (source.absolutePath != File(userPath).absolutePath) {
+                            if (userDirectoryWasPreExisting) {
+                                // Patch ahead of GameFileCache's own startup scan, which
+                                // silently strips unresolvable ISOPaths and saves — otherwise
+                                // that runs before the user even sees the migration dialog.
+                                patchStalePaths(context, source)
+                            } else {
+                                // Destination is empty until the copy runs, so first-run flags
+                                // like the analytics prompt would otherwise reset and re-fire
+                                // on every storage location change.
+                                seedFirstRunFlagsFromSource(source)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         extractSysDirectory(context)
         NativeLibrary.Initialize()
 
@@ -91,22 +135,416 @@ object DirectoryInitialization {
     }
 
     @JvmStatic
-    fun getUserDirectoryPath(context: Context?): File? {
-        if (context == null) {
-            return null
+    fun hasSdCard(context: Context): Boolean = getSdCardRoot(context) != null
+
+    @JvmStatic
+    fun getStorageMode(context: Context): Int {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+            .getInt(PREF_USER_DIR_MODE, USER_DIR_MODE_SCOPED)
+    }
+
+    @JvmStatic
+    fun setStorageMode(context: Context, mode: Int) {
+        val current = getStorageMode(context)
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putInt(PREF_USER_DIR_MODE, mode)
+            .putInt(PREF_PREVIOUS_USER_DIR_MODE, current)
+            .remove(PREF_MIGRATION_OFFERED)
+            .apply()
+    }
+
+    private fun getPathForMode(context: Context, mode: Int): File? = when (mode) {
+        USER_DIR_MODE_INTERNAL -> getLegacyUserDirectoryPath()
+        USER_DIR_MODE_SDCARD   -> getSdCardRoot(context)?.let { File(it, "dolphin-emu") }
+        else                   -> context.getExternalFilesDir(null)
+    }
+
+    enum class MigrationState { NONE, CLEAN, CONFLICT }
+
+    @JvmStatic
+    fun getMigrationState(context: Context): MigrationState {
+        if (!areDirectoriesAvailable) return MigrationState.NONE
+
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        if (prefs.getBoolean(PREF_MIGRATION_OFFERED, false)) return MigrationState.NONE
+
+        val prevMode = prefs.getInt(PREF_PREVIOUS_USER_DIR_MODE, -1)
+        if (prevMode == -1) return MigrationState.NONE
+
+        val currentMode = getStorageMode(context)
+        if (prevMode == currentMode) return MigrationState.NONE
+
+        val sourceDir = getPathForMode(context, prevMode) ?: return MigrationState.NONE
+        if (!sourceDir.exists() || sourceDir.listFiles()?.isEmpty() != false) return MigrationState.NONE
+
+        val destDir = File(userPath)
+        // If paths are the same the app fell back to scoped due to missing permission — not a real migration
+        if (sourceDir.canonicalPath == destDir.canonicalPath) return MigrationState.NONE
+
+        // Use the pre-init snapshot so Dolphin's own folder scaffolding doesn't look like a conflict
+        return if (userDirectoryWasPreExisting) MigrationState.CONFLICT else MigrationState.CLEAN
+    }
+
+    @JvmStatic
+    fun markMigrationOffered(context: Context) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .putBoolean(PREF_MIGRATION_OFFERED, true).apply()
+    }
+
+    enum class MigrationResult { SUCCESS, NOT_ENOUGH_SPACE, SD_CARD_UNAVAILABLE, FAILED }
+
+    // Require some headroom on top of the exact byte count copied, since filesystem block
+    // overhead means a copy can run out of space slightly before an exact total would suggest.
+    private const val MIGRATION_SPACE_MARGIN_BYTES = 50L * 1024 * 1024
+
+    @JvmStatic
+    fun copyUserDataToNewLocation(
+        context: Context,
+        onProgress: (copied: Int, total: Int) -> Unit,
+        onComplete: (MigrationResult) -> Unit
+    ) {
+        if (!areDirectoriesAvailable) { onComplete(MigrationResult.FAILED); return }
+
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val prevMode = prefs.getInt(PREF_PREVIOUS_USER_DIR_MODE, -1)
+        val source = getPathForMode(context, prevMode) ?: run { onComplete(MigrationResult.FAILED); return }
+        val dest = File(userPath)
+        if (source.absolutePath == dest.absolutePath) { onComplete(MigrationResult.SUCCESS); return }
+
+        thread {
+            try {
+                // The SD card can be removed in the window between the dialog appearing and the
+                // user confirming — check it's still there rather than surfacing a raw IOException.
+                val currentMode = getStorageMode(context)
+                if (prevMode == USER_DIR_MODE_SDCARD || currentMode == USER_DIR_MODE_SDCARD) {
+                    val sdRoot = getSdCardRoot(context)
+                    if (sdRoot == null || !isVolumeMounted(sdRoot)) {
+                        Log.error("[DirectoryInitialization] Migration aborted — SD card not available")
+                        onComplete(MigrationResult.SD_CARD_UNAVAILABLE)
+                        return@thread
+                    }
+                }
+
+                // Source could have been emptied or removed in that same window
+                if (!source.exists() || source.listFiles()?.isEmpty() != false) {
+                    Log.error("[DirectoryInitialization] Migration aborted — source directory missing or empty")
+                    onComplete(MigrationResult.FAILED)
+                    return@thread
+                }
+
+                val files = source.walk().filter { it.isFile }.toList()
+                val requiredBytes = files.sumOf { it.length() }
+
+                // dest may not exist yet (clean migration) — walk up to the nearest existing
+                // ancestor to find its writability and how much space is available on that volume.
+                var spaceProbe = dest
+                while (!spaceProbe.exists() && spaceProbe.parentFile != null) {
+                    spaceProbe = spaceProbe.parentFile!!
+                }
+
+                if (!spaceProbe.canWrite()) {
+                    Log.error("[DirectoryInitialization] Migration aborted — destination is not writable")
+                    onComplete(MigrationResult.FAILED)
+                    return@thread
+                }
+
+                val availableBytes = spaceProbe.usableSpace
+                if (availableBytes < requiredBytes + MIGRATION_SPACE_MARGIN_BYTES) {
+                    Log.error(
+                        "[DirectoryInitialization] Migration aborted — not enough free space " +
+                            "(need ~${requiredBytes / (1024 * 1024)}MB + margin, " +
+                            "have ~${availableBytes / (1024 * 1024)}MB available)"
+                    )
+                    onComplete(MigrationResult.NOT_ENOUGH_SPACE)
+                    return@thread
+                }
+
+                // Clear destination first so no stale files remain after copy
+                val clearFailed = dest.listFiles()?.any { !it.deleteRecursively() } == true
+                if (clearFailed) {
+                    Log.error("[DirectoryInitialization] Migration aborted — could not clear destination")
+                    onComplete(MigrationResult.FAILED)
+                    return@thread
+                }
+
+                val total = files.size
+                onProgress(0, total)
+
+                files.forEachIndexed { index, srcFile ->
+                    val destFile = dest.resolve(srcFile.relativeTo(source))
+                    destFile.parentFile?.mkdirs()
+                    srcFile.copyTo(destFile, overwrite = true)
+                    onProgress(index + 1, total)
+                }
+
+                if (verifyMigration(source, dest)) {
+                    // The copied Dolphin.ini still has path/URI values pointing at the old
+                    // location — rewrite anything that resolves under the new user directory.
+                    patchStalePaths(context, source)
+
+                    // For Internal/SD Card we own the dolphin-emu folder entirely — delete it.
+                    // For Scoped, Android manages the directory itself so only empty it.
+                    if (prevMode == USER_DIR_MODE_INTERNAL || prevMode == USER_DIR_MODE_SDCARD) {
+                        source.deleteRecursively()
+                    } else {
+                        source.listFiles()?.forEach { it.deleteRecursively() }
+                    }
+                    onComplete(MigrationResult.SUCCESS)
+                } else {
+                    Log.error("[DirectoryInitialization] Migration verification failed — source kept")
+                    onComplete(MigrationResult.FAILED)
+                }
+            } catch (e: Exception) {
+                Log.error("[DirectoryInitialization] Migration failed: ${e.message}")
+                onComplete(MigrationResult.FAILED)
+            }
+        }
+    }
+
+    private fun verifyMigration(source: File, dest: File): Boolean {
+        source.walk().filter { it.isFile }.forEach { srcFile ->
+            val destFile = dest.resolve(srcFile.relativeTo(source))
+            if (!destFile.exists() || destFile.length() != srcFile.length()) return false
+        }
+        return true
+    }
+
+    // Dolphin.ini keys that store filesystem paths and can end up stale after a storage
+    // location change — either copied verbatim (clean migration) or already present in a
+    // pre-existing folder the user chose to keep. ISOPath0, ISOPath1, ... are handled separately
+    // since they're a numbered array rather than a fixed key.
+    private val TRACKED_STRING_PATHS = mapOf(
+        "Core" to setOf("DefaultISO"),
+        "General" to setOf(
+            "DumpPath", "LoadPath", "ResourcePackPath", "NANDRootPath",
+            "WiiSDCardPath", "WiiSDCardSyncFolder", "WFSPath"
+        ),
+        "GBA" to setOf("BIOS", "GBPlayerRom", "SavesPath")
+    )
+    private val ISO_PATH_KEY = Regex("ISOPath\\d+")
+
+    /**
+     * Copies the analytics prompt's answer (and choice) from the previous user directory's
+     * Dolphin.ini into the new, still-empty one, so the prompt doesn't reappear on every
+     * storage location change while waiting for the real migration copy to run.
+     */
+    private fun seedFirstRunFlagsFromSource(source: File) {
+        val sourceIni = File(source, "Config" + File.separator + "Dolphin.ini")
+        if (!sourceIni.exists()) return
+
+        var permissionAsked = false
+        var analyticsEnabled = "False"
+        var inAnalyticsSection = false
+
+        try {
+            sourceIni.forEachLine { rawLine ->
+                val trimmed = rawLine.trim()
+                if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+                    inAnalyticsSection = trimmed == "[Analytics]"
+                    return@forEachLine
+                }
+                if (!inAnalyticsSection) return@forEachLine
+
+                val eq = rawLine.indexOf('=')
+                if (eq == -1) return@forEachLine
+                when (rawLine.substring(0, eq).trim()) {
+                    "PermissionAsked" -> permissionAsked = rawLine.substring(eq + 1).trim() == "True"
+                    "Enabled" -> analyticsEnabled = rawLine.substring(eq + 1).trim()
+                }
+            }
+        } catch (e: IOException) {
+            Log.error("[DirectoryInitialization] Failed to read source Dolphin.ini for seeding: ${e.message}")
+            return
         }
 
-        if (Environment.getExternalStorageState() != Environment.MEDIA_MOUNTED) {
-            return null
+        if (!permissionAsked) return
+
+        val destIni = File(userPath, "Config" + File.separator + "Dolphin.ini")
+        if (destIni.exists()) return // Don't clobber anything already scaffolded here
+
+        try {
+            destIni.parentFile?.mkdirs()
+            destIni.writeText("[Analytics]\nPermissionAsked = True\nEnabled = $analyticsEnabled\n")
+        } catch (e: IOException) {
+            Log.error("[DirectoryInitialization] Failed to seed first-run flags: ${e.message}")
+        }
+    }
+
+    /**
+     * Rewrites path-like settings in Dolphin.ini that still point at [sourceRoot] (the previous
+     * user directory) so they resolve under the current [userPath] instead. Values that don't
+     * fall under [sourceRoot] are left untouched, since they were deliberately pointed elsewhere.
+     */
+    private fun patchStalePaths(context: Context, sourceRoot: File) {
+        val iniFile = File(userPath, "Config" + File.separator + "Dolphin.ini")
+        if (!iniFile.exists()) return
+
+        val sourceRootAbs = sourceRoot.absolutePath
+        val sourceRootRelative = relativeToVolumeRoot(context, sourceRoot)
+
+        val lines = try {
+            iniFile.readLines()
+        } catch (e: IOException) {
+            Log.error("[DirectoryInitialization] Failed to read Dolphin.ini for path fixup: ${e.message}")
+            return
         }
 
-        usingLegacyUserDirectory =
-            preferLegacyUserDirectory(context) && PermissionsHandler.hasWriteAccess(context)
+        var currentSection = ""
+        var changed = false
 
-        return if (usingLegacyUserDirectory) {
-            getLegacyUserDirectoryPath()
+        val newLines = lines.map { line ->
+            val trimmed = line.trim()
+            if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+                currentSection = trimmed.substring(1, trimmed.length - 1)
+                return@map line
+            }
+
+            val eq = line.indexOf('=')
+            if (eq == -1) return@map line
+
+            val key = line.substring(0, eq).trim()
+            val value = line.substring(eq + 1).trim()
+            if (value.isEmpty()) return@map line
+
+            val isTracked = (currentSection == "General" && ISO_PATH_KEY.matches(key)) ||
+                TRACKED_STRING_PATHS[currentSection]?.contains(key) == true
+            if (!isTracked) return@map line
+
+            val rewritten = rewriteStalePath(value, sourceRootAbs, sourceRootRelative) ?: return@map line
+            changed = true
+            "$key = $rewritten"
+        }
+
+        if (changed) {
+            try {
+                iniFile.writeText(newLines.joinToString("\n") + "\n")
+            } catch (e: IOException) {
+                Log.error("[DirectoryInitialization] Failed to rewrite stale paths: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Returns [dir]'s path relative to the shared-storage volume it lives on (primary internal
+     * storage or a removable SD card), so it can be compared against a SAF document ID's
+     * volume-relative path. Returns null if [dir] isn't under a recognized volume.
+     */
+    private fun relativeToVolumeRoot(context: Context, dir: File): String? {
+        val sdRoot = getSdCardRoot(context)
+        val externalRoot = Environment.getExternalStorageDirectory()
+
+        val volumeRoot = when {
+            sdRoot != null && dir.absolutePath.startsWith(sdRoot.absolutePath + File.separator) -> sdRoot
+            dir.absolutePath.startsWith(externalRoot.absolutePath + File.separator) -> externalRoot
+            else -> return null
+        }
+
+        return dir.absolutePath.removePrefix(volumeRoot.absolutePath + File.separator)
+    }
+
+    private fun rewriteStalePath(value: String, sourceRootAbs: String, sourceRootRelative: String?): String? {
+        val suffix = if (ContentHandler.isContentUri(value)) {
+            if (sourceRootRelative == null) return null
+
+            val uri = try {
+                Uri.parse(value)
+            } catch (e: Exception) {
+                return null
+            }
+            if (uri.authority != "com.android.externalstorage.documents") return null
+
+            val documentId = try {
+                DocumentsContract.getDocumentId(uri)
+            } catch (e: Exception) {
+                try {
+                    DocumentsContract.getTreeDocumentId(uri)
+                } catch (e2: Exception) {
+                    null
+                }
+            } ?: return null
+
+            val colonIndex = documentId.indexOf(':')
+            if (colonIndex == -1) return null
+            val relativePath = documentId.substring(colonIndex + 1)
+
+            when {
+                relativePath == sourceRootRelative -> ""
+                relativePath.startsWith("$sourceRootRelative/") ->
+                    relativePath.removePrefix("$sourceRootRelative/")
+                else -> return null
+            }
         } else {
-            context.getExternalFilesDir(null)
+            when {
+                value == sourceRootAbs -> ""
+                value.startsWith(sourceRootAbs + File.separator) ->
+                    value.removePrefix(sourceRootAbs + File.separator)
+                else -> return null
+            }
+        }
+
+        val newFile = if (suffix.isEmpty()) File(userPath) else File(userPath, suffix)
+        return if (newFile.exists()) newFile.absolutePath else null
+    }
+
+    private fun hasLegacyStorageAccess(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Environment.isExternalStorageManager()
+        } else {
+            PermissionsHandler.hasWriteAccess(context)
+        }
+    }
+
+    private fun getSdCardRoot(context: Context): File? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val sm = context.getSystemService(StorageManager::class.java)
+            return sm.storageVolumes
+                .firstOrNull { it.isRemovable && it.state == Environment.MEDIA_MOUNTED }
+                ?.directory
+        }
+        // Pre-R: strip Android/data/<pkg>/files (4 levels) from the scoped SD card path
+        val dirs = ContextCompat.getExternalFilesDirs(context, null)
+        var sdScoped = dirs.getOrNull(1) ?: return null
+        repeat(4) { sdScoped = sdScoped.parentFile ?: return null }
+        return sdScoped
+    }
+
+    private fun isVolumeMounted(root: File): Boolean {
+        return try {
+            Environment.getExternalStorageState(root) == Environment.MEDIA_MOUNTED
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    @JvmStatic
+    fun getUserDirectoryPath(context: Context?): File? {
+        if (context == null) return null
+        if (Environment.getExternalStorageState() != Environment.MEDIA_MOUNTED) return null
+
+        return when (getStorageMode(context)) {
+            USER_DIR_MODE_INTERNAL -> {
+                if (hasLegacyStorageAccess(context)) {
+                    usingLegacyUserDirectory = true
+                    getLegacyUserDirectoryPath()
+                } else {
+                    usingLegacyUserDirectory = false
+                    context.getExternalFilesDir(null)
+                }
+            }
+            USER_DIR_MODE_SDCARD -> {
+                val sdRoot = getSdCardRoot(context)
+                if (sdRoot != null && hasLegacyStorageAccess(context)) {
+                    usingLegacyUserDirectory = true
+                    File(sdRoot, "dolphin-emu")
+                } else {
+                    usingLegacyUserDirectory = false
+                    context.getExternalFilesDir(null)
+                }
+            }
+            else -> { // USER_DIR_MODE_SCOPED
+                usingLegacyUserDirectory = false
+                context.getExternalFilesDir(null)
+            }
         }
     }
 
@@ -296,33 +734,6 @@ object DirectoryInitialization {
         )
     }
 
-    private fun isExternalFilesDirEmpty(context: Context): Boolean {
-        val dir =
-            context.getExternalFilesDir(null) ?: return false // External storage not available
-        val contents = dir.listFiles()
-        return contents == null || contents.isEmpty()
-    }
-
-    private fun legacyUserDirectoryExists(): Boolean {
-        return try {
-            getLegacyUserDirectoryPath()?.exists() == true
-        } catch (_: SecurityException) {
-            // Most likely we don't have permission to read external storage.
-            // Return true so that external storage permissions will be requested.
-            //
-            // Strangely, we don't seem to trigger this case in practice, even with no
-            // permissions... But this only makes things more convenient for users, so no harm
-            // done.
-            true
-        }
-    }
-
-    private fun preferLegacyUserDirectory(context: Context): Boolean {
-        return PermissionsHandler.isExternalStorageLegacy() && !PermissionsHandler.isWritePermissionDenied() && isExternalFilesDirEmpty(
-            context
-        ) && legacyUserDirectoryExists()
-    }
-
     @JvmStatic
     fun isUsingLegacyUserDirectory(): Boolean {
         return usingLegacyUserDirectory
@@ -335,7 +746,12 @@ object DirectoryInitialization {
             return false
         }
 
-        return preferLegacyUserDirectory(context) && !PermissionsHandler.hasWriteAccess(context)
+        val mode = getStorageMode(context)
+        if (mode == USER_DIR_MODE_SCOPED) return false
+
+        // On Android 11+, MANAGE_EXTERNAL_STORAGE is resolved at launch; we don't block here.
+        // On older Android, block until WRITE_EXTERNAL_STORAGE is granted.
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.R && !PermissionsHandler.hasWriteAccess(context)
     }
 
     private fun checkThemeSettings(context: Context) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PermissionsHandler.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PermissionsHandler.kt
@@ -45,6 +45,11 @@ object PermissionsHandler {
     }
 
     @JvmStatic
+    fun hasManageExternalStoragePermission(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager()
+    }
+
+    @JvmStatic
     fun setWritePermissionDenied() {
         writePermissionDenied = true
     }

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -759,4 +759,24 @@
         <item>1</item>
         <item>2</item>
     </integer-array>
+
+    <string-array name="userDataStorageEntries">
+        <item>Scoped Storage (default)</item>
+        <item>Internal Storage (/sdcard/dolphin-emu)</item>
+        <item>SD Card (/storage/&lt;card&gt;/dolphin-emu)</item>
+    </string-array>
+    <integer-array name="userDataStorageValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
+
+    <string-array name="userDataStorageEntriesNoSd">
+        <item>Scoped Storage (default)</item>
+        <item>Internal Storage (/sdcard/dolphin-emu)</item>
+    </string-array>
+    <integer-array name="userDataStorageValuesNoSd">
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
 </resources>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -70,6 +70,31 @@
 
     <!-- General Preference Fragment -->
     <string name="general_submenu">General</string>
+    <string name="user_data_storage">User Data Storage Location</string>
+    <string name="user_data_storage_description">Where Dolphin stores saves, settings, and other user data. Internal/SD Card requires restarting Dolphin to take effect. On Android 11+, \"All files access\" permission must be granted.</string>
+    <string name="storage_restart_title">Restart Required</string>
+    <string name="storage_restart_message">Dolphin needs to restart to apply the new storage location.</string>
+    <string name="storage_restart_button">Restart Now</string>
+    <string name="storage_permission_title">All Files Access Required</string>
+    <string name="storage_permission_needed">You have selected Internal Storage or SD Card for user data. Android 11 and above requires the \"All files access\" permission to write to this location. Dolphin will use Scoped Storage until the permission is granted.</string>
+    <string name="storage_permission_grant">Grant Permission</string>
+    <string name="storage_permission_use_scoped">Use Scoped Storage</string>
+    <string name="migrate_user_data_title">Copy Existing User Data?</string>
+    <string name="migrate_user_data_message">Dolphin found existing user data in your previous storage location. Would you like to copy it to the new location? Files will be deleted from the old location once they are verified. This may take a moment.</string>
+    <string name="migrate_user_data_yes">Copy</string>
+    <string name="migrate_user_data_no">No Thanks</string>
+    <string name="migrate_user_data_in_progress">Copying User Data…</string>
+    <string name="migrate_user_data_progress">Preparing…</string>
+    <string name="migrate_user_data_progress_file">File %1$d of %2$d</string>
+    <string name="migrate_conflict_title">Files Already Exist</string>
+    <string name="migrate_conflict_message">The dolphin-emu folder at the new location already contains data. Replacing will delete all existing files there, then copy your files from the previous location. This cannot be undone.</string>
+    <string name="migrate_conflict_replace">Replace</string>
+    <string name="migrate_conflict_keep">Keep Existing</string>
+    <string name="migrate_user_data_success_title">Migration Complete</string>
+    <string name="migrate_user_data_success_message">Your data has been copied and verified. Dolphin needs to restart to load your settings from the new location.</string>
+    <string name="migrate_user_data_failed">Migration failed or verification failed. Files have been kept in the original location.</string>
+    <string name="migrate_user_data_failed_space">Not enough free space at the destination to copy your data. Free up space and try again. Files have been kept in the original location.</string>
+    <string name="migrate_user_data_failed_sdcard">SD card is not available. Reconnect it and try again. Files have been kept in the original location.</string>
     <string name="dual_core">Dual Core (speedhack)</string>
     <string name="dual_core_description">Split workload to two CPU cores instead of one. Increases speed.</string>
     <string name="enable_cheats">Enable Cheats</string>


### PR DESCRIPTION
Lots of devices unable to access scoped storage, especially on the Android handheld side - makes it difficult for using things like Syncthing, adding HD texture packs, using custom saves and really anything with scoped storage.

This adds a settings toggle in Settings > Config > General > User Data Storage Location for the user to choose Scoped Storage which is default, Internal Storage (creates a folder called dolphin-emu on internal) or their SD card (created a folder called dolphin-emu on SD card).

Making the switch requires All Files Access, and forces a restart when given.

Changing locations offers the ability to migrate data (in all directions) with a progress bar and copies file by file then removes the old data (if the user chooses to). If the user chooses a location with the dolphin-emu folder already, they can replace or keep existing (great for sharing between devices).

There's also checks for free space, writable destination and if the SD card is mounted. Paths are rewritten to resolve under the new location since some paths were still referencing the old.

Testing performed:

- from scratch, install dolphin, change settings, configure, add game folders, change data locations
- add hd texture packs, large ones, make sure they copy over correctly
- use existing dolphin-emu folder data when choosing location to ensure app picks them up
- booted up games, make sure states/saves are still recognized and working etc.

Note: This was developed with the help of Claude. I've reviewed and tested the code personally, but it was Claude-assisted. 