### PR TITLE
Android: Make vibration length variable

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/ControllerInterface.kt
@@ -186,7 +186,7 @@ object ControllerInterface {
     private fun vibrate(vibrator: Vibrator) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             vibrator.vibrate(
-                VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE),
+                VibrationEffect.createOneShot(10000, VibrationEffect.DEFAULT_AMPLITUDE),
                 VibrationAttributes.Builder().setUsage(VibrationAttributes.USAGE_MEDIA).build()
             )
         } else {
@@ -194,14 +194,20 @@ object ControllerInterface {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 @Suppress("DEPRECATION")
                 vibrator.vibrate(
-                    VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE),
+                    VibrationEffect.createOneShot(10000, VibrationEffect.DEFAULT_AMPLITUDE),
                     attributes
                 )
             } else {
                 @Suppress("DEPRECATION")
-                vibrator.vibrate(100, attributes)
+                vibrator.vibrate(10000, attributes)
             }
         }
+    }
+
+    @Keep
+    @JvmStatic
+    private fun cancelVibration(vibrator: Vibrator) {
+        vibrator.cancel()
     }
 
     private class InputDeviceListener : InputManager.InputDeviceListener {

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -252,9 +252,7 @@ bool Init(Core::System& system, std::unique_ptr<BootParameters> boot, const Wind
 
 static void ResetRumble()
 {
-#if defined(__LIBUSB__)
   GCAdapter::ResetRumble();
-#endif
   if (!Pad::IsInitialized())
     return;
   for (int i = 0; i < 4; ++i)

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -69,6 +69,7 @@ jmethodID s_controller_interface_unregister_input_device_listener;
 jmethodID s_controller_interface_get_vibrator_manager;
 jmethodID s_controller_interface_get_system_vibrator_manager;
 jmethodID s_controller_interface_vibrate;
+jmethodID s_controller_interface_cancel_vibration;
 
 jclass s_sensor_event_listener_class;
 jmethodID s_sensor_event_listener_constructor;
@@ -602,6 +603,11 @@ public:
       IDCache::GetEnvForThread()->CallStaticVoidMethod(s_controller_interface_class,
                                                        s_controller_interface_vibrate, m_vibrator);
     }
+    else if (old_state >= 0.5 && state < 0.5)
+    {
+      IDCache::GetEnvForThread()->CallStaticVoidMethod(
+          s_controller_interface_class, s_controller_interface_cancel_vibration, m_vibrator);
+    }
   }
 
 private:
@@ -892,6 +898,8 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
       "()Lorg/dolphinemu/dolphinemu/features/input/model/DolphinVibratorManager;");
   s_controller_interface_vibrate =
       env->GetStaticMethodID(s_controller_interface_class, "vibrate", "(Landroid/os/Vibrator;)V");
+  s_controller_interface_cancel_vibration = env->GetStaticMethodID(
+      s_controller_interface_class, "cancelVibration", "(Landroid/os/Vibrator;)V");
   env->DeleteLocalRef(controller_interface_class);
 
   const jclass sensor_event_listener_class =


### PR DESCRIPTION
Previously we would vibrate for 100 ms on every vibration, which was especially annoying if a game was doing a bunch of vibrations that were supposed to be much shorter than that. Now we tell Android to vibrate for 10 s, then cancel the vibration as soon as the game turns the vibration off.