### PR TITLE
Android: Set refresh rate to match the game

### DIFF
--- a/Source/Android/app/proguard-rules.pro
+++ b/Source/Android/app/proguard-rules.pro
@@ -13,7 +13,10 @@
 -dontwarn org.openjsse.javax.net.ssl.SSLSocket
 -dontwarn org.openjsse.net.ssl.OpenJSSE
 
-# This is referenced in JNI_OnLoad.
--keep class androidx.core.util.Pair {
+# These are referenced in JNI_OnLoad.
+-keep,allowoptimization class androidx.core.util.Pair {
     <init>(java.lang.Object, java.lang.Object);
+}
+-keep,allowoptimization interface androidx.lifecycle.Observer {
+    public void onChanged(...);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
@@ -4,8 +4,10 @@ package org.dolphinemu.dolphinemu.fragments
 
 import android.content.Context
 import android.graphics.Rect
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.View
 import android.view.ViewGroup
@@ -21,7 +23,9 @@ import org.dolphinemu.dolphinemu.activities.EmulationActivity
 import org.dolphinemu.dolphinemu.databinding.FragmentEmulationBinding
 import org.dolphinemu.dolphinemu.features.netplay.NetplayManager
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
+import org.dolphinemu.dolphinemu.features.settings.model.FloatSetting
 import org.dolphinemu.dolphinemu.features.settings.model.Settings
+import org.dolphinemu.dolphinemu.model.VideoInterface
 import org.dolphinemu.dolphinemu.overlay.InputOverlay
 import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner
 import org.dolphinemu.dolphinemu.utils.Log
@@ -29,6 +33,7 @@ import java.io.File
 
 class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     private var inputOverlay: InputOverlay? = null
+    private var surface: Surface? = null
 
     private var gamePaths: Array<String>? = null
     private var riivolution = false
@@ -60,6 +65,9 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
             gamePaths = getStringArray(KEY_GAMEPATHS)
             riivolution = getBoolean(KEY_RIIVOLUTION)
             launchSystemMenu = getBoolean(KEY_SYSTEM_MENU)
+        }
+        VideoInterface.observeTargetRefreshRate(this) {
+            frameRate -> activity?.runOnUiThread { setRefreshRate(surface, frameRate) }
         }
     }
 
@@ -153,6 +161,8 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
 
     override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
         Log.debug("[EmulationFragment] Surface changed. Resolution: $width x $height")
+        surface = holder.surface
+        setRefreshRate(holder.surface, VideoInterface.getTargetRefreshRate())
         NativeLibrary.SurfaceChanged(holder.surface)
         if (runWhenSurfaceIsValid) {
             runWithValidSurface()
@@ -162,6 +172,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     override fun surfaceDestroyed(holder: SurfaceHolder) {
         Log.debug("[EmulationFragment] Surface destroyed.")
         NativeLibrary.SurfaceDestroyed()
+        surface = null
         runWhenSurfaceIsValid = true
     }
 
@@ -258,6 +269,32 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
                 Log.debug("[EmulationFragment] Resuming emulation.")
                 NativeLibrary.UnPauseEmulation()
             }
+        }
+    }
+
+    private fun setRefreshRate(surface: Surface?, refreshRate: Double) {
+        if (surface == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return
+        }
+
+        // Adjust for emulation speed. The special case of 0.0 emulation speed meaning unlimited
+        // works out nicely without any special handling, since a number multiplied by 0.0 is 0.0
+        // and Surface.setFrameRate treats 0.0 as us not requesting any particular frame rate.
+        val adjustedRefreshRate = refreshRate * FloatSetting.MAIN_EMULATION_SPEED.float
+
+        Log.info("Requesting refresh rate $adjustedRefreshRate")
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            surface.setFrameRate(
+                adjustedRefreshRate.toFloat(),
+                Surface.FRAME_RATE_COMPATIBILITY_FIXED_SOURCE,
+                Surface.CHANGE_FRAME_RATE_ALWAYS
+            )
+        } else {
+            surface.setFrameRate(
+                adjustedRefreshRate.toFloat(),
+                Surface.FRAME_RATE_COMPATIBILITY_FIXED_SOURCE
+            )
         }
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/VideoInterface.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/VideoInterface.kt
@@ -1,0 +1,15 @@
+package org.dolphinemu.dolphinemu.model
+
+import androidx.annotation.Keep
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Observer
+
+object VideoInterface {
+    @Keep
+    @JvmStatic
+    external fun getTargetRefreshRate(): Double
+
+    @Keep
+    @JvmStatic
+    external fun observeTargetRefreshRate(owner: LifecycleOwner, observer: Observer<Double>)
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/EventHookLifecycleObserver.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/EventHookLifecycleObserver.kt
@@ -1,0 +1,30 @@
+package org.dolphinemu.dolphinemu.utils
+
+import androidx.annotation.Keep
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+
+@Keep
+class EventHookLifecycleObserver(lifecycleOwner: LifecycleOwner, private var eventHookPointer: Long,
+                                 private var globalReference: Long) {
+    init {
+        lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onDestroy(owner: LifecycleOwner) {
+                if (eventHookPointer == 0L) {
+                    throw IllegalStateException("Attempted to delete null EventHook")
+                }
+                deleteEventHook(eventHookPointer)
+                eventHookPointer = 0
+
+                if (globalReference != 0L) {
+                    deleteGlobalReference(globalReference)
+                    globalReference = 0
+                }
+            }
+        })
+    }
+
+    private external fun deleteEventHook(pointer: Long)
+
+    private external fun deleteGlobalReference(pointer: Long)
+}

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -151,6 +151,15 @@ static jclass s_audio_utils_class;
 static jmethodID s_audio_utils_get_sample_rate;
 static jmethodID s_audio_utils_get_frames_per_buffer;
 
+static jclass s_observer_class;
+static jmethodID s_observer_on_changed;
+
+static jclass s_event_hook_lifecycle_observer_class;
+static jmethodID s_event_hook_lifecycle_observer_constructor;
+
+static jclass s_double_class;
+static jmethodID s_double_constructor;
+
 namespace IDCache
 {
 JNIEnv* GetEnvForThread()
@@ -721,6 +730,36 @@ jmethodID GetAudioUtilsGetFramesPerBuffer()
   return s_audio_utils_get_frames_per_buffer;
 }
 
+jclass GetObserverClass()
+{
+  return s_observer_class;
+}
+
+jmethodID GetObserverOnChanged()
+{
+  return s_observer_on_changed;
+}
+
+jclass GetEventHookLifecycleObserverClass()
+{
+  return s_event_hook_lifecycle_observer_class;
+}
+
+jmethodID GetEventHookLifecycleObserverConstructor()
+{
+  return s_event_hook_lifecycle_observer_constructor;
+}
+
+jclass GetDoubleClass()
+{
+  return s_double_class;
+}
+
+jmethodID GetDoubleConstructor()
+{
+  return s_double_constructor;
+}
+
 }  // namespace IDCache
 
 extern "C" {
@@ -1015,6 +1054,24 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
       env->GetStaticMethodID(audio_utils_class, "getFramesPerBuffer", "()I");
   env->DeleteLocalRef(audio_utils_class);
 
+  const jclass observer_class = env->FindClass("androidx/lifecycle/Observer");
+  s_observer_class = reinterpret_cast<jclass>(env->NewGlobalRef(observer_class));
+  s_observer_on_changed = env->GetMethodID(observer_class, "onChanged", "(Ljava/lang/Object;)V");
+  env->DeleteLocalRef(observer_class);
+
+  const jclass event_hook_lifecycle_observer_class =
+      env->FindClass("org/dolphinemu/dolphinemu/utils/EventHookLifecycleObserver");
+  s_event_hook_lifecycle_observer_class =
+      reinterpret_cast<jclass>(env->NewGlobalRef(event_hook_lifecycle_observer_class));
+  s_event_hook_lifecycle_observer_constructor = env->GetMethodID(
+      event_hook_lifecycle_observer_class, "<init>", "(Landroidx/lifecycle/LifecycleOwner;JJ)V");
+  env->DeleteLocalRef(event_hook_lifecycle_observer_class);
+
+  const jclass double_class = env->FindClass("java/lang/Double");
+  s_double_class = reinterpret_cast<jclass>(env->NewGlobalRef(double_class));
+  s_double_constructor = env->GetMethodID(double_class, "<init>", "(D)V");
+  env->DeleteLocalRef(double_class);
+
   return JNI_VERSION;
 }
 
@@ -1054,5 +1111,8 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved)
   env->DeleteGlobalRef(s_input_detector_class);
   env->DeleteGlobalRef(s_permission_handler_class);
   env->DeleteGlobalRef(s_audio_utils_class);
+  env->DeleteGlobalRef(s_observer_class);
+  env->DeleteGlobalRef(s_event_hook_lifecycle_observer_class);
+  env->DeleteGlobalRef(s_double_class);
 }
 }

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -150,4 +150,13 @@ jclass GetAudioUtilsClass();
 jmethodID GetAudioUtilsGetSampleRate();
 jmethodID GetAudioUtilsGetFramesPerBuffer();
 
+jclass GetObserverClass();
+jmethodID GetObserverOnChanged();
+
+jclass GetEventHookLifecycleObserverClass();
+jmethodID GetEventHookLifecycleObserverConstructor();
+
+jclass GetDoubleClass();
+jmethodID GetDoubleConstructor();
+
 }  // namespace IDCache

--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(main SHARED
   Config/ConfigChangedCallback.cpp
   Config/NativeConfig.cpp
   Config/PostProcessing.cpp
+  EventHook.cpp
+  EventHook.h
   GameList/GameFile.cpp
   GameList/GameFile.h
   GameList/GameFileCache.cpp
@@ -36,6 +38,7 @@ add_library(main SHARED
   MainAndroid.cpp
   RiivolutionPatches.cpp
   SkylanderConfig.cpp
+  VideoInterface.cpp
   WiiUtils.cpp
 )
 

--- a/Source/Android/jni/EventHook.cpp
+++ b/Source/Android/jni/EventHook.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "jni/EventHook.h"
+
+#include <jni.h>
+
+#include "Common/HookableEvent.h"
+#include "jni/AndroidCommon/IDCache.h"
+
+void ConnectEventHookToLifecycle(JNIEnv* env, Common::EventHook&& event_hook,
+                                 jobject lifecycle_owner, jobject global_reference)
+{
+  env->NewObject(IDCache::GetEventHookLifecycleObserverClass(),
+                 IDCache::GetEventHookLifecycleObserverConstructor(), lifecycle_owner,
+                 reinterpret_cast<jlong>(event_hook.release()),
+                 reinterpret_cast<jlong>(global_reference));
+}
+
+extern "C" {
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_utils_EventHookLifecycleObserver_deleteEventHook(JNIEnv* env,
+                                                                                jobject,
+                                                                                jlong pointer)
+{
+  delete reinterpret_cast<Common::HookBase*>(pointer);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_utils_EventHookLifecycleObserver_deleteGlobalReference(JNIEnv* env,
+                                                                                      jobject,
+                                                                                      jlong pointer)
+{
+  env->DeleteGlobalRef(reinterpret_cast<jobject>(pointer));
+}
+}

--- a/Source/Android/jni/EventHook.h
+++ b/Source/Android/jni/EventHook.h
@@ -1,0 +1,16 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <jni.h>
+
+#include "Common/HookableEvent.h"
+
+// Takes ownership of an EventHook and makes sure it gets destroyed when the lifecycle enters the
+// destroy state.
+//
+// global_reference is optional and can be set to any JNI global reference. If it's set,
+// DeleteGlobalRef will be called for it when the lifecycle enters the destroy state.
+void ConnectEventHookToLifecycle(JNIEnv* env, Common::EventHook&& event_hook,
+                                 jobject lifecycle_owner, jobject global_reference = nullptr);

--- a/Source/Android/jni/VideoInterface.cpp
+++ b/Source/Android/jni/VideoInterface.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <utility>
+
+#include <jni.h>
+
+#include "Core/HW/VideoInterface.h"
+#include "Core/System.h"
+#include "jni/AndroidCommon/IDCache.h"
+#include "jni/EventHook.h"
+
+extern "C" {
+
+JNIEXPORT jdouble JNICALL
+Java_org_dolphinemu_dolphinemu_model_VideoInterface_getTargetRefreshRate(JNIEnv* env, jclass)
+{
+  return Core::System::GetInstance().GetVideoInterface().GetTargetRefreshRate();
+}
+
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_model_VideoInterface_observeTargetRefreshRate(
+    JNIEnv* env, jclass, jobject owner, jobject observer)
+{
+  jobject global_observer = env->NewGlobalRef(observer);
+
+  auto& video_interface = Core::System::GetInstance().GetVideoInterface();
+  Common::EventHook event_hook = video_interface.RegisterTargetRefreshRateChangedCallback(
+      [global_observer](double refresh_rate) {
+        JNIEnv* env = IDCache::GetEnvForThread();
+        jobject boxed_refresh_rate = env->NewObject(IDCache::GetDoubleClass(),
+                                                    IDCache::GetDoubleConstructor(), refresh_rate);
+        env->CallVoidMethod(global_observer, IDCache::GetObserverOnChanged(), boxed_refresh_rate);
+      });
+
+  ConnectEventHookToLifecycle(env, std::move(event_hook), owner, global_observer);
+}
+}

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -77,6 +77,7 @@ void Shutdown(Core::System& system)
   system.GetHSP().Shutdown();
   system.GetExpansionInterface().Shutdown();
   system.GetSerialInterface().Shutdown();
+  system.GetVideoInterface().Shutdown();
   system.GetAudioInterface().Shutdown();
 
   State::Shutdown();

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -43,10 +43,7 @@ VideoInterfaceManager::VideoInterfaceManager(Core::System& system) : m_system(sy
 {
 }
 
-VideoInterfaceManager::~VideoInterfaceManager()
-{
-  Config::RemoveConfigChangedCallback(m_config_changed_callback_id);
-}
+VideoInterfaceManager::~VideoInterfaceManager() = default;
 
 static constexpr std::array<u32, 2> CLOCK_FREQUENCIES{{
     27000000,
@@ -183,6 +180,16 @@ void VideoInterfaceManager::Init()
 
   m_config_changed_callback_id = Config::AddConfigChangedCallback([this] { RefreshConfig(); });
   RefreshConfig();
+}
+
+void VideoInterfaceManager::Shutdown()
+{
+  Config::RemoveConfigChangedCallback(m_config_changed_callback_id);
+
+  m_target_refresh_rate_numerator = 0;
+  m_target_refresh_rate_denominator = 1;
+  m_target_refresh_rate = 0;
+  m_target_refresh_rate_changed_event.Trigger(0);
 }
 
 void VideoInterfaceManager::RefreshConfig()
@@ -738,8 +745,14 @@ void VideoInterfaceManager::UpdateRefreshRate()
 {
   m_target_refresh_rate_numerator = m_system.GetSystemTimers().GetTicksPerSecond() * 2;
   m_target_refresh_rate_denominator = GetTicksPerEvenField() + GetTicksPerOddField();
-  m_target_refresh_rate =
+
+  const double target_refresh_rate =
       static_cast<double>(m_target_refresh_rate_numerator) / m_target_refresh_rate_denominator;
+  if (m_target_refresh_rate != target_refresh_rate)
+  {
+    m_target_refresh_rate = target_refresh_rate;
+    m_target_refresh_rate_changed_event.Trigger(target_refresh_rate);
+  }
 }
 
 double VideoInterfaceManager::GetTargetRefreshRate() const
@@ -755,6 +768,12 @@ u32 VideoInterfaceManager::GetTargetRefreshRateNumerator() const
 u32 VideoInterfaceManager::GetTargetRefreshRateDenominator() const
 {
   return m_target_refresh_rate_denominator;
+}
+
+[[nodiscard]] Common::EventHook VideoInterfaceManager::RegisterTargetRefreshRateChangedCallback(
+    std::function<void(double)> callback)
+{
+  return m_target_refresh_rate_changed_event.Register(std::move(callback));
 }
 
 u32 VideoInterfaceManager::GetTicksPerSample() const

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -8,6 +8,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
+#include "Common/HookableEvent.h"
 
 enum class FieldType;
 class PointerWrap;
@@ -364,6 +365,7 @@ public:
   void Preset(bool _bNTSC);
 
   void Init();
+  void Shutdown();
   void DoState(PointerWrap& p);
 
   void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
@@ -384,6 +386,9 @@ public:
   double GetTargetRefreshRate() const;
   u32 GetTargetRefreshRateNumerator() const;
   u32 GetTargetRefreshRateDenominator() const;
+
+  [[nodiscard]] Common::EventHook
+  RegisterTargetRefreshRateChangedCallback(std::function<void(double)> callback);
 
   u32 GetTicksPerSample() const;
   u32 GetTicksPerHalfLine() const;
@@ -455,6 +460,8 @@ private:
   u32 m_odd_field_last_hl = 0;    // index last halfline of the odd field
 
   float m_config_vi_oc_factor = 1.0f;
+
+  Common::HookableEvent<double> m_target_refresh_rate_changed_event;
 
   Config::ConfigChangedCallbackID m_config_changed_callback_id;
   Core::System& m_system;


### PR DESCRIPTION
This makes us tell Android what refresh rate we want the screen to use. This has two benefits:

1. If the screen's refresh rate is higher than 60 Hz normally, it can drop down to 60 Hz when running a game in Dolphin, saving battery. (Though at least on my phone, it goes back up again temporarily when I touch the screen.)
2. If the screen's refresh rate normally isn't an integer multiple of the game's refresh rate, the screen's refresh rate can (if the device is willing) increase or decrease to something that is an integer multiple. This is most relevant for games running at 50 Hz, but I guess it's also relevant for 60 Hz games on 90/100 Hz screens.

I took a new approach with bringing the refresh rate value from C++ into Kotlin. Previously I would have done something along the lines of adding a new Host function that passes the value to EmulationActivity which in turn passes the value to EmulationFragment, but this time I decided to use EventHook and make a nice Kotlin wrapper for it. Well, it's pretty nice to use for the caller, but I had to write quite a bit of JNI and utility code that made the implementation much larger than the way I would have implemented it otherwise. But I have been thinking that this kind of functionality would be useful for future changes, and a lot of the added code is code that doesn't need duplicating if we want to observe other EventHooks in the future.