### PR TITLE
PerformanceMetrics: Fix compiling using clang&libstdc++

### DIFF
--- a/Source/Core/VideoCommon/PerformanceMetrics.h
+++ b/Source/Core/VideoCommon/PerformanceMetrics.h
@@ -51,8 +51,10 @@ public:
 private:
   struct FrameBufferSize
   {
-    u32 width = 0;
-    u32 height = 0;
+    FrameBufferSize() : width(0), height(0) {}
+    FrameBufferSize(u32 w, u32 h) : width(w), height(h) {}
+    u32 width;
+    u32 height;
   };
 
   PerformanceTracker m_fps_counter{"render_times.txt"};


### PR DESCRIPTION
When using clang and libstdc++, compiling fails with these errors:

```
FAILED: [code=1] Source/Core/VideoCommon/CMakeFiles/videocommon.dir/PerformanceMetrics.cpp.o
/usr/sbin/ccache /usr/sbin/clang++ -DAUTOUPDATE=1 -DDATA_DIR=\"/usr/local/share/dolphin-emu/\" -DHAS_OPENGL -DHAS_VULKAN -DHAVE_CPPIPC -DHAVE_LIBSYSTEMD -DIMGUI_USER_CONFIG=\"imgui_user_config.h\" -DLZMA_API_STATIC -DOFF -DPUGIXML_NO_EXCEPTIONS -DRC_CLIENT_SUPPORTS_HASH -DSFML_STATIC -DSPNG_STATIC -DTINYGLTF_NOEXCEPTION -DTINYGLTF_NO_EXTERNAL_IMAGE -DTINYGLTF_USE_CPP14 -DUSE_ANALYTICS=1 -DUSE_MEMORYWATCHER=1 -DUSE_PIPES=1 -DUSE_RETRO_ACHIEVEMENTS -DZSTD_MULTITHREAD -D_ARCH_64=1 -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_M_X86_64=1 -D__LIBUSB__ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I/dolphin-local/Source/Core -I/dolphin-local/Externals/picojson -I/dolphin-local/build/release/x64/Source/Core -I/dolphin-local/Externals/enet/enet/include -I/dolphin-local/Externals/fmt/fmt/include -I/dolphin-local/Externals/mbedtls/include -I/dolphin-local/Externals/minizip-ng/minizip-ng -I/dolphin-local/Externals/liblzma/api -I/dolphin-local/Externals/zstd/zstd/build/cmake/../../lib -I/dolphin-local/Externals/libiconv/include -I/dolphin-local/build/release/x64/Externals/libiconv/lib -I/dolphin-local/Externals/libiconv/libcharset/include -I/dolphin-local/build/release/x64/Externals/libiconv/libcharset -I/dolphin-local/Externals/SFML/SFML/include -I/dolphin-local/Externals/bzip2/bzip2 -I/dolphin-local/Externals/expr/include -I/dolphin-local/Externals/hidapi/hidapi-src/hidapi -I/dolphin-local/Externals/pugixml/pugixml/src -I/dolphin-local/Externals/glslang/glslang/glslang/.. -I/dolphin-local/build/release/x64/include -I/dolphin-local/Externals/rcheevos -I/dolphin-local/Externals/libspng/libspng/spng -I/dolphin-local/Externals/xxhash/xxHash -I/dolphin-local/Externals/imgui -I/dolphin-local/Externals/imgui/imgui -I/dolphin-local/Externals/implot/implot -I/dolphin-local/Externals/glslang/glslang/SPIRV/.. -I/dolphin-local/Externals/tinygltf -isystem /dolphin-local/Externals/libusb/libusb/libusb -isystem /dolphin-local/Externals/glslang/glslang -isystem /dolphin-local/Externals/glslang/glslang/Public -isystem /dolphin-local/Externals/glslang -Qunused-arguments -fcolor-diagnostics -O3 -DNDEBUG -std=c++23 -msse2 -fdiagnostics-color -fno-strict-aliasing -fno-exceptions -fvisibility-inlines-hidden -fvisibility=hidden -fomit-frame-pointer -Wall -Wtype-limits -Wsign-compare -Wignored-qualifiers -Wuninitialized -Wshadow -Wshadow-field-in-constructor -Winit-self -Wmissing-declarations-Wmissing-variable-declarations -Werror=format -Wno-trigraphs -MD -MT Source/Core/VideoCommon/CMakeFiles/videocommon.dir/PerformanceMetrics.cpp.o -MF Source/Core/VideoCommon/CMakeFiles/videocommon.dir/PerformanceMetrics.cpp.o.d -o Source/Core/VideoCommon/CMakeFiles/videocommon.dir/PerformanceMetrics.cpp.o -c /dolphin-local/Source/Core/VideoCommon/PerformanceMetrics.cpp
In file included from /dolphin-local/Source/Core/VideoCommon/PerformanceMetrics.cpp:4:
/dolphin-local/Source/Core/VideoCommon/PerformanceMetrics.h:69:51: error: no matching constructor for initialization of 'std::atomic<FrameBufferSize>'
   69 |   std::atomic<FrameBufferSize> m_frame_buffer_size{};
      |                                                   ^~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16/../../../../include/c++/16/atomic:237:17: note: candidate constructor not viable: constraints not satisfied
  237 |       constexpr atomic() noexcept(is_nothrow_default_constructible_v<_Tp>)
      |                 ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16/../../../../include/c++/16/atomic:238:11: note: because 'is_default_constructible_v<PerformanceMetrics::FrameBufferSize>' evaluated to false
  238 |         requires is_default_constructible_v<_Tp>
      |                  ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16/../../../../include/c++/16/atomic:246:7: note: candidate constructor not viable: requires 1 argument, but 0 were provided
  246 |       atomic(const atomic&) = delete;
      |       ^      ~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16/../../../../include/c++/16/atomic:252:17: note: candidate constructor not viable: requires single argument '__i', but no arguments were provided
  252 |       constexpr atomic(_Tp __i) noexcept : _M_i(__i)
      |                 ^      ~~~~~~~
1 error generated.
```

This was tested and occurs on both Arch and Alpine Linux. I believe this is the relevant bug report: https://github.com/llvm/llvm-project/issues/50248