### PR TITLE
IOS/ES: allow Wii System Transfer and WagonCompat Transfer Tool to pass SetUID check

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -283,7 +283,11 @@ static ReturnCode CheckIsAllowedToSetUID(EmulationKernel& kernel, ES::UIDSys* ui
   {
     const bool is_wiiu_transfer_tool =
         active_tmd.IsValid() && (active_tmd.GetTitleId() | 0xFF) == 0x00010001'484353ff;
-    if (is_wiiu_transfer_tool)
+    const bool is_wii_system_transfer =
+        active_tmd.IsValid() && (active_tmd.GetTitleId() | 0xFF) == 0x00010001'484354ff;
+    const bool is_wagoncompat_transfer =
+        active_tmd.IsValid() && (active_tmd.GetTitleId() | 0xFF) == 0x00010008'48435aff;
+    if (is_wiiu_transfer_tool || is_wii_system_transfer || is_wagoncompat_transfer)
       return IPC_SUCCESS;
   }
 


### PR DESCRIPTION
Trying to launch either the Wii System Transfer or the hidden WagonCompat transfer tool (00010001-HCT and 00010008-HCZ respectively) would result in a permission check error (-1017). This PR changes CheckIsAllowedToSetUID and adds exceptions for both of these titles alongside the already-existing exception for the Wii U Transfer Tool.