### PR TITLE
GCAdapter: Deregister callback when scan thread exits

### DIFF
--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -473,6 +473,17 @@ static void ScanThreadFunc()
   }
 #endif
 
+#if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
+#if LIBUSB_API_HAS_HOTPLUG
+  if (s_libusb_hotplug_enabled)
+    libusb_hotplug_deregister_callback(*s_libusb_context, s_hotplug_handle);
+#endif
+#elif GCADAPTER_USE_ANDROID_IMPLEMENTATION
+  const jmethodID disable_hotplug_callback_func =
+      env->GetStaticMethodID(s_adapter_class, "disableHotplugCallback", "()V");
+  env->CallStaticVoidMethod(s_adapter_class, disable_hotplug_callback_func);
+#endif
+
   NOTICE_LOG_FMT(CONTROLLERINTERFACE, "GC Adapter scanning thread stopped");
 }
 
@@ -761,17 +772,6 @@ static void AddGCAdapter(libusb_device* device)
 void Shutdown()
 {
   StopScanThread();
-#if GCADAPTER_USE_LIBUSB_IMPLEMENTATION
-#if LIBUSB_API_HAS_HOTPLUG
-  if (s_libusb_context && s_libusb_context->IsValid() && s_libusb_hotplug_enabled)
-    libusb_hotplug_deregister_callback(*s_libusb_context, s_hotplug_handle);
-#endif
-#elif GCADAPTER_USE_ANDROID_IMPLEMENTATION
-  JNIEnv* const env = IDCache::GetEnvForThread();
-  const jmethodID disable_hotplug_callback_func =
-      env->GetStaticMethodID(s_adapter_class, "disableHotplugCallback", "()V");
-  env->CallStaticVoidMethod(s_adapter_class, disable_hotplug_callback_func);
-#endif
   Reset();
 
 #if GCADAPTER_USE_LIBUSB_IMPLEMENTATION


### PR DESCRIPTION
We were registering the hotplug callback when starting the thread, but deregistering it when shutting down GCAdapter as a whole. Because the thread can start and stop potentially many times before GCAdapter shuts down, this led to callbacks being registered when we already have callbacks. On Android, this was making Dolphin's Kotlin code for registering the callback throw an IllegalStateException.

To fix this, deregister the callback when stopping the thread.