### PR TITLE
GameINI: Update codes to unlock Black Edition and Collector's Edition in Need for Speed (update to #14581)

### DIFF
--- a/Data/Sys/GameSettings/GOWE69.ini
+++ b/Data/Sys/GameSettings/GOWE69.ini
@@ -1,6 +1,5 @@
 # GOWE69 - Need for Speed: Most Wanted
 
 [Gecko]
-$Unlock Black Edition [Xanvier]
-C241EECC 00000001
-00000001 00000000
+$Unlock Black Edition [Ralf]
+0441EECC 00000001

--- a/Data/Sys/GameSettings/GW5E69.ini
+++ b/Data/Sys/GameSettings/GW5E69.ini
@@ -1,6 +1,5 @@
 # GW5E69 - Need for Speed: Carbon
 
-[ActionReplay]
-$Unlock Collector's Edition
-0AB3E002 18000000
+[Gecko]
+$Unlock Collector's Edition [Ralf]
 045075B8 00000001


### PR DESCRIPTION
As the title says, this PR is just a small update to https://github.com/dolphin-emu/dolphin/pull/14581. In that PR, I ported some AR codes for Most Wanted and Carbon. The AR code for Carbon worked fine, [but the one for Most Wanted didn't](https://github.com/dolphin-emu/dolphin/pull/14581#discussion_r3205556629), so I reverted it to a Gecko code I found on the internet.

Since then, I was wanting a way to keep them consistent, meaning either both should be AR codes or both should be Gecko codes, but since I don't know why the AR code for Most Wanted don't worked properly (and, unfortunately, don't have the time to investigate/learn why), I decided to simply update both to Gecko codes.

These updated codes were ported by me from PAL/GERMAN codes by Ralf, the source to the original codes can be found [here](https://web.archive.org/web/20260507212631/https://www.gc-forever.com/forums/viewtopic.php?t=3038) and [here](https://web.archive.org/web/20230427155207/https://www.gc-forever.com/forums/viewtopic.php?t=3052).

Any users with existing save files created using the old codes won't lose any progress, I did some quick tests and the saves seems to still work with the updated codes, but obviously, for the AR code that was replaced by a Gecko code, the user will need to enable the new code first.