### PR TITLE
ResourcePackManager: Fix crash when removing pack and properly update list

### DIFF
--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -3,6 +3,8 @@
 
 #include "DolphinQt/ResourcePackManager.h"
 
+#include <string>
+
 #include <QDesktopServices>
 #include <QDialogButtonBox>
 #include <QGridLayout>
@@ -243,8 +245,10 @@ void ResourcePackManager::Remove()
   if (box.exec() != QMessageBox::Yes)
     return;
 
+  const std::string selected_pack_path =
+      ResourcePack::GetPacks()[GetResourcePackIndex(items[0])].GetPath();
   Uninstall();
-  File::Delete(ResourcePack::GetPacks()[GetResourcePackIndex(items[0])].GetPath());
+  File::Delete(selected_pack_path);
   RepopulateTable();
 }
 

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -17,6 +17,7 @@
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "UICommon/ResourcePack/Manager.h"
+#include "UICommon/ResourcePack/ResourcePack.h"
 
 ResourcePackManager::ResourcePackManager(QWidget* widget) : QDialog(widget)
 {
@@ -245,9 +246,11 @@ void ResourcePackManager::Remove()
   if (box.exec() != QMessageBox::Yes)
     return;
 
-  const std::string selected_pack_path =
-      ResourcePack::GetPacks()[GetResourcePackIndex(items[0])].GetPath();
+  ResourcePack::ResourcePack& selected_pack =
+      ResourcePack::GetPacks()[GetResourcePackIndex(items[0])];
+  const std::string selected_pack_path = selected_pack.GetPath();
   Uninstall();
+  ResourcePack::Remove(selected_pack);
   File::Delete(selected_pack_path);
   RepopulateTable();
 }


### PR DESCRIPTION
Fix a use-after-free crash in `ResourcePackManager` when removing a pack.

Fixes https://bugs.dolphin-emu.org/issues/14095.

Resolving that issue revealed another one where the table still showed the deleted pack and `Packs.ini` wasn't updated accordingly. This PR fixes that too.