### PR TITLE
GameFile: Disallow mods from being converted

### DIFF
--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -842,7 +842,8 @@ std::string GameFile::GetFileFormatName() const
 
 bool GameFile::ShouldAllowConversion() const
 {
-  return DiscIO::IsDisc(m_platform) && m_volume_size_type == DiscIO::DataSizeType::Accurate;
+  return DiscIO::IsDisc(m_platform) && m_volume_size_type == DiscIO::DataSizeType::Accurate &&
+         !IsModDescriptor();
 }
 
 bool GameFile::IsModDescriptor() const


### PR DESCRIPTION
Riivolution `.json` files could previously get converted if multi-selected from the game list. This would create a file ~50x bigger than the json file that Dolphin couldn't read.

Before/after:
<img width="936" height="187" alt="image" src="https://github.com/user-attachments/assets/bd0145d9-a7c2-46ff-b0c3-08d72068110f" />
<img width="943" height="134" alt="image" src="https://github.com/user-attachments/assets/780c9875-dd70-47a3-bd83-c903808e22de" />
