### PR TITLE
Convert To WBFS Support

### DIFF
--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -23,6 +23,11 @@
 #include "Common/CommonTypes.h"
 #include "Common/Swap.h"
 
+namespace Common::AES
+{
+class Context;
+}
+
 namespace DiscIO
 {
 enum class WIARVZCompressionType : u32;
@@ -92,7 +97,8 @@ public:
     return false;
   }
 
-  virtual bool ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr, u64 partition_data_offset)
+  virtual bool ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr, u64 partition_data_offset,
+                                Common::AES::Context* aes_context = nullptr)
   {
     return false;
   }
@@ -206,5 +212,4 @@ bool ConvertToWIAOrRVZ(BlobReader* infile, const std::string& infile_path,
                        const std::string& outfile_path, bool rvz,
                        WIARVZCompressionType compression_type, int compression_level,
                        int chunk_size, const CompressCB& callback);
-
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -212,4 +212,7 @@ bool ConvertToWIAOrRVZ(BlobReader* infile, const std::string& infile_path,
                        const std::string& outfile_path, bool rvz,
                        WIARVZCompressionType compression_type, int compression_level,
                        int chunk_size, const CompressCB& callback);
+bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
+                   const std::string& outfile_path, const CompressCB& callback);
+
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(discio
   LaggedFibonacciGenerator.cpp
   LaggedFibonacciGenerator.h
   MultithreadedCompressor.h
+  NKitHeader.cpp
+  NKitHeader.h
   NANDImporter.cpp
   NANDImporter.h
   NFSBlob.cpp
@@ -79,6 +81,7 @@ PRIVATE
   fmt::fmt
   MINIZIP::minizip-ng
   pugixml
+  xxhash::xxhash
   ZLIB::ZLIB
 )
 

--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -28,8 +28,8 @@ add_library(discio
   LaggedFibonacciGenerator.cpp
   LaggedFibonacciGenerator.h
   MultithreadedCompressor.h
-  NKitHeader.cpp
-  NKitHeader.h
+  NKitv2Header.cpp
+  NKitv2Header.h
   NANDImporter.cpp
   NANDImporter.h
   NFSBlob.cpp

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -274,7 +274,8 @@ bool ConvertToGCZ(BlobReader* infile, const std::string& infile_path,
                   const std::string& outfile_path, u32 sub_type, int block_size,
                   const CompressCB& callback)
 {
-  ASSERT(infile->GetDataSizeType() == DataSizeType::Accurate);
+  ASSERT(infile->GetDataSizeType() == DataSizeType::Accurate ||
+         infile->GetDataSizeType() == DataSizeType::UpperBound);
 
   File::DirectIOFile outfile(outfile_path, File::AccessMode::Write);
   if (!outfile.IsOpen())

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -530,7 +530,7 @@ bool DirectoryBlobReader::SupportsReadWiiDecrypted(u64 offset, u64 size,
 }
 
 bool DirectoryBlobReader::ReadWiiDecrypted(u64 offset, u64 size, u8* buffer,
-                                           u64 partition_data_offset)
+                                           u64 partition_data_offset, Common::AES::Context*)
 {
   const DirectoryBlobPartition* partition = GetPartition(offset, size, partition_data_offset);
   if (!partition)

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -257,7 +257,8 @@ public:
 
   bool Read(u64 offset, u64 length, u8* buffer) override;
   bool SupportsReadWiiDecrypted(u64 offset, u64 size, u64 partition_data_offset) const override;
-  bool ReadWiiDecrypted(u64 offset, u64 size, u8* buffer, u64 partition_data_offset) override;
+  bool ReadWiiDecrypted(u64 offset, u64 size, u8* buffer, u64 partition_data_offset,
+                        Common::AES::Context* aes_context = nullptr) override;
 
   BlobType GetBlobType() const override;
   std::unique_ptr<BlobReader> CopyReader() const override;

--- a/Source/Core/DiscIO/FileBlob.cpp
+++ b/Source/Core/DiscIO/FileBlob.cpp
@@ -41,7 +41,8 @@ bool PlainFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 bool ConvertToPlain(BlobReader* infile, const std::string& infile_path,
                     const std::string& outfile_path, const CompressCB& callback)
 {
-  ASSERT(infile->GetDataSizeType() == DataSizeType::Accurate);
+  ASSERT(infile->GetDataSizeType() == DataSizeType::Accurate ||
+         infile->GetDataSizeType() == DataSizeType::UpperBound);
 
   File::DirectIOFile outfile(outfile_path, File::AccessMode::Write);
   if (!outfile.IsOpen())

--- a/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
+++ b/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
@@ -256,7 +256,7 @@ void LaggedFibonacciGenerator::GenerateSeed(u32 seed_out[SEED_SIZE], const u8 di
 void LaggedFibonacciGenerator::FillJunkData(std::span<u8> out, u64 disc_offset, const u8 disc_id[4],
                                             u8 disc_num)
 {
-  static constexpr size_t SECTOR_SIZE = 0x8000;
+  static constexpr size_t BLOCK_SIZE = 0x8000;
   LaggedFibonacciGenerator lfg;
 
   size_t remaining = out.size();
@@ -264,9 +264,9 @@ void LaggedFibonacciGenerator::FillJunkData(std::span<u8> out, u64 disc_offset, 
 
   while (remaining > 0)
   {
-    const u32 sector = static_cast<u32>(disc_offset / SECTOR_SIZE);
-    const size_t sector_off = static_cast<size_t>(disc_offset % SECTOR_SIZE);
-    size_t chunk = std::min(SECTOR_SIZE - sector_off, remaining);
+    const u32 sector = static_cast<u32>(disc_offset / BLOCK_SIZE);
+    const size_t sector_off = static_cast<size_t>(disc_offset % BLOCK_SIZE);
+    size_t chunk = std::min(BLOCK_SIZE - sector_off, remaining);
 
     u32 seed[SEED_SIZE];
     GenerateSeed(seed, disc_id, disc_num, sector);
@@ -286,14 +286,14 @@ void LaggedFibonacciGenerator::FillJunkData(std::span<u8> out, u64 disc_offset, 
 bool LaggedFibonacciGenerator::IsJunkBlock(const u8* data, size_t size, u64 disc_offset,
                                            const u8 disc_id[4], u8 disc_num)
 {
-  static constexpr size_t SECTOR_SIZE = 0x8000;
+  static constexpr size_t BLOCK_SIZE = 0x8000;
   LaggedFibonacciGenerator lfg;
 
   while (size > 0)
   {
-    const u32 sector = static_cast<u32>(disc_offset / SECTOR_SIZE);
-    const size_t sector_off = static_cast<size_t>(disc_offset % SECTOR_SIZE);
-    const size_t chunk = std::min(SECTOR_SIZE - sector_off, size);
+    const u32 sector = static_cast<u32>(disc_offset / BLOCK_SIZE);
+    const size_t sector_off = static_cast<size_t>(disc_offset % BLOCK_SIZE);
+    const size_t chunk = std::min(BLOCK_SIZE - sector_off, size);
 
     u32 seed[SEED_SIZE];
     GenerateSeed(seed, disc_id, disc_num, sector);

--- a/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
+++ b/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
@@ -115,6 +115,28 @@ void LaggedFibonacciGenerator::GetBytes(size_t count, u8* out)
   }
 }
 
+bool LaggedFibonacciGenerator::CompareBytes(size_t count, const u8* data)
+{
+  while (count > 0)
+  {
+    const size_t length = std::min(count, LFG_K * sizeof(u32) - m_position_bytes);
+
+    if (std::memcmp(data, reinterpret_cast<u8*>(m_buffer.data()) + m_position_bytes, length) != 0)
+      return false;
+
+    m_position_bytes += length;
+    count -= length;
+    data += length;
+
+    if (m_position_bytes == LFG_K * sizeof(u32))
+    {
+      Forward();
+      m_position_bytes = 0;
+    }
+  }
+  return true;
+}
+
 u8 LaggedFibonacciGenerator::GetByte()
 {
   const u8 result = reinterpret_cast<u8*>(m_buffer.data())[m_position_bytes];
@@ -206,6 +228,58 @@ bool LaggedFibonacciGenerator::Initialize(bool check_existing_data)
   for (size_t i = 0; i < 4; ++i)
     Forward();
 
+  return true;
+}
+
+// Disc-level junk seed generation.
+// Based on: https://github.com/encounter/nod/blob/d10d376/nod/src/util/lfg.rs#L62-L78
+void LaggedFibonacciGenerator::GenerateSeed(u32 seed_out[SEED_SIZE], const u8 disc_id[4],
+                                            u8 disc_num, u32 sector)
+{
+  u32 seed = (static_cast<u32>(disc_id[2]) << 24) | (static_cast<u32>(disc_id[1]) << 16) |
+             (static_cast<u32>(disc_id[3] + disc_id[2]) << 8) |
+             static_cast<u32>(disc_id[0] + disc_id[1]);
+  seed ^= static_cast<u32>(disc_num);
+  u32 n = (seed * 0x260BCD5u) ^ (sector * 0x1EF29123u);
+  for (size_t i = 0; i < SEED_SIZE; i++)
+  {
+    seed_out[i] = 0;
+    for (size_t j = 0; j < LFG_J; j++)
+    {
+      n = n * 0x5D588B65u + 1;
+      seed_out[i] = (seed_out[i] >> 1) | (n & 0x80000000u);
+    }
+  }
+  seed_out[16] ^= (seed_out[0] >> 9) ^ (seed_out[16] << 23);
+}
+
+bool LaggedFibonacciGenerator::IsJunkBlock(const u8* data, size_t size, u64 disc_offset,
+                                           const u8 disc_id[4], u8 disc_num)
+{
+  static constexpr size_t SECTOR_SIZE = 0x8000;
+  LaggedFibonacciGenerator lfg;
+
+  while (size > 0)
+  {
+    const u32 sector = static_cast<u32>(disc_offset / SECTOR_SIZE);
+    const size_t sector_off = static_cast<size_t>(disc_offset % SECTOR_SIZE);
+    const size_t chunk = std::min(SECTOR_SIZE - sector_off, size);
+
+    u32 seed[SEED_SIZE];
+    GenerateSeed(seed, disc_id, disc_num, sector);
+    for (size_t s = 0; s < SEED_SIZE; s++)
+      seed[s] = Common::swap32(seed[s]);
+    lfg.SetSeed(seed);
+    if (sector_off > 0)
+      lfg.Forward(sector_off);
+
+    if (!lfg.CompareBytes(chunk, data))
+      return false;
+
+    data += chunk;
+    disc_offset += chunk;
+    size -= chunk;
+  }
   return true;
 }
 

--- a/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
+++ b/Source/Core/DiscIO/LaggedFibonacciGenerator.cpp
@@ -253,6 +253,36 @@ void LaggedFibonacciGenerator::GenerateSeed(u32 seed_out[SEED_SIZE], const u8 di
   seed_out[16] ^= (seed_out[0] >> 9) ^ (seed_out[16] << 23);
 }
 
+void LaggedFibonacciGenerator::FillJunkData(std::span<u8> out, u64 disc_offset, const u8 disc_id[4],
+                                            u8 disc_num)
+{
+  static constexpr size_t SECTOR_SIZE = 0x8000;
+  LaggedFibonacciGenerator lfg;
+
+  size_t remaining = out.size();
+  u8* ptr = out.data();
+
+  while (remaining > 0)
+  {
+    const u32 sector = static_cast<u32>(disc_offset / SECTOR_SIZE);
+    const size_t sector_off = static_cast<size_t>(disc_offset % SECTOR_SIZE);
+    size_t chunk = std::min(SECTOR_SIZE - sector_off, remaining);
+
+    u32 seed[SEED_SIZE];
+    GenerateSeed(seed, disc_id, disc_num, sector);
+    for (size_t s = 0; s < SEED_SIZE; s++)
+      seed[s] = Common::swap32(seed[s]);
+    lfg.SetSeed(seed);
+    if (sector_off > 0)
+      lfg.Forward(sector_off);
+    lfg.GetBytes(chunk, ptr);
+
+    ptr += chunk;
+    disc_offset += chunk;
+    remaining -= chunk;
+  }
+}
+
 bool LaggedFibonacciGenerator::IsJunkBlock(const u8* data, size_t size, u64 disc_offset,
                                            const u8 disc_id[4], u8 disc_num)
 {

--- a/Source/Core/DiscIO/LaggedFibonacciGenerator.h
+++ b/Source/Core/DiscIO/LaggedFibonacciGenerator.h
@@ -19,12 +19,23 @@ public:
   // data - data_offset must be 4-byte aligned.
   static size_t GetSeed(const u8* data, size_t size, size_t data_offset, u32 seed_out[SEED_SIZE]);
 
+  // Generates a disc-level junk seed from disc ID, disc number, and sector index.
+  // Based on: https://github.com/encounter/nod/blob/d10d376/nod/src/util/lfg.rs#L62
+  static void GenerateSeed(u32 seed_out[SEED_SIZE], const u8 disc_id[4], u8 disc_num, u32 sector);
+
+  // Checks if a block of data matches the expected disc-level junk pattern.
+  // Re-seeds per 0x8000-byte sector boundary. Returns true if the entire block is junk.
+  static bool IsJunkBlock(const u8* data, size_t size, u64 disc_offset, const u8 disc_id[4],
+                          u8 disc_num);
+
   // SetSeed must be called before using the functions below
   void SetSeed(const u32 seed[SEED_SIZE]);
   void SetSeed(const u8 seed[SEED_SIZE * sizeof(u32)]);
 
   // Outputs a number of bytes and advances the internal state by the same amount.
   void GetBytes(size_t count, u8* out);
+  // Compares data against the LFG state, returns false at first mismatch.
+  bool CompareBytes(size_t count, const u8* data);
   u8 GetByte();
 
   // Advances the internal state like GetBytes, but without outputting data. O(N), like GetBytes.

--- a/Source/Core/DiscIO/LaggedFibonacciGenerator.h
+++ b/Source/Core/DiscIO/LaggedFibonacciGenerator.h
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstddef>
+#include <span>
 
 #include "Common/CommonTypes.h"
 
@@ -22,6 +23,10 @@ public:
   // Generates a disc-level junk seed from disc ID, disc number, and sector index.
   // Based on: https://github.com/encounter/nod/blob/d10d376/nod/src/util/lfg.rs#L62
   static void GenerateSeed(u32 seed_out[SEED_SIZE], const u8 disc_id[4], u8 disc_num, u32 sector);
+
+  // Fills a buffer with the expected disc-level junk pattern.
+  // Re-seeds per 0x8000-byte sector boundary.
+  static void FillJunkData(std::span<u8> out, u64 disc_offset, const u8 disc_id[4], u8 disc_num);
 
   // Checks if a block of data matches the expected disc-level junk pattern.
   // Re-seeds per 0x8000-byte sector boundary. Returns true if the entire block is junk.

--- a/Source/Core/DiscIO/NKitHeader.cpp
+++ b/Source/Core/DiscIO/NKitHeader.cpp
@@ -1,0 +1,285 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// NKit v2 header format designed by Nanook.
+// Implementation based on nod: https://github.com/encounter/nod/blob/d10d376/nod/src/io/nkit.rs
+// See: https://github.com/dolphin-emu/dolphin/pull/14731
+
+#include "DiscIO/NKitHeader.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include <mbedtls/md5.h>
+#include <xxhash.h>
+
+#include "Common/BitUtils.h"
+#include "Common/CommonTypes.h"
+#include "Common/Crypto/SHA1.h"
+#include "Common/Hash.h"
+#include "DiscIO/Blob.h"
+
+namespace DiscIO::NKit
+{
+static constexpr char NKIT_MAGIC[8] = {'N', 'K', 'I', 'T', ' ', ' ', 'v', '2'};
+
+static bool ParseHeaderFields(const Header& header, const u8* data, size_t remaining,
+                              const u8* gap_data, u64 gap_type_blocks, Info& info)
+{
+  const Flags flags = static_cast<Flags>(static_cast<u16>(header.flags));
+  size_t pos = 0;
+
+  if (!!(flags & Flags::Size))
+  {
+    if (pos + sizeof(SizeField) > remaining)
+      return false;
+    SizeField field;
+    std::memcpy(&field, data + pos, sizeof(field));
+    info.digests.disc_size = field.disc_size;
+    pos += sizeof(SizeField);
+  }
+
+  if (!!(flags & Flags::Crc32))
+  {
+    if (pos + sizeof(Crc32Field) > remaining)
+      return false;
+    Crc32Field field;
+    std::memcpy(&field, data + pos, sizeof(field));
+    info.digests.crc32 = field.crc32;
+    pos += sizeof(Crc32Field);
+  }
+
+  if (!!(flags & Flags::Md5))
+  {
+    if (pos + sizeof(Md5Field) > remaining)
+      return false;
+    Md5Field field;
+    std::memcpy(&field, data + pos, sizeof(field));
+    info.digests.md5 = field.digest;
+    pos += sizeof(Md5Field);
+  }
+
+  if (!!(flags & Flags::Sha1))
+  {
+    if (pos + sizeof(Sha1Field) > remaining)
+      return false;
+    Sha1Field field;
+    std::memcpy(&field, data + pos, sizeof(field));
+    info.digests.sha1 = field.digest;
+    pos += sizeof(Sha1Field);
+  }
+
+  if (!!(flags & Flags::XxHash64))
+  {
+    if (pos + sizeof(XxHash64Field) > remaining)
+      return false;
+    XxHash64Field field;
+    std::memcpy(&field, data + pos, sizeof(field));
+    info.digests.xxhash64 = field.hash;
+    pos += sizeof(XxHash64Field);
+  }
+
+  if (!!(flags & Flags::Key))
+  {
+    if (pos + sizeof(KeyField) > remaining)
+      return false;
+    KeyField key_header;
+    std::memcpy(&key_header, data + pos, sizeof(key_header));
+    pos += sizeof(KeyField) + key_header.key_length;
+  }
+
+  // Encrypted, ExtraData, IndexFile are flag-only (no data)
+
+  const size_t gap_type_bytes = static_cast<size_t>((gap_type_blocks + 7) / 8);
+  info.gap_type.assign(gap_data, gap_data + gap_type_bytes);
+  info.flags = flags;
+  info.valid = true;
+  return true;
+}
+
+Info ReadHeader(BlobReader* reader, u64 offset, u64 gap_type_blocks)
+{
+  Info info;
+
+  Header header;
+  if (!reader->Read(offset, sizeof(header), reinterpret_cast<u8*>(&header)))
+    return info;
+
+  if (std::memcmp(header.magic, NKIT_MAGIC, sizeof(NKIT_MAGIC)) != 0)
+    return info;
+
+  const u16 header_size = header.header_size;
+  if (header_size < sizeof(Header))
+    return info;
+
+  const size_t remaining = header_size - sizeof(Header);
+  const size_t gap_type_bytes = static_cast<size_t>((gap_type_blocks + 7) / 8);
+  std::vector<u8> data(remaining + gap_type_bytes);
+  if (!reader->Read(offset + sizeof(Header), data.size(), data.data()))
+    return info;
+
+  ParseHeaderFields(header, data.data(), remaining, data.data() + remaining, gap_type_blocks, info);
+  return info;
+}
+
+Info ReadHeaderFromFile(File::DirectIOFile& file, u64 offset, u64 gap_type_blocks)
+{
+  Info info;
+
+  Header header;
+  file.Seek(offset, File::SeekOrigin::Begin);
+  if (!file.Read(Common::AsWritableU8Span(header)))
+    return info;
+
+  if (std::memcmp(header.magic, NKIT_MAGIC, sizeof(NKIT_MAGIC)) != 0)
+    return info;
+
+  const u16 header_size = header.header_size;
+  if (header_size < sizeof(Header))
+    return info;
+
+  const size_t remaining = header_size - sizeof(Header);
+  const size_t gap_type_bytes = static_cast<size_t>((gap_type_blocks + 7) / 8);
+  std::vector<u8> data(remaining + gap_type_bytes);
+  if (!file.Read(data.data(), data.size()))
+    return info;
+
+  ParseHeaderFields(header, data.data(), remaining, data.data() + remaining, gap_type_blocks, info);
+  return info;
+}
+
+bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
+{
+  const u64 gap_type_bytes = info.gap_type.size();
+
+  size_t data_size = 0;
+  if (!!(info.flags & Flags::Size))
+    data_size += sizeof(SizeField);
+  if (!!(info.flags & Flags::Crc32))
+    data_size += sizeof(Crc32Field);
+  if (!!(info.flags & Flags::Md5))
+    data_size += sizeof(Md5Field);
+  if (!!(info.flags & Flags::Sha1))
+    data_size += sizeof(Sha1Field);
+  if (!!(info.flags & Flags::XxHash64))
+    data_size += sizeof(XxHash64Field);
+  const u16 total_header_size = static_cast<u16>(sizeof(Header) + data_size);
+
+  std::vector<u8> buffer(total_header_size + gap_type_bytes, 0);
+
+  Header header;
+  std::memcpy(header.magic, NKIT_MAGIC, sizeof(NKIT_MAGIC));
+  header.header_size = total_header_size;
+  header.flags = static_cast<u16>(info.flags);
+  std::memcpy(buffer.data(), &header, sizeof(Header));
+
+  size_t pos = sizeof(Header);
+
+  if (!!(info.flags & Flags::Size))
+  {
+    SizeField field;
+    field.disc_size = info.digests.disc_size;
+    std::memcpy(buffer.data() + pos, &field, sizeof(field));
+    pos += sizeof(SizeField);
+  }
+
+  if (!!(info.flags & Flags::Crc32))
+  {
+    Crc32Field field;
+    field.crc32 = info.digests.crc32;
+    std::memcpy(buffer.data() + pos, &field, sizeof(field));
+    pos += sizeof(Crc32Field);
+  }
+
+  if (!!(info.flags & Flags::Md5))
+  {
+    Md5Field field;
+    field.digest = info.digests.md5;
+    std::memcpy(buffer.data() + pos, &field, sizeof(field));
+    pos += sizeof(Md5Field);
+  }
+
+  if (!!(info.flags & Flags::Sha1))
+  {
+    Sha1Field field;
+    field.digest = info.digests.sha1;
+    std::memcpy(buffer.data() + pos, &field, sizeof(field));
+    pos += sizeof(Sha1Field);
+  }
+
+  if (!!(info.flags & Flags::XxHash64))
+  {
+    XxHash64Field field;
+    field.hash = info.digests.xxhash64;
+    std::memcpy(buffer.data() + pos, &field, sizeof(field));
+    pos += sizeof(XxHash64Field);
+  }
+
+  std::memcpy(buffer.data() + pos, info.gap_type.data(), gap_type_bytes);
+
+  file.Seek(offset, File::SeekOrigin::Begin);
+  return file.Write(buffer.data(), buffer.size());
+}
+
+Digests ComputeDigests(BlobReader* reader, u64 disc_size)
+{
+  Digests digests;
+  digests.disc_size = disc_size;
+
+  auto sha1_ctx = Common::SHA1::CreateContext();
+  u32 crc = Common::StartCRC32();
+  mbedtls_md5_context md5_ctx{};
+  mbedtls_md5_init(&md5_ctx);
+  mbedtls_md5_starts_ret(&md5_ctx);
+  XXH64_state_t* xxh_state = XXH64_createState();
+  XXH64_reset(xxh_state, 0);
+
+  constexpr size_t CHUNK_SIZE = 1 << 21;  // 2 MiB
+  std::vector<u8> buffer(CHUNK_SIZE);
+
+  for (u64 offset = 0; offset < disc_size; offset += CHUNK_SIZE)
+  {
+    const size_t sz = static_cast<size_t>(std::min<u64>(CHUNK_SIZE, disc_size - offset));
+    if (!reader->Read(offset, sz, buffer.data()))
+      break;
+
+    sha1_ctx->Update(buffer.data(), sz);
+    crc = Common::UpdateCRC32(crc, buffer.data(), sz);
+    mbedtls_md5_update_ret(&md5_ctx, buffer.data(), sz);
+    XXH64_update(xxh_state, buffer.data(), sz);
+  }
+
+  digests.sha1 = sha1_ctx->Finish();
+  digests.crc32 = crc;
+  mbedtls_md5_finish_ret(&md5_ctx, digests.md5.data());
+  mbedtls_md5_free(&md5_ctx);
+  digests.xxhash64 = XXH64_digest(xxh_state);
+  XXH64_freeState(xxh_state);
+
+  return digests;
+}
+
+VerifyResult Verify(const Info& stored, const Digests& computed)
+{
+  VerifyResult result;
+
+  result.size_match =
+      !(stored.flags & Flags::Size) || stored.digests.disc_size == computed.disc_size;
+  result.crc32_match = !(stored.flags & Flags::Crc32) || stored.digests.crc32 == computed.crc32;
+  result.md5_match = !(stored.flags & Flags::Md5) || stored.digests.md5 == computed.md5;
+  result.sha1_match = !(stored.flags & Flags::Sha1) || stored.digests.sha1 == computed.sha1;
+  result.xxhash64_match =
+      !(stored.flags & Flags::XxHash64) || stored.digests.xxhash64 == computed.xxhash64;
+
+  return result;
+}
+
+bool IsGapJunk(const std::vector<u8>& gap_type, u64 block_index)
+{
+  const size_t byte_index = static_cast<size_t>(block_index / 8);
+  if (byte_index >= gap_type.size())
+    return false;
+  return (gap_type[byte_index] & (1 << (7 - (block_index & 7)))) != 0;
+}
+
+}  // namespace DiscIO::NKit

--- a/Source/Core/DiscIO/NKitHeader.h
+++ b/Source/Core/DiscIO/NKitHeader.h
@@ -1,0 +1,136 @@
+// Copyright 2025 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+#include "Common/DirectIOFile.h"
+#include "Common/Swap.h"
+
+namespace DiscIO
+{
+class BlobReader;
+}
+
+namespace DiscIO::NKit
+{
+constexpr u64 HEADER_OFFSET = 0x10000;
+
+enum class Flags : u16
+{
+  None = 0,
+  Size = 1 << 0,
+  Crc32 = 1 << 1,
+  Md5 = 1 << 2,
+  Sha1 = 1 << 3,
+  XxHash64 = 1 << 4,
+  Key = 1 << 5,
+  Encrypted = 1 << 6,
+  ExtraData = 1 << 7,
+  IndexFile = 1 << 8,
+};
+
+constexpr Flags operator|(Flags a, Flags b)
+{
+  return static_cast<Flags>(static_cast<u16>(a) | static_cast<u16>(b));
+}
+
+constexpr Flags operator&(Flags a, Flags b)
+{
+  return static_cast<Flags>(static_cast<u16>(a) & static_cast<u16>(b));
+}
+
+constexpr bool operator!(Flags a)
+{
+  return static_cast<u16>(a) == 0;
+}
+
+#pragma pack(1)
+struct Header
+{
+  char magic[8];
+  Common::BigEndianValue<u16> header_size;
+  Common::BigEndianValue<u16> flags;
+};
+static_assert(sizeof(Header) == 12);
+
+struct SizeField
+{
+  Common::BigEndianValue<u64> disc_size;
+};
+static_assert(sizeof(SizeField) == 8);
+
+struct Crc32Field
+{
+  Common::BigEndianValue<u32> crc32;
+};
+static_assert(sizeof(Crc32Field) == 4);
+
+struct Md5Field
+{
+  std::array<u8, 16> digest;
+};
+static_assert(sizeof(Md5Field) == 16);
+
+struct Sha1Field
+{
+  std::array<u8, 20> digest;
+};
+static_assert(sizeof(Sha1Field) == 20);
+
+struct XxHash64Field
+{
+  Common::BigEndianValue<u64> hash;
+};
+static_assert(sizeof(XxHash64Field) == 8);
+
+struct KeyField
+{
+  u8 key_length;
+  u8 key_type;
+};
+static_assert(sizeof(KeyField) == 2);
+#pragma pack()
+
+struct Digests
+{
+  u64 disc_size = 0;
+  u32 crc32 = 0;
+  std::array<u8, 16> md5{};
+  std::array<u8, 20> sha1{};
+  u64 xxhash64 = 0;
+};
+
+struct Info
+{
+  Digests digests;
+  Flags flags = Flags::None;
+  std::vector<u8> gap_type;
+  bool valid = false;
+};
+
+struct VerifyResult
+{
+  bool size_match = false;
+  bool crc32_match = false;
+  bool md5_match = false;
+  bool sha1_match = false;
+  bool xxhash64_match = false;
+
+  bool AllMatch() const
+  {
+    return size_match && crc32_match && md5_match && sha1_match && xxhash64_match;
+  }
+};
+
+Info ReadHeader(BlobReader* reader, u64 offset, u64 gap_type_blocks);
+Info ReadHeaderFromFile(File::DirectIOFile& file, u64 offset, u64 gap_type_blocks);
+bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info);
+Digests ComputeDigests(BlobReader* reader, u64 disc_size);
+VerifyResult Verify(const Info& stored, const Digests& computed);
+bool IsGapJunk(const std::vector<u8>& gap_type, u64 block_index);
+
+}  // namespace DiscIO::NKit

--- a/Source/Core/DiscIO/NKitv2Header.cpp
+++ b/Source/Core/DiscIO/NKitv2Header.cpp
@@ -14,7 +14,8 @@
 
 namespace DiscIO::NKitv2
 {
-static constexpr char NKIT_MAGIC[8] = {'N', 'K', 'I', 'T', ' ', ' ', 'v', '2'};
+static constexpr char NKIT_MAGIC[4] = {'N', 'K', 'I', 'T'};
+static constexpr char NKIT_V2[4] = {' ', ' ', 'v', '2'};
 
 static bool ParseHeaderFields(const Header& header, const u8* data, size_t remaining,
                               const u8* gap_data, u64 gap_type_blocks, Info& info)
@@ -102,6 +103,9 @@ Info ReadHeaderFromFile(File::DirectIOFile& file, u64 offset, u64 gap_type_block
   if (std::memcmp(header.magic, NKIT_MAGIC, sizeof(NKIT_MAGIC)) != 0)
     return info;
 
+  if (std::memcmp(header.magic + 4, NKIT_V2, sizeof(NKIT_V2)) != 0)
+    return info;
+
   const u16 header_size = header.header_size;
   if (header_size < sizeof(Header))
     return info;
@@ -137,6 +141,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
 
   Header header;
   std::memcpy(header.magic, NKIT_MAGIC, sizeof(NKIT_MAGIC));
+  std::memcpy(header.magic + 4, NKIT_V2, sizeof(NKIT_V2));
   header.header_size = total_header_size;
   header.flags = static_cast<u16>(info.flags);
   std::memcpy(buffer.data(), &header, sizeof(Header));

--- a/Source/Core/DiscIO/NKitv2Header.cpp
+++ b/Source/Core/DiscIO/NKitv2Header.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstring>
 
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Swap.h"
 
@@ -23,7 +24,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
   const Flags flags = static_cast<Flags>(static_cast<u16>(header.flags));
   size_t pos = 0;
 
-  if (flags & Flags::Size)
+  if ((flags & Flags::Size) != Flags::None)
   {
     if (pos + sizeof(SizeField) > remaining)
       return false;
@@ -33,7 +34,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(SizeField);
   }
 
-  if (flags & Flags::Crc32)
+  if ((flags & Flags::Crc32) != Flags::None)
   {
     if (pos + sizeof(Crc32Field) > remaining)
       return false;
@@ -43,7 +44,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(Crc32Field);
   }
 
-  if (flags & Flags::Md5)
+  if ((flags & Flags::Md5) != Flags::None)
   {
     if (pos + sizeof(Md5Field) > remaining)
       return false;
@@ -53,7 +54,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(Md5Field);
   }
 
-  if (flags & Flags::Sha1)
+  if ((flags & Flags::Sha1) != Flags::None)
   {
     if (pos + sizeof(Sha1Field) > remaining)
       return false;
@@ -63,7 +64,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(Sha1Field);
   }
 
-  if (flags & Flags::XxHash64)
+  if ((flags & Flags::XxHash64) != Flags::None)
   {
     if (pos + sizeof(XxHash64Field) > remaining)
       return false;
@@ -73,7 +74,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(XxHash64Field);
   }
 
-  if (flags & Flags::Key)
+  if ((flags & Flags::Key) != Flags::None)
   {
     if (pos + sizeof(KeyField) > remaining)
       return false;
@@ -125,15 +126,15 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
   const u64 gap_type_bytes = info.gap_type.size();
 
   size_t data_size = 0;
-  if (info.flags & Flags::Size)
+  if ((info.flags & Flags::Size) != Flags::None)
     data_size += sizeof(SizeField);
-  if (info.flags & Flags::Crc32)
+  if ((info.flags & Flags::Crc32) != Flags::None)
     data_size += sizeof(Crc32Field);
-  if (info.flags & Flags::Md5)
+  if ((info.flags & Flags::Md5) != Flags::None)
     data_size += sizeof(Md5Field);
-  if (info.flags & Flags::Sha1)
+  if ((info.flags & Flags::Sha1) != Flags::None)
     data_size += sizeof(Sha1Field);
-  if (info.flags & Flags::XxHash64)
+  if ((info.flags & Flags::XxHash64) != Flags::None)
     data_size += sizeof(XxHash64Field);
   const u16 total_header_size = static_cast<u16>(sizeof(Header) + data_size);
 
@@ -148,7 +149,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
 
   size_t pos = sizeof(Header);
 
-  if (info.flags & Flags::Size)
+  if ((info.flags & Flags::Size) != Flags::None)
   {
     SizeField field;
     field.disc_size = info.digests.disc_size;
@@ -156,7 +157,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
     pos += sizeof(SizeField);
   }
 
-  if (info.flags & Flags::Crc32)
+  if ((info.flags & Flags::Crc32) != Flags::None)
   {
     Crc32Field field;
     field.crc32 = info.digests.crc32;
@@ -164,7 +165,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
     pos += sizeof(Crc32Field);
   }
 
-  if (info.flags & Flags::Md5)
+  if ((info.flags & Flags::Md5) != Flags::None)
   {
     Md5Field field;
     field.digest = info.digests.md5;
@@ -172,7 +173,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
     pos += sizeof(Md5Field);
   }
 
-  if (info.flags & Flags::Sha1)
+  if ((info.flags & Flags::Sha1) != Flags::None)
   {
     Sha1Field field;
     field.digest = info.digests.sha1;
@@ -180,7 +181,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
     pos += sizeof(Sha1Field);
   }
 
-  if (info.flags & Flags::XxHash64)
+  if ((info.flags & Flags::XxHash64) != Flags::None)
   {
     XxHash64Field field;
     field.hash = info.digests.xxhash64;

--- a/Source/Core/DiscIO/NKitv2Header.cpp
+++ b/Source/Core/DiscIO/NKitv2Header.cpp
@@ -1,25 +1,18 @@
-// Copyright 2025 Dolphin Emulator Project
+// Copyright 2026 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 // NKit v2 header format designed by Nanook.
 // Implementation based on nod: https://github.com/encounter/nod/blob/d10d376/nod/src/io/nkit.rs
-// See: https://github.com/dolphin-emu/dolphin/pull/14731
 
-#include "DiscIO/NKitHeader.h"
+#include "DiscIO/NKitv2Header.h"
 
 #include <algorithm>
 #include <cstring>
 
-#include <mbedtls/md5.h>
-#include <xxhash.h>
-
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
-#include "Common/Crypto/SHA1.h"
-#include "Common/Hash.h"
-#include "DiscIO/Blob.h"
+#include "Common/Swap.h"
 
-namespace DiscIO::NKit
+namespace DiscIO::NKitv2
 {
 static constexpr char NKIT_MAGIC[8] = {'N', 'K', 'I', 'T', ' ', ' ', 'v', '2'};
 
@@ -29,7 +22,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
   const Flags flags = static_cast<Flags>(static_cast<u16>(header.flags));
   size_t pos = 0;
 
-  if (!!(flags & Flags::Size))
+  if (flags & Flags::Size)
   {
     if (pos + sizeof(SizeField) > remaining)
       return false;
@@ -39,7 +32,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(SizeField);
   }
 
-  if (!!(flags & Flags::Crc32))
+  if (flags & Flags::Crc32)
   {
     if (pos + sizeof(Crc32Field) > remaining)
       return false;
@@ -49,7 +42,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(Crc32Field);
   }
 
-  if (!!(flags & Flags::Md5))
+  if (flags & Flags::Md5)
   {
     if (pos + sizeof(Md5Field) > remaining)
       return false;
@@ -59,7 +52,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(Md5Field);
   }
 
-  if (!!(flags & Flags::Sha1))
+  if (flags & Flags::Sha1)
   {
     if (pos + sizeof(Sha1Field) > remaining)
       return false;
@@ -69,7 +62,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(Sha1Field);
   }
 
-  if (!!(flags & Flags::XxHash64))
+  if (flags & Flags::XxHash64)
   {
     if (pos + sizeof(XxHash64Field) > remaining)
       return false;
@@ -79,7 +72,7 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
     pos += sizeof(XxHash64Field);
   }
 
-  if (!!(flags & Flags::Key))
+  if (flags & Flags::Key)
   {
     if (pos + sizeof(KeyField) > remaining)
       return false;
@@ -95,31 +88,6 @@ static bool ParseHeaderFields(const Header& header, const u8* data, size_t remai
   info.flags = flags;
   info.valid = true;
   return true;
-}
-
-Info ReadHeader(BlobReader* reader, u64 offset, u64 gap_type_blocks)
-{
-  Info info;
-
-  Header header;
-  if (!reader->Read(offset, sizeof(header), reinterpret_cast<u8*>(&header)))
-    return info;
-
-  if (std::memcmp(header.magic, NKIT_MAGIC, sizeof(NKIT_MAGIC)) != 0)
-    return info;
-
-  const u16 header_size = header.header_size;
-  if (header_size < sizeof(Header))
-    return info;
-
-  const size_t remaining = header_size - sizeof(Header);
-  const size_t gap_type_bytes = static_cast<size_t>((gap_type_blocks + 7) / 8);
-  std::vector<u8> data(remaining + gap_type_bytes);
-  if (!reader->Read(offset + sizeof(Header), data.size(), data.data()))
-    return info;
-
-  ParseHeaderFields(header, data.data(), remaining, data.data() + remaining, gap_type_blocks, info);
-  return info;
 }
 
 Info ReadHeaderFromFile(File::DirectIOFile& file, u64 offset, u64 gap_type_blocks)
@@ -153,15 +121,15 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
   const u64 gap_type_bytes = info.gap_type.size();
 
   size_t data_size = 0;
-  if (!!(info.flags & Flags::Size))
+  if (info.flags & Flags::Size)
     data_size += sizeof(SizeField);
-  if (!!(info.flags & Flags::Crc32))
+  if (info.flags & Flags::Crc32)
     data_size += sizeof(Crc32Field);
-  if (!!(info.flags & Flags::Md5))
+  if (info.flags & Flags::Md5)
     data_size += sizeof(Md5Field);
-  if (!!(info.flags & Flags::Sha1))
+  if (info.flags & Flags::Sha1)
     data_size += sizeof(Sha1Field);
-  if (!!(info.flags & Flags::XxHash64))
+  if (info.flags & Flags::XxHash64)
     data_size += sizeof(XxHash64Field);
   const u16 total_header_size = static_cast<u16>(sizeof(Header) + data_size);
 
@@ -175,7 +143,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
 
   size_t pos = sizeof(Header);
 
-  if (!!(info.flags & Flags::Size))
+  if (info.flags & Flags::Size)
   {
     SizeField field;
     field.disc_size = info.digests.disc_size;
@@ -183,7 +151,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
     pos += sizeof(SizeField);
   }
 
-  if (!!(info.flags & Flags::Crc32))
+  if (info.flags & Flags::Crc32)
   {
     Crc32Field field;
     field.crc32 = info.digests.crc32;
@@ -191,7 +159,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
     pos += sizeof(Crc32Field);
   }
 
-  if (!!(info.flags & Flags::Md5))
+  if (info.flags & Flags::Md5)
   {
     Md5Field field;
     field.digest = info.digests.md5;
@@ -199,7 +167,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
     pos += sizeof(Md5Field);
   }
 
-  if (!!(info.flags & Flags::Sha1))
+  if (info.flags & Flags::Sha1)
   {
     Sha1Field field;
     field.digest = info.digests.sha1;
@@ -207,7 +175,7 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
     pos += sizeof(Sha1Field);
   }
 
-  if (!!(info.flags & Flags::XxHash64))
+  if (info.flags & Flags::XxHash64)
   {
     XxHash64Field field;
     field.hash = info.digests.xxhash64;
@@ -221,59 +189,6 @@ bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info)
   return file.Write(buffer.data(), buffer.size());
 }
 
-Digests ComputeDigests(BlobReader* reader, u64 disc_size)
-{
-  Digests digests;
-  digests.disc_size = disc_size;
-
-  auto sha1_ctx = Common::SHA1::CreateContext();
-  u32 crc = Common::StartCRC32();
-  mbedtls_md5_context md5_ctx{};
-  mbedtls_md5_init(&md5_ctx);
-  mbedtls_md5_starts_ret(&md5_ctx);
-  XXH64_state_t* xxh_state = XXH64_createState();
-  XXH64_reset(xxh_state, 0);
-
-  constexpr size_t CHUNK_SIZE = 1 << 21;  // 2 MiB
-  std::vector<u8> buffer(CHUNK_SIZE);
-
-  for (u64 offset = 0; offset < disc_size; offset += CHUNK_SIZE)
-  {
-    const size_t sz = static_cast<size_t>(std::min<u64>(CHUNK_SIZE, disc_size - offset));
-    if (!reader->Read(offset, sz, buffer.data()))
-      break;
-
-    sha1_ctx->Update(buffer.data(), sz);
-    crc = Common::UpdateCRC32(crc, buffer.data(), sz);
-    mbedtls_md5_update_ret(&md5_ctx, buffer.data(), sz);
-    XXH64_update(xxh_state, buffer.data(), sz);
-  }
-
-  digests.sha1 = sha1_ctx->Finish();
-  digests.crc32 = crc;
-  mbedtls_md5_finish_ret(&md5_ctx, digests.md5.data());
-  mbedtls_md5_free(&md5_ctx);
-  digests.xxhash64 = XXH64_digest(xxh_state);
-  XXH64_freeState(xxh_state);
-
-  return digests;
-}
-
-VerifyResult Verify(const Info& stored, const Digests& computed)
-{
-  VerifyResult result;
-
-  result.size_match =
-      !(stored.flags & Flags::Size) || stored.digests.disc_size == computed.disc_size;
-  result.crc32_match = !(stored.flags & Flags::Crc32) || stored.digests.crc32 == computed.crc32;
-  result.md5_match = !(stored.flags & Flags::Md5) || stored.digests.md5 == computed.md5;
-  result.sha1_match = !(stored.flags & Flags::Sha1) || stored.digests.sha1 == computed.sha1;
-  result.xxhash64_match =
-      !(stored.flags & Flags::XxHash64) || stored.digests.xxhash64 == computed.xxhash64;
-
-  return result;
-}
-
 bool IsGapJunk(const std::vector<u8>& gap_type, u64 block_index)
 {
   const size_t byte_index = static_cast<size_t>(block_index / 8);
@@ -282,4 +197,4 @@ bool IsGapJunk(const std::vector<u8>& gap_type, u64 block_index)
   return (gap_type[byte_index] & (1 << (7 - (block_index & 7)))) != 0;
 }
 
-}  // namespace DiscIO::NKit
+}  // namespace DiscIO::NKitv2

--- a/Source/Core/DiscIO/NKitv2Header.h
+++ b/Source/Core/DiscIO/NKitv2Header.h
@@ -1,4 +1,4 @@
-// Copyright 2025 Dolphin Emulator Project
+// Copyright 2026 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
@@ -10,12 +10,7 @@
 #include "Common/DirectIOFile.h"
 #include "Common/Swap.h"
 
-namespace DiscIO
-{
-class BlobReader;
-}
-
-namespace DiscIO::NKit
+namespace DiscIO::NKitv2
 {
 constexpr u64 HEADER_OFFSET = 0x10000;
 
@@ -112,25 +107,8 @@ struct Info
   bool valid = false;
 };
 
-struct VerifyResult
-{
-  bool size_match = false;
-  bool crc32_match = false;
-  bool md5_match = false;
-  bool sha1_match = false;
-  bool xxhash64_match = false;
-
-  bool AllMatch() const
-  {
-    return size_match && crc32_match && md5_match && sha1_match && xxhash64_match;
-  }
-};
-
-Info ReadHeader(BlobReader* reader, u64 offset, u64 gap_type_blocks);
 Info ReadHeaderFromFile(File::DirectIOFile& file, u64 offset, u64 gap_type_blocks);
 bool WriteHeader(File::DirectIOFile& file, u64 offset, const Info& info);
-Digests ComputeDigests(BlobReader* reader, u64 disc_size);
-VerifyResult Verify(const Info& stored, const Digests& computed);
 bool IsGapJunk(const std::vector<u8>& gap_type, u64 block_index);
 
-}  // namespace DiscIO::NKit
+}  // namespace DiscIO::NKitv2

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -16,6 +16,7 @@
 #include <mz_zip.h>
 #include <mz_zip_rw.h>
 #include <pugixml.hpp>
+#include <xxhash.h>
 
 #include "Common/Align.h"
 #include "Common/Assert.h"
@@ -357,7 +358,7 @@ VolumeVerifier::VolumeVerifier(const Volume& volume, bool redump_verification,
     : m_volume(volume), m_redump_verification(redump_verification),
       m_hashes_to_calculate(hashes_to_calculate),
       m_calculating_any_hash(hashes_to_calculate.crc32 || hashes_to_calculate.md5 ||
-                             hashes_to_calculate.sha1),
+                             hashes_to_calculate.sha1 || hashes_to_calculate.xxhash64),
       m_max_progress(volume.GetDataSize()), m_data_size_type(volume.GetDataSizeType())
 {
   if (!m_calculating_any_hash)
@@ -367,6 +368,8 @@ VolumeVerifier::VolumeVerifier(const Volume& volume, bool redump_verification,
 VolumeVerifier::~VolumeVerifier()
 {
   WaitForAsyncOperations();
+  if (m_xxhash64_state)
+    XXH64_freeState(static_cast<XXH64_state_t*>(m_xxhash64_state));
 }
 
 Hashes<bool> VolumeVerifier::GetDefaultHashesToCalculate()
@@ -1095,6 +1098,12 @@ void VolumeVerifier::SetUpHashing()
   {
     m_sha1_context = Common::SHA1::CreateContext();
   }
+
+  if (m_hashes_to_calculate.xxhash64)
+  {
+    m_xxhash64_state = static_cast<void*>(XXH64_createState());
+    XXH64_reset(static_cast<XXH64_state_t*>(m_xxhash64_state), 0);
+  }
 }
 
 void VolumeVerifier::WaitForAsyncOperations() const
@@ -1105,6 +1114,8 @@ void VolumeVerifier::WaitForAsyncOperations() const
     m_md5_future.wait();
   if (m_sha1_future.valid())
     m_sha1_future.wait();
+  if (m_xxhash64_future.valid())
+    m_xxhash64_future.wait();
   if (m_content_future.valid())
     m_content_future.wait();
   if (m_group_future.valid())
@@ -1241,6 +1252,13 @@ void VolumeVerifier::Process()
         m_sha1_context->Update(m_data.data(), byte_increment);
       });
     }
+
+    if (m_hashes_to_calculate.xxhash64)
+    {
+      m_xxhash64_future = std::async(std::launch::async, [this, byte_increment] {
+        XXH64_update(static_cast<XXH64_state_t*>(m_xxhash64_state), m_data.data(), byte_increment);
+      });
+    }
   }
 
   if (content_read)
@@ -1331,6 +1349,16 @@ void VolumeVerifier::Finish()
     {
       const auto digest = m_sha1_context->Finish();
       m_result.hashes.sha1 = std::vector<u8>(digest.begin(), digest.end());
+    }
+
+    if (m_hashes_to_calculate.xxhash64)
+    {
+      m_result.hashes.xxhash64 = std::vector<u8>(8);
+      auto* xxh_state = static_cast<XXH64_state_t*>(m_xxhash64_state);
+      const u64 xxh_be = Common::swap64(XXH64_digest(xxh_state));
+      std::memcpy(m_result.hashes.xxhash64.data(), &xxh_be, 8);
+      XXH64_freeState(xxh_state);
+      m_xxhash64_state = nullptr;
     }
   }
 

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -16,7 +16,6 @@
 #include <mz_zip.h>
 #include <mz_zip_rw.h>
 #include <pugixml.hpp>
-#include <xxhash.h>
 
 #include "Common/Align.h"
 #include "Common/Assert.h"
@@ -358,7 +357,7 @@ VolumeVerifier::VolumeVerifier(const Volume& volume, bool redump_verification,
     : m_volume(volume), m_redump_verification(redump_verification),
       m_hashes_to_calculate(hashes_to_calculate),
       m_calculating_any_hash(hashes_to_calculate.crc32 || hashes_to_calculate.md5 ||
-                             hashes_to_calculate.sha1 || hashes_to_calculate.xxhash64),
+                             hashes_to_calculate.sha1),
       m_max_progress(volume.GetDataSize()), m_data_size_type(volume.GetDataSizeType())
 {
   if (!m_calculating_any_hash)
@@ -368,8 +367,6 @@ VolumeVerifier::VolumeVerifier(const Volume& volume, bool redump_verification,
 VolumeVerifier::~VolumeVerifier()
 {
   WaitForAsyncOperations();
-  if (m_xxhash64_state)
-    XXH64_freeState(static_cast<XXH64_state_t*>(m_xxhash64_state));
 }
 
 Hashes<bool> VolumeVerifier::GetDefaultHashesToCalculate()
@@ -1099,11 +1096,6 @@ void VolumeVerifier::SetUpHashing()
     m_sha1_context = Common::SHA1::CreateContext();
   }
 
-  if (m_hashes_to_calculate.xxhash64)
-  {
-    m_xxhash64_state = static_cast<void*>(XXH64_createState());
-    XXH64_reset(static_cast<XXH64_state_t*>(m_xxhash64_state), 0);
-  }
 }
 
 void VolumeVerifier::WaitForAsyncOperations() const
@@ -1114,8 +1106,6 @@ void VolumeVerifier::WaitForAsyncOperations() const
     m_md5_future.wait();
   if (m_sha1_future.valid())
     m_sha1_future.wait();
-  if (m_xxhash64_future.valid())
-    m_xxhash64_future.wait();
   if (m_content_future.valid())
     m_content_future.wait();
   if (m_group_future.valid())
@@ -1253,12 +1243,6 @@ void VolumeVerifier::Process()
       });
     }
 
-    if (m_hashes_to_calculate.xxhash64)
-    {
-      m_xxhash64_future = std::async(std::launch::async, [this, byte_increment] {
-        XXH64_update(static_cast<XXH64_state_t*>(m_xxhash64_state), m_data.data(), byte_increment);
-      });
-    }
   }
 
   if (content_read)
@@ -1351,15 +1335,6 @@ void VolumeVerifier::Finish()
       m_result.hashes.sha1 = std::vector<u8>(digest.begin(), digest.end());
     }
 
-    if (m_hashes_to_calculate.xxhash64)
-    {
-      m_result.hashes.xxhash64 = std::vector<u8>(8);
-      auto* xxh_state = static_cast<XXH64_state_t*>(m_xxhash64_state);
-      const u64 xxh_be = Common::swap64(XXH64_digest(xxh_state));
-      std::memcpy(m_result.hashes.xxhash64.data(), &xxh_be, 8);
-      XXH64_freeState(xxh_state);
-      m_xxhash64_state = nullptr;
-    }
   }
 
   if (m_read_errors_occurred)

--- a/Source/Core/DiscIO/VolumeVerifier.h
+++ b/Source/Core/DiscIO/VolumeVerifier.h
@@ -39,7 +39,6 @@ struct Hashes
   T crc32;
   T md5;
   T sha1;
-  T xxhash64;
 };
 
 class RedumpVerifier final
@@ -178,14 +177,11 @@ private:
   u32 m_crc32_context = 0;
   mbedtls_md5_context m_md5_context{};
   std::unique_ptr<Common::SHA1::Context> m_sha1_context;
-  void* m_xxhash64_state = nullptr;
-
   u64 m_excess_bytes = 0;
   std::vector<u8> m_data;
   std::future<void> m_crc32_future;
   std::future<void> m_md5_future;
   std::future<void> m_sha1_future;
-  std::future<void> m_xxhash64_future;
   std::future<void> m_content_future;
   std::future<void> m_group_future;
 

--- a/Source/Core/DiscIO/VolumeVerifier.h
+++ b/Source/Core/DiscIO/VolumeVerifier.h
@@ -39,6 +39,7 @@ struct Hashes
   T crc32;
   T md5;
   T sha1;
+  T xxhash64;
 };
 
 class RedumpVerifier final
@@ -177,12 +178,14 @@ private:
   u32 m_crc32_context = 0;
   mbedtls_md5_context m_md5_context{};
   std::unique_ptr<Common::SHA1::Context> m_sha1_context;
+  void* m_xxhash64_state = nullptr;
 
   u64 m_excess_bytes = 0;
   std::vector<u8> m_data;
   std::future<void> m_crc32_future;
   std::future<void> m_md5_future;
   std::future<void> m_sha1_future;
+  std::future<void> m_xxhash64_future;
   std::future<void> m_content_future;
   std::future<void> m_group_future;
 

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -174,7 +174,8 @@ bool VolumeWii::Read(u64 offset, u64 length, u8* buffer, const Partition& partit
   if (m_has_hashes && m_has_encryption &&
       m_reader->SupportsReadWiiDecrypted(offset, length, partition_data_offset))
   {
-    return m_reader->ReadWiiDecrypted(offset, length, buffer, partition_data_offset);
+    return m_reader->ReadWiiDecrypted(offset, length, buffer, partition_data_offset,
+                                      partition_details.key->get());
   }
 
   if (!m_has_hashes)
@@ -585,12 +586,15 @@ bool VolumeWii::EncryptGroup(
   std::vector<std::array<u8, BLOCK_DATA_SIZE>> unencrypted_data(BLOCKS_PER_GROUP);
   std::vector<HashBlock> unencrypted_hashes(BLOCKS_PER_GROUP);
 
+  auto decrypt_context = Common::AES::CreateContextDecrypt(key.data());
+
   const bool success =
       HashGroup(unencrypted_data.data(), unencrypted_hashes.data(), [&](size_t block) {
         if (offset + (block + 1) * BLOCK_DATA_SIZE <= partition_data_decrypted_size)
         {
           if (!blob->ReadWiiDecrypted(offset + block * BLOCK_DATA_SIZE, BLOCK_DATA_SIZE,
-                                      unencrypted_data[block].data(), partition_data_offset))
+                                      unencrypted_data[block].data(), partition_data_offset,
+                                      decrypt_context.get()))
           {
             return false;
           }

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -1745,7 +1745,8 @@ WIARVZFileReader<RVZ>::Convert(BlobReader* infile, const VolumeDisc* infile_volu
                                File::DirectIOFile* outfile, WIARVZCompressionType compression_type,
                                int compression_level, int chunk_size, CompressCB callback)
 {
-  ASSERT(infile->GetDataSizeType() == DataSizeType::Accurate);
+  ASSERT(infile->GetDataSizeType() == DataSizeType::Accurate ||
+         infile->GetDataSizeType() == DataSizeType::UpperBound);
   ASSERT(chunk_size > 0);
 
   const u64 iso_size = infile->GetDataSize();

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -457,7 +457,7 @@ bool WIARVZFileReader<RVZ>::SupportsReadWiiDecrypted(u64 offset, u64 size,
 
 template <bool RVZ>
 bool WIARVZFileReader<RVZ>::ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr,
-                                             u64 partition_data_offset)
+                                             u64 partition_data_offset, Common::AES::Context*)
 {
   u32 partition_first_sector;
   const PartitionEntry* partition = GetPartition(partition_data_offset, &partition_first_sector);

--- a/Source/Core/DiscIO/WIABlob.h
+++ b/Source/Core/DiscIO/WIABlob.h
@@ -65,7 +65,8 @@ public:
 
   bool Read(u64 offset, u64 size, u8* out_ptr) override;
   bool SupportsReadWiiDecrypted(u64 offset, u64 size, u64 partition_data_offset) const override;
-  bool ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr, u64 partition_data_offset) override;
+  bool ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr, u64 partition_data_offset,
+                        Common::AES::Context* aes_context = nullptr) override;
 
   static ConversionResultCode Convert(BlobReader* infile, const VolumeDisc* infile_volume,
                                       File::DirectIOFile* outfile,

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -4,19 +4,31 @@
 #include "DiscIO/WbfsBlob.h"
 
 #include <algorithm>
-#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include <mbedtls/md5.h>
+#include <xxhash.h>
+
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
+#include "Common/Crypto/SHA1.h"
+#include "Common/FileUtil.h"
+#include "Common/Hash.h"
 #include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
+#include "Common/ScopeGuard.h"
 #include "Common/Swap.h"
+#include "DiscIO/DiscUtils.h"
+#include "DiscIO/LaggedFibonacciGenerator.h"
+#include "DiscIO/NKitHeader.h"
+#include "DiscIO/Volume.h"
+#include "DiscIO/VolumeWii.h"
 
 namespace DiscIO
 {
@@ -25,7 +37,7 @@ static constexpr u64 WII_SECTOR_COUNT = 143432 * 2;
 static constexpr u64 WII_DISC_HEADER_SIZE = 256;
 
 WbfsFileReader::WbfsFileReader(File::DirectIOFile file, const std::string& path)
-    : m_size(0), m_good(false)
+    : m_size(0), m_good(false), m_encryption_cache(this)
 {
   if (!AddFileToList(std::move(file)))
     return;
@@ -35,13 +47,25 @@ WbfsFileReader::WbfsFileReader(File::DirectIOFile file, const std::string& path)
     return;
   m_good = true;
 
+  // Read disc header copy for disc_id and disc_num (needed for junk reconstruction)
+  m_files[0].file.Seek(m_hd_sector_size, File::SeekOrigin::Begin);
+  u8 disc_header_buf[7];
+  if (m_files[0].file.Read(disc_header_buf, sizeof(disc_header_buf)))
+  {
+    std::memcpy(m_disc_id, disc_header_buf, 4);
+    m_disc_num = disc_header_buf[6];
+  }
+
   // Grab disc info (assume slot 0, checked in ReadHeader())
+  // TODO: Multi-disc WBFS support (disc_table can hold up to 500 entries).
+  // Offset would be: m_hd_sector_size + WII_DISC_HEADER_SIZE + i * m_disc_info_size
   m_wlba_table.resize(m_blocks_per_disc);
-  m_files[0].file.Seek(m_hd_sector_size + WII_DISC_HEADER_SIZE /*+ i * m_disc_info_size*/,
-                       File::SeekOrigin::Begin);
+  m_files[0].file.Seek(m_hd_sector_size + WII_DISC_HEADER_SIZE, File::SeekOrigin::Begin);
   m_files[0].file.Read(Common::AsWritableU8Span(m_wlba_table));
   for (size_t i = 0; i < m_blocks_per_disc; i++)
     m_wlba_table[i] = Common::swap16(m_wlba_table[i]);
+
+  ReadNKitHeader();
 }
 
 WbfsFileReader::~WbfsFileReader() = default;
@@ -56,6 +80,8 @@ std::unique_ptr<BlobReader> WbfsFileReader::CopyReader() const
 
 u64 WbfsFileReader::GetDataSize() const
 {
+  if (m_has_nkit_header && m_nkit_info.digests.disc_size > 0)
+    return m_nkit_info.digests.disc_size;
   return WII_SECTOR_COUNT * WII_SECTOR_SIZE;
 }
 
@@ -106,7 +132,6 @@ bool WbfsFileReader::ReadHeader()
 
   // Read wbfs cluster info
   m_wbfs_sector_size = 1ull << m_header.wbfs_sector_shift;
-  m_wbfs_sector_count = m_size / m_wbfs_sector_size;
 
   if (m_wbfs_sector_size < WII_SECTOR_SIZE)
     return false;
@@ -119,6 +144,131 @@ bool WbfsFileReader::ReadHeader()
   return m_header.disc_table[0] != 0;
 }
 
+bool WbfsFileReader::ReadNKitHeader()
+{
+  const u64 gap_type_blocks = (DL_DVD_SIZE + m_wbfs_sector_size - 1) / m_wbfs_sector_size;
+  m_nkit_info = NKit::ReadHeaderFromFile(m_files[0].file, NKit::HEADER_OFFSET, gap_type_blocks);
+  if (!m_nkit_info.valid)
+    return false;
+
+  m_has_nkit_header = true;
+  return true;
+}
+
+bool WbfsFileReader::IsBlockStored(u64 block_index) const
+{
+  return block_index < m_blocks_per_disc && m_wlba_table[block_index] != 0;
+}
+
+bool WbfsFileReader::IsGapJunk(u64 block_index) const
+{
+  return NKit::IsGapJunk(m_nkit_info.gap_type, block_index);
+}
+
+void WbfsFileReader::GenerateJunkData(u64 disc_offset, std::span<u8> out) const
+{
+  LaggedFibonacciGenerator::FillJunkData(out, disc_offset, m_disc_id, m_disc_num);
+}
+
+void WbfsFileReader::ReadPartitionInfo()
+{
+  std::unique_ptr<VolumeDisc> volume = CreateDisc(CopyReader());
+  if (!volume)
+    return;
+
+  for (const Partition& partition : volume->GetPartitions())
+  {
+    const auto& ticket = volume->GetTicket(partition);
+
+    u8 data_info[8];
+    if (!Read(partition.offset + 0x2B8, 8, data_info))
+      continue;
+
+    PartitionEntry entry;
+    entry.data_offset = partition.offset + (static_cast<u64>(Common::swap32(data_info)) << 2);
+    entry.data_size = static_cast<u64>(Common::swap32(data_info + 4)) << 2;
+    entry.key = ticket.GetTitleKey();
+    m_partitions.push_back(entry);
+  }
+}
+
+const WbfsFileReader::PartitionEntry* WbfsFileReader::FindPartition(u64 disc_offset) const
+{
+  for (const auto& p : m_partitions)
+  {
+    if (disc_offset >= p.data_offset && disc_offset < p.data_offset + p.data_size)
+      return &p;
+  }
+  return nullptr;
+}
+
+bool WbfsFileReader::SupportsReadWiiDecrypted(u64 offset, u64 size, u64 partition_data_offset) const
+{
+  if (!m_has_nkit_header)
+    return false;
+
+  const u64 block_in_partition = offset / VolumeWii::BLOCK_DATA_SIZE;
+  const u64 disc_offset = partition_data_offset + block_in_partition * VolumeWii::BLOCK_TOTAL_SIZE;
+  const u64 wbfs_block = disc_offset >> m_header.wbfs_sector_shift;
+
+  return wbfs_block < m_blocks_per_disc && !IsBlockStored(wbfs_block);
+}
+
+bool WbfsFileReader::ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr, u64 partition_data_offset,
+                                      Common::AES::Context* aes_context)
+{
+  std::vector<u8> encrypted(VolumeWii::BLOCK_TOTAL_SIZE);
+
+  while (size > 0)
+  {
+    const u64 block_in_partition = offset / VolumeWii::BLOCK_DATA_SIZE;
+    const u64 offset_in_block = offset % VolumeWii::BLOCK_DATA_SIZE;
+    const u64 bytes_in_block = VolumeWii::BLOCK_DATA_SIZE - offset_in_block;
+    const size_t read_size = static_cast<size_t>(std::min(bytes_in_block, size));
+
+    const u64 disc_offset =
+        partition_data_offset + block_in_partition * VolumeWii::BLOCK_TOTAL_SIZE;
+    const u64 wbfs_block = disc_offset >> m_header.wbfs_sector_shift;
+
+    if (IsBlockStored(wbfs_block))
+    {
+      // Stored blocks need decryption. This path is reachable even with standard 2MiB
+      // WBFS sectors because partition data may not start at a sector-aligned offset,
+      // causing an encryption group to straddle two WBFS blocks.
+      u64 available;
+      auto& file = SeekToCluster(disc_offset, &available);
+      if (available < VolumeWii::BLOCK_TOTAL_SIZE ||
+          !file.Read(encrypted.data(), VolumeWii::BLOCK_TOTAL_SIZE))
+        return false;
+      if (offset_in_block == 0 && read_size == VolumeWii::BLOCK_DATA_SIZE)
+      {
+        VolumeWii::DecryptBlockData(encrypted.data(), out_ptr, aes_context);
+      }
+      else
+      {
+        u8 decrypted[VolumeWii::BLOCK_DATA_SIZE];
+        VolumeWii::DecryptBlockData(encrypted.data(), decrypted, aes_context);
+        std::memcpy(out_ptr, decrypted + offset_in_block, read_size);
+      }
+    }
+    else if (IsGapJunk(wbfs_block))
+    {
+      const u64 junk_offset = block_in_partition * VolumeWii::BLOCK_DATA_SIZE + offset_in_block;
+      LaggedFibonacciGenerator::FillJunkData({out_ptr, read_size}, junk_offset, m_disc_id,
+                                             m_disc_num);
+    }
+    else
+    {
+      std::memset(out_ptr, 0, read_size);
+    }
+
+    out_ptr += read_size;
+    offset += read_size;
+    size -= read_size;
+  }
+  return true;
+}
+
 bool WbfsFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 {
   if (offset + nbytes > GetDataSize())
@@ -126,15 +276,52 @@ bool WbfsFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 
   while (nbytes)
   {
-    u64 read_size;
-    auto& data_file = SeekToCluster(offset, &read_size);
-    if (read_size == 0)
-      return false;
-    read_size = std::min(read_size, nbytes);
+    const u64 base_cluster = offset >> m_header.wbfs_sector_shift;
+    const u64 cluster_offset = offset & (m_wbfs_sector_size - 1);
+    const u64 bytes_in_cluster = m_wbfs_sector_size - cluster_offset;
+    u64 read_size = std::min(bytes_in_cluster, nbytes);
 
-    if (!data_file.Read(out_ptr, read_size))
+    if (base_cluster >= m_blocks_per_disc || !IsBlockStored(base_cluster))
     {
-      return false;
+      if (m_has_nkit_header && base_cluster < m_blocks_per_disc)
+      {
+        const PartitionEntry* pe = FindPartition(offset);
+        if (pe)
+        {
+          // Non-stored partition sectors need re-encryption via WiiEncryptionCache
+          const u64 partition_offset = offset - pe->data_offset;
+          const u64 partition_data_decrypted_size =
+              pe->data_size / VolumeWii::BLOCK_TOTAL_SIZE * VolumeWii::BLOCK_DATA_SIZE;
+          if (!m_encryption_cache.EncryptGroups(partition_offset, read_size, out_ptr,
+                                                pe->data_offset, partition_data_decrypted_size,
+                                                pe->key))
+          {
+            std::memset(out_ptr, 0, static_cast<size_t>(read_size));
+          }
+        }
+        else if (IsGapJunk(base_cluster))
+        {
+          GenerateJunkData(offset, {out_ptr, read_size});
+        }
+        else
+        {
+          std::memset(out_ptr, 0, static_cast<size_t>(read_size));
+        }
+      }
+      else
+      {
+        std::memset(out_ptr, 0, static_cast<size_t>(read_size));
+      }
+    }
+    else
+    {
+      u64 available;
+      auto& data_file = SeekToCluster(offset, &available);
+      if (available == 0)
+        return false;
+      read_size = std::min(read_size, available);
+      if (!data_file.Read(out_ptr, read_size))
+        return false;
     }
 
     out_ptr += read_size;
@@ -186,7 +373,11 @@ std::unique_ptr<WbfsFileReader> WbfsFileReader::Create(File::DirectIOFile file,
   if (!reader->IsGood())
     reader.reset();
 
+  if (reader && reader->m_has_nkit_header)
+    reader->ReadPartitionInfo();
+
   return reader;
 }
+
 
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -26,7 +26,7 @@
 #include "Common/Swap.h"
 #include "DiscIO/DiscUtils.h"
 #include "DiscIO/LaggedFibonacciGenerator.h"
-#include "DiscIO/NKitHeader.h"
+#include "DiscIO/NKitv2Header.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeWii.h"
 
@@ -147,7 +147,7 @@ bool WbfsFileReader::ReadHeader()
 bool WbfsFileReader::ReadNKitHeader()
 {
   const u64 gap_type_blocks = (DL_DVD_SIZE + m_wbfs_sector_size - 1) / m_wbfs_sector_size;
-  m_nkit_info = NKit::ReadHeaderFromFile(m_files[0].file, NKit::HEADER_OFFSET, gap_type_blocks);
+  m_nkit_info = NKitv2::ReadHeaderFromFile(m_files[0].file, NKitv2::HEADER_OFFSET, gap_type_blocks);
   if (!m_nkit_info.valid)
     return false;
 
@@ -162,7 +162,7 @@ bool WbfsFileReader::IsBlockStored(u64 block_index) const
 
 bool WbfsFileReader::IsGapJunk(u64 block_index) const
 {
-  return NKit::IsGapJunk(m_nkit_info.gap_type, block_index);
+  return NKitv2::IsGapJunk(m_nkit_info.gap_type, block_index);
 }
 
 void WbfsFileReader::GenerateJunkData(u64 disc_offset, std::span<u8> out) const
@@ -632,9 +632,9 @@ bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
     return write_failed_panic();
 
   // Write NKit v2 header at offset 0x10000 for lossless round-trip.
-  NKit::Info nkit_info;
-  nkit_info.flags = NKit::Flags::Size | NKit::Flags::Crc32 | NKit::Flags::Md5 | NKit::Flags::Sha1 |
-                    NKit::Flags::XxHash64;
+  NKitv2::Info nkit_info;
+  nkit_info.flags = NKitv2::Flags::Size | NKitv2::Flags::Crc32 | NKitv2::Flags::Md5 | NKitv2::Flags::Sha1 |
+                    NKitv2::Flags::XxHash64;
   nkit_info.digests.disc_size = disc_size;
   nkit_info.digests.crc32 = crc;
   mbedtls_md5_finish_ret(&md5_ctx, nkit_info.digests.md5.data());
@@ -642,7 +642,7 @@ bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
   nkit_info.digests.xxhash64 = xxh_digest;
   nkit_info.gap_type = std::move(gap_type);
 
-  if (!NKit::WriteHeader(outfile, NKit::HEADER_OFFSET, nkit_info))
+  if (!NKitv2::WriteHeader(outfile, NKitv2::HEADER_OFFSET, nkit_info))
     return write_failed_panic();
 
   file_cleanup.Dismiss();

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -379,5 +379,274 @@ std::unique_ptr<WbfsFileReader> WbfsFileReader::Create(File::DirectIOFile file,
   return reader;
 }
 
+// Converts any disc image to WBFS with an NKit v2 header for lossless round-trips.
+// Strips disc-level junk and partition-level junk (encrypted sectors whose decrypted
+// content is zero or LFG padding), records a junk bitmap for reconstruction.
+// See: https://github.com/dolphin-emu/dolphin/pull/14731
+bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
+                   const std::string& outfile_path, const CompressCB& callback)
+{
+  ASSERT(infile->GetDataSizeType() == DataSizeType::Accurate ||
+         infile->GetDataSizeType() == DataSizeType::UpperBound);
+
+  File::DirectIOFile outfile(outfile_path, File::AccessMode::Write);
+  if (!outfile.IsOpen())
+  {
+    PanicAlertFmtT(
+        "Failed to open the output file \"{0}\".\n"
+        "Check that you have permissions to write the target folder and that the media can "
+        "be written.",
+        outfile_path);
+    return false;
+  }
+
+  const u64 disc_size = infile->GetDataSize();
+
+  // These match the values used by standard WBFS tools (wwt, WBFS Manager)
+  static constexpr u8 hd_sector_shift = 9;
+  static constexpr u8 wbfs_sector_shift = 21;
+  static constexpr u64 hd_sector_size = 1ull << hd_sector_shift;
+  static constexpr u64 wbfs_sector_size = 1ull << wbfs_sector_shift;
+
+  const u64 blocks_per_disc = (disc_size + wbfs_sector_size - 1) / wbfs_sector_size;
+  const u64 disc_info_size =
+      Common::AlignUp(WII_DISC_HEADER_SIZE + blocks_per_disc * sizeof(u16), hd_sector_size);
+
+  // Read disc header (first 256 bytes contain disc_id, disc_num, title, etc.)
+  std::vector<u8> disc_header(WII_DISC_HEADER_SIZE, 0);
+  if (!infile->Read(0, WII_DISC_HEADER_SIZE, disc_header.data()))
+  {
+    PanicAlertFmtT("Failed to read from the input file \"{0}\".", infile_path);
+    return false;
+  }
+
+  // Use Volume for partition info and decrypted reads
+  struct PartitionInfo
+  {
+    u64 data_offset;
+    u64 data_size;
+    Partition partition;
+  };
+  std::vector<PartitionInfo> partitions;
+
+  std::unique_ptr<VolumeDisc> volume = CreateDisc(infile_path);
+  if (volume)
+  {
+    for (const Partition& partition : volume->GetPartitions())
+    {
+      const std::optional<u64> data_offset =
+          volume->ReadSwappedAndShifted(partition.offset + 0x2B8, PARTITION_NONE);
+      const std::optional<u64> data_size =
+          volume->ReadSwappedAndShifted(partition.offset + 0x2BC, PARTITION_NONE);
+      if (!data_offset || !data_size)
+        continue;
+
+      PartitionInfo info;
+      info.data_offset = partition.offset + *data_offset;
+      info.data_size = *data_size;
+      info.partition = partition;
+      partitions.push_back(info);
+    }
+  }
+
+  // NKit v2 gap type bitmap: 1 bit per block, MSB-first, always sized for dual-layer
+  const u64 gap_type_blocks = (DL_DVD_SIZE + wbfs_sector_size - 1) / wbfs_sector_size;
+  const u64 gap_type_bytes = (gap_type_blocks + 7) / 8;
+  std::vector<u8> gap_type(gap_type_bytes, 0);
+
+  // Compute data_start up front so we can write sectors during the scan
+  const u64 data_start = Common::AlignUp(hd_sector_size + disc_info_size, wbfs_sector_size);
+  const u16 wlba_base = static_cast<u16>(data_start / wbfs_sector_size);
+
+  // Single pass: scan, classify, hash, and write used sectors in one loop
+  std::vector<u8> sector_buf(wbfs_sector_size, 0);
+  std::vector<u16> wlba_table(blocks_per_disc, 0);
+  u16 used_count = 0;
+  u16 zero_block_wlba = 0;  // Dedup: wlba of first stored all-zero ciphertext block
+
+  // NKit v2 stores four hash digests for verification
+  auto sha1_ctx = Common::SHA1::CreateContext();
+  u32 crc = Common::StartCRC32();
+  mbedtls_md5_context md5_ctx{};
+  mbedtls_md5_init(&md5_ctx);
+  mbedtls_md5_starts_ret(&md5_ctx);
+  XXH64_state_t* xxh_state = XXH64_createState();
+  XXH64_reset(xxh_state, 0);
+
+  auto hash_cleanup = Common::ScopeGuard([&] {
+    XXH64_freeState(xxh_state);
+    mbedtls_md5_free(&md5_ctx);
+  });
+
+  auto file_cleanup = Common::ScopeGuard([&] {
+    outfile.Close();
+    File::Delete(outfile_path);
+  });
+
+  const auto write_failed_panic = [&] {
+    PanicAlertFmtT("Failed to write the output file \"{0}\".\n"
+                   "Check that you have enough space available on the target drive.",
+                   outfile_path);
+    return false;
+  };
+
+  outfile.Seek(data_start, File::SeekOrigin::Begin);
+
+  for (u64 i = 0; i < blocks_per_disc; i++)
+  {
+    if (i % 100 == 0)
+    {
+      const bool was_cancelled =
+          !callback(Common::GetStringT("Converting"),
+                    static_cast<float>(i) / static_cast<float>(blocks_per_disc));
+      if (was_cancelled)
+        return false;
+    }
+
+    const u64 offset = i * wbfs_sector_size;
+    const size_t sz = static_cast<size_t>(std::min(wbfs_sector_size, disc_size - offset));
+
+    if (!infile->Read(offset, sz, sector_buf.data()))
+    {
+      PanicAlertFmtT("Failed to read from the input file \"{0}\".", infile_path);
+      return false;
+    }
+
+    // Update all four hashes with the full disc data
+    sha1_ctx->Update(sector_buf.data(), sz);
+    crc = Common::UpdateCRC32(crc, sector_buf.data(), sz);
+    mbedtls_md5_update_ret(&md5_ctx, sector_buf.data(), sz);
+    XXH64_update(xxh_state, sector_buf.data(), sz);
+
+    // Find which partition (if any) this block belongs to
+    const auto pi = std::ranges::find_if(partitions, [&](const PartitionInfo& p) {
+      return offset >= p.data_offset && (offset + sz) <= (p.data_offset + p.data_size);
+    });
+
+    bool is_used = true;
+
+    if (pi != partitions.end())
+    {
+      // Partition data: use Volume::Read to get decrypted data for junk/zero checks.
+      // All-zero and all-junk are checked separately - mixed blocks are stored.
+      bool all_zero = true;
+      bool all_junk = true;
+      for (u64 sub = 0; sub < sz; sub += VolumeWii::BLOCK_TOTAL_SIZE)
+      {
+        const u64 abs = offset + sub;
+        const u64 sector_in_partition = (abs - pi->data_offset) / VolumeWii::BLOCK_TOTAL_SIZE;
+        const u64 partition_offset = sector_in_partition * VolumeWii::BLOCK_DATA_SIZE;
+
+        u8 decrypted[VolumeWii::BLOCK_DATA_SIZE];
+        if (!volume->Read(partition_offset, VolumeWii::BLOCK_DATA_SIZE, decrypted, pi->partition))
+          break;
+
+        const bool sector_zero = std::ranges::all_of(decrypted, [](u8 b) { return b == 0; });
+        if (!sector_zero)
+        {
+          all_zero = false;
+          const bool sector_junk = LaggedFibonacciGenerator::IsJunkBlock(
+              decrypted, VolumeWii::BLOCK_DATA_SIZE, partition_offset, disc_header.data(),
+              disc_header[6]);
+          if (!sector_junk)
+            all_junk = false;
+        }
+
+        if (!all_zero && !all_junk)
+          break;
+      }
+
+      if (all_zero || all_junk)
+      {
+        if (all_junk && !all_zero)
+          gap_type[i / 8] |= static_cast<u8>(1 << (7 - (i & 7)));
+        is_used = false;
+      }
+    }
+    else
+    {
+      // Non-partition data: check disc-level zero and junk patterns
+      const bool is_zero = std::ranges::all_of(sector_buf, [](u8 b) { return b == 0; });
+      if (is_zero)
+      {
+        is_used = false;
+      }
+      else if (LaggedFibonacciGenerator::IsJunkBlock(sector_buf.data(), sz, offset,
+                                                     disc_header.data(), disc_header[6]))
+      {
+        gap_type[i / 8] |= static_cast<u8>(1 << (7 - (i & 7)));
+        is_used = false;
+      }
+    }
+
+    if (is_used)
+    {
+      // Store one copy of all-zero blocks and reuse the wlba entry for duplicates.
+      const bool raw_zero = std::ranges::all_of(sector_buf.begin(), sector_buf.begin() + sz,
+                                                [](u8 b) { return b == 0; });
+
+      if (raw_zero && zero_block_wlba != 0)
+      {
+        wlba_table[i] = zero_block_wlba;
+      }
+      else
+      {
+        std::fill(sector_buf.begin() + sz, sector_buf.end(), u8{0});
+        if (!outfile.Write(sector_buf.data(), wbfs_sector_size))
+          return write_failed_panic();
+
+        wlba_table[i] = Common::swap16(static_cast<u16>(wlba_base + used_count));
+
+        if (raw_zero && zero_block_wlba == 0)
+          zero_block_wlba = wlba_table[i];
+
+        used_count++;
+      }
+    }
+  }
+
+  // Finalize hashes
+  const Common::SHA1::Digest sha1_digest = sha1_ctx->Finish();
+  const u64 xxh_digest = XXH64_digest(xxh_state);
+
+  // Write WBFS header (seek back to start)
+  const u64 total_size = data_start + static_cast<u64>(used_count) * wbfs_sector_size;
+  const u32 hd_sector_count = static_cast<u32>(total_size / hd_sector_size);
+
+  WbfsHeader header{};
+  header.magic = WBFS_MAGIC;
+  header.hd_sector_count = Common::swap32(hd_sector_count);
+  header.hd_sector_shift = hd_sector_shift;
+  header.wbfs_sector_shift = wbfs_sector_shift;
+  header.disc_table[0] = 1;
+
+  outfile.Seek(0, File::SeekOrigin::Begin);
+  if (!outfile.Write(Common::AsU8Span(header)))
+    return write_failed_panic();
+
+  // Write disc info at offset hd_sector_size: disc header + wlba table
+  outfile.Seek(hd_sector_size, File::SeekOrigin::Begin);
+  if (!outfile.Write(disc_header.data(), WII_DISC_HEADER_SIZE))
+    return write_failed_panic();
+  if (!outfile.Write(Common::AsU8Span(wlba_table)))
+    return write_failed_panic();
+
+  // Write NKit v2 header at offset 0x10000 for lossless round-trip.
+  NKit::Info nkit_info;
+  nkit_info.flags = NKit::Flags::Size | NKit::Flags::Crc32 | NKit::Flags::Md5 | NKit::Flags::Sha1 |
+                    NKit::Flags::XxHash64;
+  nkit_info.digests.disc_size = disc_size;
+  nkit_info.digests.crc32 = crc;
+  mbedtls_md5_finish_ret(&md5_ctx, nkit_info.digests.md5.data());
+  nkit_info.digests.sha1 = sha1_digest;
+  nkit_info.digests.xxhash64 = xxh_digest;
+  nkit_info.gap_type = std::move(gap_type);
+
+  if (!NKit::WriteHeader(outfile, NKit::HEADER_OFFSET, nkit_info))
+    return write_failed_panic();
+
+  file_cleanup.Dismiss();
+  return true;
+}
 
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -57,8 +57,6 @@ WbfsFileReader::WbfsFileReader(File::DirectIOFile file, const std::string& path)
   }
 
   // Grab disc info (assume slot 0, checked in ReadHeader())
-  // TODO: Multi-disc WBFS support (disc_table can hold up to 500 entries).
-  // Offset would be: m_hd_sector_size + WII_DISC_HEADER_SIZE + i * m_disc_info_size
   m_wlba_table.resize(m_blocks_per_disc);
   m_files[0].file.Seek(m_hd_sector_size + WII_DISC_HEADER_SIZE, File::SeekOrigin::Begin);
   m_files[0].file.Read(Common::AsWritableU8Span(m_wlba_table));
@@ -163,11 +161,6 @@ bool WbfsFileReader::IsBlockStored(u64 block_index) const
 bool WbfsFileReader::IsGapJunk(u64 block_index) const
 {
   return NKitv2::IsGapJunk(m_nkit_info.gap_type, block_index);
-}
-
-void WbfsFileReader::GenerateJunkData(u64 disc_offset, std::span<u8> out) const
-{
-  LaggedFibonacciGenerator::FillJunkData(out, disc_offset, m_disc_id, m_disc_num);
 }
 
 void WbfsFileReader::ReadPartitionInfo()
@@ -301,7 +294,7 @@ bool WbfsFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
         }
         else if (IsGapJunk(base_cluster))
         {
-          GenerateJunkData(offset, {out_ptr, read_size});
+          LaggedFibonacciGenerator::FillJunkData({out_ptr, read_size}, offset, m_disc_id, m_disc_num);
         }
         else
         {

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -372,10 +372,9 @@ std::unique_ptr<WbfsFileReader> WbfsFileReader::Create(File::DirectIOFile file,
   return reader;
 }
 
-// Converts any disc image to WBFS with an NKit v2 header for lossless round-trips.
+// Converts any disc image to lossless WBFS with an NKitv2 header.
 // Strips disc-level junk and partition-level junk (encrypted sectors whose decrypted
 // content is zero or LFG padding), records a junk bitmap for reconstruction.
-// See: https://github.com/dolphin-emu/dolphin/pull/14731
 bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
                    const std::string& outfile_path, const CompressCB& callback)
 {
@@ -392,6 +391,11 @@ bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
         outfile_path);
     return false;
   }
+
+  auto file_cleanup = Common::ScopeGuard([&] {
+    outfile.Close();
+    File::Delete(outfile_path);
+  });
 
   const u64 disc_size = infile->GetDataSize();
 
@@ -451,7 +455,6 @@ bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
   const u64 data_start = Common::AlignUp(hd_sector_size + disc_info_size, wbfs_sector_size);
   const u16 wlba_base = static_cast<u16>(data_start / wbfs_sector_size);
 
-  // Single pass: scan, classify, hash, and write used sectors in one loop
   std::vector<u8> sector_buf(wbfs_sector_size, 0);
   std::vector<u16> wlba_table(blocks_per_disc, 0);
   u16 used_count = 0;
@@ -469,11 +472,6 @@ bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
   auto hash_cleanup = Common::ScopeGuard([&] {
     XXH64_freeState(xxh_state);
     mbedtls_md5_free(&md5_ctx);
-  });
-
-  auto file_cleanup = Common::ScopeGuard([&] {
-    outfile.Close();
-    File::Delete(outfile_path);
   });
 
   const auto write_failed_panic = [&] {
@@ -520,19 +518,21 @@ bool ConvertToWBFS(BlobReader* infile, const std::string& infile_path,
 
     if (pi != partitions.end())
     {
-      // Partition data: use Volume::Read to get decrypted data for junk/zero checks.
-      // All-zero and all-junk are checked separately - mixed blocks are stored.
       bool all_zero = true;
       bool all_junk = true;
       for (u64 sub = 0; sub < sz; sub += VolumeWii::BLOCK_TOTAL_SIZE)
       {
         const u64 abs = offset + sub;
-        const u64 sector_in_partition = (abs - pi->data_offset) / VolumeWii::BLOCK_TOTAL_SIZE;
-        const u64 partition_offset = sector_in_partition * VolumeWii::BLOCK_DATA_SIZE;
+        const u64 block_in_partition = (abs - pi->data_offset) / VolumeWii::BLOCK_TOTAL_SIZE;
+        const u64 partition_offset = block_in_partition * VolumeWii::BLOCK_DATA_SIZE;
 
         u8 decrypted[VolumeWii::BLOCK_DATA_SIZE];
         if (!volume->Read(partition_offset, VolumeWii::BLOCK_DATA_SIZE, decrypted, pi->partition))
+        {
+          all_zero = false;
+          all_junk = false;
           break;
+        }
 
         const bool sector_zero = std::ranges::all_of(decrypted, [](u8 b) { return b == 0; });
         if (!sector_zero)

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -3,17 +3,34 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/DirectIOFile.h"
 #include "DiscIO/Blob.h"
+#include "DiscIO/NKitHeader.h"
+#include "DiscIO/VolumeWii.h"
+#include "DiscIO/WiiEncryptionCache.h"
 
 namespace DiscIO
 {
 static constexpr u32 WBFS_MAGIC = 0x53464257;  // "WBFS" (byteswapped to little endian)
+
+#pragma pack(1)
+struct WbfsHeader
+{
+  u32 magic;
+  u32 hd_sector_count;
+  u8 hd_sector_shift;
+  u8 wbfs_sector_shift;
+  u8 padding[2];
+  u8 disc_table[500];
+};
+#pragma pack()
 
 class WbfsFileReader final : public BlobReader
 {
@@ -27,7 +44,10 @@ public:
 
   u64 GetRawSize() const override { return m_size; }
   u64 GetDataSize() const override;
-  DataSizeType GetDataSizeType() const override { return DataSizeType::UpperBound; }
+  DataSizeType GetDataSizeType() const override
+  {
+    return m_has_nkit_header ? DataSizeType::Accurate : DataSizeType::UpperBound;
+  }
 
   u64 GetBlockSize() const override { return m_wbfs_sector_size; }
   bool HasFastRandomAccessInBlock() const override { return true; }
@@ -35,6 +55,9 @@ public:
   std::optional<int> GetCompressionLevel() const override { return std::nullopt; }
 
   bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;
+  bool SupportsReadWiiDecrypted(u64 offset, u64 size, u64 partition_data_offset) const override;
+  bool ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr, u64 partition_data_offset,
+                        Common::AES::Context* aes_context = nullptr) override;
 
 private:
   WbfsFileReader(File::DirectIOFile file, const std::string& path = "");
@@ -42,6 +65,20 @@ private:
   void OpenAdditionalFiles(const std::string& path);
   bool AddFileToList(File::DirectIOFile file);
   bool ReadHeader();
+  bool ReadNKitHeader();
+  void ReadPartitionInfo();
+  bool IsBlockStored(u64 block_index) const;
+  bool IsGapJunk(u64 block_index) const;
+  void GenerateJunkData(u64 disc_offset, std::span<u8> out) const;
+
+  struct PartitionEntry
+  {
+    u64 data_offset;
+    u64 data_size;
+    // Needed by Read() -> EncryptGroups for non-stored block reconstruction
+    std::array<u8, 16> key;
+  };
+  const PartitionEntry* FindPartition(u64 disc_offset) const;
 
   File::DirectIOFile& SeekToCluster(u64 offset, u64* available);
   bool IsGood() const { return m_good; }
@@ -63,25 +100,24 @@ private:
 
   u64 m_hd_sector_size;
   u64 m_wbfs_sector_size;
-  u64 m_wbfs_sector_count;
   u64 m_disc_info_size;
 
-#pragma pack(1)
-  struct WbfsHeader
-  {
-    u32 magic;
-    u32 hd_sector_count;
-    u8 hd_sector_shift;
-    u8 wbfs_sector_shift;
-    u8 padding[2];
-    u8 disc_table[500];
-  } m_header;
-#pragma pack()
+  WbfsHeader m_header;
 
   std::vector<u16> m_wlba_table;
   u64 m_blocks_per_disc;
 
   bool m_good;
+
+  // NKit v2 header for lossless round-trip
+  NKit::Info m_nkit_info;
+  bool m_has_nkit_header = false;
+  u8 m_disc_id[4] = {};
+  u8 m_disc_num = 0;
+
+  // Partition info for encrypted junk reconstruction
+  std::vector<PartitionEntry> m_partitions;
+  WiiEncryptionCache m_encryption_cache;
 };
 
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -12,7 +12,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/DirectIOFile.h"
 #include "DiscIO/Blob.h"
-#include "DiscIO/NKitHeader.h"
+#include "DiscIO/NKitv2Header.h"
 #include "DiscIO/VolumeWii.h"
 #include "DiscIO/WiiEncryptionCache.h"
 
@@ -110,7 +110,7 @@ private:
   bool m_good;
 
   // NKit v2 header for lossless round-trip
-  NKit::Info m_nkit_info;
+  NKitv2::Info m_nkit_info;
   bool m_has_nkit_header = false;
   u8 m_disc_id[4] = {};
   u8 m_disc_num = 0;

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -69,7 +69,6 @@ private:
   void ReadPartitionInfo();
   bool IsBlockStored(u64 block_index) const;
   bool IsGapJunk(u64 block_index) const;
-  void GenerateJunkData(u64 disc_offset, std::span<u8> out) const;
 
   struct PartitionEntry
   {

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -72,9 +72,9 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
   auto* const convert_button = new QPushButton(tr("Convert..."));
 
   m_lossy_warning = new QLabel(
-      tr("Warning: This file does not contain verification data. Some disc data may have been lost "
+      tr("Warning: This file uses a lossy format. Some disc data may have been lost "
          "during the original conversion, so the result will not be an exact copy of the original "
-         "disc. The converted file will still work fine for playing games."));
+         "disc. This won't affect your ability to play the game."));
   m_lossy_warning->setWordWrap(true);
   m_lossy_warning->setStyleSheet(QStringLiteral("color: red; font-weight: bold;"));
   m_lossy_warning->setVisible(std::ranges::any_of(m_files, [](const auto& file) {
@@ -92,9 +92,8 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
          "data (unless removed).\n\n"
          "RVZ: An advanced compressed format which is compatible with Dolphin 5.0-12188 and later. "
          "It can efficiently compress both junk data and encrypted Wii data.\n\n"
-         "WBFS: NKit v2 WBFS, a lossless variant that strips unused disc sectors "
-         "and stores verification data for perfect round-trips. Compatible with USB loaders on a "
-         "real Wii."));
+         "WBFS: A block-mapped format that strips unused disc sectors to save space. "
+         "Compatible with real Wiis."));
   info_text->setWordWrap(true);
   info_text->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
@@ -316,7 +315,7 @@ void ConvertDialog::Convert()
       }))
   {
     if (!ShowAreYouSureDialog(tr("Converting a GameCube disc to WBFS will produce a valid WBFS "
-                                 "file but is not playable on a real Wii. "
+                                 "file, but the result is not playable on a real Wii. "
                                  "Do you want to continue anyway?")))
     {
       return;
@@ -463,7 +462,7 @@ void ConvertDialog::Convert()
     std::unique_ptr<DiscIO::BlobReader> blob_reader;
     bool scrub_current_file = scrub;
 
-    // WBFS conversion computes hashes over the original disc data
+    // WBFS already strips unused sectors, so scrubbing is redundant
     if (format == DiscIO::BlobType::WBFS)
       scrub_current_file = false;
 

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -48,6 +48,7 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
   m_format->addItem(QStringLiteral("ISO"), static_cast<int>(DiscIO::BlobType::PLAIN));
   m_format->addItem(QStringLiteral("GCZ"), static_cast<int>(DiscIO::BlobType::GCZ));
   m_format->addItem(QStringLiteral("WIA"), static_cast<int>(DiscIO::BlobType::WIA));
+  m_format->addItem(QStringLiteral("WBFS"), static_cast<int>(DiscIO::BlobType::WBFS));
   m_format->addItem(QStringLiteral("RVZ"), static_cast<int>(DiscIO::BlobType::RVZ));
   if (std::ranges::all_of(
           m_files, [](const auto& file) { return file->GetBlobType() == DiscIO::BlobType::PLAIN; }))
@@ -70,6 +71,16 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
 
   auto* const convert_button = new QPushButton(tr("Convert..."));
 
+  m_lossy_warning = new QLabel(
+      tr("Warning: This file does not contain verification data. Some disc data may have been lost "
+         "during the original conversion, so the result will not be an exact copy of the original "
+         "disc. The converted file will still work fine for playing games."));
+  m_lossy_warning->setWordWrap(true);
+  m_lossy_warning->setStyleSheet(QStringLiteral("color: red; font-weight: bold;"));
+  m_lossy_warning->setVisible(std::ranges::any_of(m_files, [](const auto& file) {
+    return file->GetVolumeSizeType() == DiscIO::DataSizeType::UpperBound;
+  }));
+
   auto* const info_text = new QLabel(
       tr("ISO: A simple and robust format which is supported by many programs. It takes up more "
          "space than any other format.\n\n"
@@ -80,7 +91,10 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
          "and a few other programs. It can efficiently compress encrypted Wii data, but not junk "
          "data (unless removed).\n\n"
          "RVZ: An advanced compressed format which is compatible with Dolphin 5.0-12188 and later. "
-         "It can efficiently compress both junk data and encrypted Wii data."));
+         "It can efficiently compress both junk data and encrypted Wii data.\n\n"
+         "WBFS: NKit v2 WBFS, a lossless variant that strips unused disc sectors "
+         "and stores verification data for perfect round-trips. Compatible with USB loaders on a "
+         "real Wii."));
   info_text->setWordWrap(true);
   info_text->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
@@ -95,6 +109,7 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
 
   auto* const main_layout = new QVBoxLayout{this};
   main_layout->addWidget(options_group);
+  main_layout->addWidget(m_lossy_warning);
   main_layout->addWidget(info_group, 1);
 
   connect(m_format, &QComboBox::currentIndexChanged, this, &ConvertDialog::OnFormatChanged);
@@ -236,8 +251,9 @@ void ConvertDialog::OnFormatChanged()
   m_block_size->setEnabled(m_block_size->count() > 1);
   m_compression->setEnabled(m_compression->count() > 1);
 
-  // Block scrubbing of RVZ containers and Datel discs
+  // Block scrubbing of RVZ containers, WBFS, and Datel discs
   const bool scrubbing_allowed = format != DiscIO::BlobType::RVZ &&
+                                 format != DiscIO::BlobType::WBFS &&
                                  std::ranges::none_of(m_files, &UICommon::GameFile::IsDatelDisc);
 
   m_scrub->setEnabled(scrubbing_allowed);
@@ -295,6 +311,18 @@ void ConvertDialog::Convert()
     }
   }
 
+  if (format == DiscIO::BlobType::WBFS && std::ranges::any_of(m_files, [](const auto& file) {
+        return file->GetPlatform() == DiscIO::Platform::GameCubeDisc;
+      }))
+  {
+    if (!ShowAreYouSureDialog(tr("Converting a GameCube disc to WBFS will produce a valid WBFS "
+                                 "file but is not playable on a real Wii. "
+                                 "Do you want to continue anyway?")))
+    {
+      return;
+    }
+  }
+
   if (!scrub && format == DiscIO::BlobType::GCZ &&
       std::ranges::any_of(m_files, [](const auto& file) {
         return file->GetPlatform() == DiscIO::Platform::WiiDisc && !file->IsDatelDisc();
@@ -342,6 +370,10 @@ void ConvertDialog::Convert()
   case DiscIO::BlobType::RVZ:
     extension = QStringLiteral(".rvz");
     filter = tr("RVZ GC/Wii images (*.rvz)");
+    break;
+  case DiscIO::BlobType::WBFS:
+    extension = QStringLiteral(".wbfs");
+    filter = tr("WBFS Wii images (*.wbfs)");
     break;
   default:
     ASSERT(false);
@@ -431,6 +463,10 @@ void ConvertDialog::Convert()
     std::unique_ptr<DiscIO::BlobReader> blob_reader;
     bool scrub_current_file = scrub;
 
+    // WBFS conversion computes hashes over the original disc data
+    if (format == DiscIO::BlobType::WBFS)
+      scrub_current_file = false;
+
     if (scrub_current_file)
     {
       blob_reader = DiscIO::ScrubbedBlob::Create(original_path);
@@ -497,6 +533,15 @@ void ConvertDialog::Convert()
               DiscIO::ConvertToWIAOrRVZ(blob_reader.get(), original_path, dst_path.toStdString(),
                                         format == DiscIO::BlobType::RVZ, compression,
                                         compression_level, block_size, callback);
+          progress_dialog.Reset();
+          return good;
+        });
+        break;
+
+      case DiscIO::BlobType::WBFS:
+        success = std::async(std::launch::async, [&] {
+          const bool good = DiscIO::ConvertToWBFS(blob_reader.get(), original_path,
+                                                  dst_path.toStdString(), callback);
           progress_dialog.Reset();
           return good;
         });

--- a/Source/Core/DolphinQt/ConvertDialog.h
+++ b/Source/Core/DolphinQt/ConvertDialog.h
@@ -12,6 +12,7 @@
 
 class QCheckBox;
 class QComboBox;
+class QLabel;
 
 namespace DiscIO
 {
@@ -48,5 +49,6 @@ private:
   QComboBox* m_compression;
   QComboBox* m_compression_level;
   QCheckBox* m_scrub;
+  QLabel* m_lossy_warning;
   QList<std::shared_ptr<const UICommon::GameFile>> m_files;
 };

--- a/Source/Core/DolphinTool/ConvertCommand.cpp
+++ b/Source/Core/DolphinTool/ConvertCommand.cpp
@@ -51,6 +51,8 @@ static std::optional<DiscIO::BlobType> ParseFormatString(const std::string& form
     return DiscIO::BlobType::WIA;
   else if (format_str == "rvz")
     return DiscIO::BlobType::RVZ;
+  else if (format_str == "wbfs")
+    return DiscIO::BlobType::WBFS;
   return std::nullopt;
 }
 
@@ -83,7 +85,7 @@ int ConvertCommand(const std::vector<std::string>& args)
       .type("string")
       .action("store")
       .help("Container format to use. Default is RVZ. [%choices]")
-      .choices({"iso", "gcz", "wia", "rvz"});
+      .choices({"iso", "gcz", "wia", "rvz", "wbfs"});
 
   parser.add_option("-s", "--scrub")
       .action("store_true")
@@ -150,6 +152,15 @@ int ConvertCommand(const std::vector<std::string>& args)
     return EXIT_FAILURE;
   }
 
+  if (blob_reader->GetDataSizeType() == DiscIO::DataSizeType::UpperBound)
+  {
+    fmt::print(std::cerr, "Warning: This file does not contain verification data. "
+                          "Some disc data may have been lost during the original conversion, "
+                          "so the result will not be an exact copy of the original disc. "
+                          "The converted file will still work fine for playing games. "
+                          "Continuing anyway.\n");
+  }
+
   // --scrub
   const bool scrub = static_cast<bool>(options.get("scrub"));
 
@@ -167,7 +178,7 @@ int ConvertCommand(const std::vector<std::string>& args)
                "Warning: The input file is not a GC/Wii disc image. Continuing anyway.\n");
   }
 
-  if (scrub)
+  if (scrub && format != DiscIO::BlobType::WBFS)
   {
     if (volume->IsDatelDisc())
     {
@@ -201,6 +212,13 @@ int ConvertCommand(const std::vector<std::string>& args)
   {
     fmt::print(std::cerr, "Warning: Converting Wii disc images to GCZ without scrubbing may not "
                           "offer space advantages over ISO. Continuing anyway.\n");
+  }
+
+  if (format == DiscIO::BlobType::WBFS && volume &&
+      volume->GetVolumeType() == DiscIO::Platform::GameCubeDisc)
+  {
+    fmt::print(std::cerr,
+               "Warning: Output will be a valid WBFS file but is not playable on a real Wii.\n");
   }
 
   if (volume && volume->IsNKit())
@@ -330,6 +348,13 @@ int ConvertCommand(const std::vector<std::string>& args)
                                         format == DiscIO::BlobType::RVZ, compression_o.value(),
                                         compression_level_o.value(), block_size_o.value(),
                                         NOOP_STATUS_CALLBACK);
+    break;
+  }
+
+  case DiscIO::BlobType::WBFS:
+  {
+    success = DiscIO::ConvertToWBFS(blob_reader.get(), input_file_path, output_file_path,
+                                    NOOP_STATUS_CALLBACK);
     break;
   }
 

--- a/Source/Core/DolphinTool/ConvertCommand.cpp
+++ b/Source/Core/DolphinTool/ConvertCommand.cpp
@@ -154,10 +154,10 @@ int ConvertCommand(const std::vector<std::string>& args)
 
   if (blob_reader->GetDataSizeType() == DiscIO::DataSizeType::UpperBound)
   {
-    fmt::print(std::cerr, "Warning: This file does not contain verification data. "
+    fmt::print(std::cerr, "Warning: This file uses a lossy format. "
                           "Some disc data may have been lost during the original conversion, "
                           "so the result will not be an exact copy of the original disc. "
-                          "The converted file will still work fine for playing games. "
+                          "This won't affect your ability to play the game. "
                           "Continuing anyway.\n");
   }
 
@@ -218,7 +218,7 @@ int ConvertCommand(const std::vector<std::string>& args)
       volume->GetVolumeType() == DiscIO::Platform::GameCubeDisc)
   {
     fmt::print(std::cerr,
-               "Warning: Output will be a valid WBFS file but is not playable on a real Wii.\n");
+               "Warning: Output will be a valid WBFS file, but the result is not playable on a real Wii.\n");
   }
 
   if (volume && volume->IsNKit())

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -843,7 +843,9 @@ std::string GameFile::GetFileFormatName() const
 
 bool GameFile::ShouldAllowConversion() const
 {
-  return DiscIO::IsDisc(m_platform) && m_volume_size_type == DiscIO::DataSizeType::Accurate &&
+  return DiscIO::IsDisc(m_platform) &&
+         (m_volume_size_type == DiscIO::DataSizeType::Accurate ||
+          m_volume_size_type == DiscIO::DataSizeType::UpperBound) &&
          !IsModDescriptor();
 }
 


### PR DESCRIPTION
This PR introduces Conversion **to** WBFS support. WBFS is the format that is used by USB Loaders on a real Wii device.

## Design decisions & hardcoded values
The writer uses fixed sector sizes that match what [libwbfs (the reference implementation by kwiirk)](https://github.com/kwiirk/wbfs/blob/master/libwbfs/libwbfs.c#L128-L134) computes for a standard single-layer Wii disc. These 2 hardcodes are stable and work correctly across all my testings.
- HD sector shift: 9 (512 bytes)
- WBFS sector shift: 21 (2 MiB)
These are not configurable via the UI. All existing WBFS tools use these values, and since the aim is to support USB Loaders then this has been tested and it is working on a real Wii.

Converting from WBFS is not enabled. The existing `WbfsFileReader` reports `DataSizeType::UpperBound`, and `ShouldAllowConversion()` requires `Accurate`. I am able to support this but since it was hardcoded by the Dolphin team I thought a discussion is warranted.

## Testing
- Verified with DolphinTool header and DolphinTool verify
- Verified with wit FILETYPE and wit DUMP (Wiimm's ISO Tools recognizes valid WBFS structure, partitions, encryption)
- Tested ISO to WBFS and RVZ to WBFS conversions
- Output file sizes match Wii Backup Manager when scrubbing is enabled (~0.1% difference), works when scrubbing is disabled.
- Output WBFS files play correctly in Dolphin
- Output WBFS files play correctly on a real Wii using USB Loader GX e25c4f3
