### PR TITLE
IOS/ES: Prevent reading TMDs that are too small

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -194,7 +194,7 @@ void SignedBlobReader::DoState(PointerWrap& p)
 
 bool IsValidTMDSize(size_t size)
 {
-  return size <= 0x49e4;
+  return size >= sizeof(TMDHeader) && size <= 0x49e4;
 }
 
 TMDReader::TMDReader(std::vector<u8> bytes) : SignedBlobReader(std::move(bytes))

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -156,7 +156,7 @@ std::optional<IPCReply> WFSIDevice::IOCtl(const IOCtlRequest& request)
 
     if (!ES::IsValidTMDSize(tmd_size))
     {
-      ERROR_LOG_FMT(IOS_WFS, "IOCTL_WFSI_IMPORT_TITLE_INIT: TMD size too large ({})", tmd_size);
+      ERROR_LOG_FMT(IOS_WFS, "IOCTL_WFSI_IMPORT_TITLE_INIT: TMD size invalid ({})", tmd_size);
       return_error_code = IPC_EINVAL;
       break;
     }

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -51,7 +51,7 @@ VolumeWAD::VolumeWAD(std::unique_ptr<BlobReader> reader) : m_reader(std::move(re
 
   if (!IOS::ES::IsValidTMDSize(m_tmd_size))
   {
-    ERROR_LOG_FMT(DISCIO, "TMD is too large: {} bytes", m_tmd_size);
+    ERROR_LOG_FMT(DISCIO, "TMD has an invalid size: {} bytes", m_tmd_size);
     return;
   }
 


### PR DESCRIPTION
Although `TMDReader::IsValid` checks for a TMD that's too small, `ES::IsValidTMDSize` doesn't, which causes `ESDevice::ImportTmd` to crash when calling `TMDReader::GetTitleId` or `TMDReader::GetTitleFlags` due to it being out of bounds.

I found this while reversing the HackMii Installer, which calls `ImportTmd` with some very lovely ASCII art instead of an actual TMD.