### PR TITLE
Auto assign wii controllers in netplay

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -2272,6 +2272,15 @@ void NetPlayServer::AssignNewUserAPad(const Client& player)
       break;
     }
   }
+  for (PlayerId& mapping : m_wiimote_map)
+  {
+    // 0 means unmapped
+    if (mapping == 0)
+    {
+      mapping = player.pid;
+      break;
+    }
+  }
 }
 
 PlayerId NetPlayServer::GiveFirstAvailableIDTo(ENetPeer* player)


### PR DESCRIPTION
Just copy the gamecube logic and automatically assign players to the first empty slot.

More consistent with GameCube and helps Android hosts where there is no UI for managing controller mappings currently.