### PR TITLE
Flatpak: Update runtime to `6.11`

### DIFF
--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -1,6 +1,6 @@
 app-id: org.DolphinEmu.dolphin-emu
 runtime: org.kde.Platform
-runtime-version: '6.10'
+runtime-version: '6.11'
 sdk: org.kde.Sdk
 command: dolphin-emu-wrapper
 rename-desktop-file: dolphin-emu.desktop


### PR DESCRIPTION
This PR bumps the KDE runtime of the Dolphin Flatpak to the latest stable version `6.11`, which currently includes Qt version `6.11.1`. Testing the build locally, everything seems to be fine, but this would need some more testing.