### PR TITLE
Android: add automatic controller setup

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -183,6 +183,12 @@ enum class BooleanSetting(
         "UseGameCovers",
         true
     ),
+    MAIN_AUTOMATIC_CONTROLLERS(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_GENERAL,
+        "AutomaticControllers",
+        false
+    ),
     MAIN_DEBUG_JIT_OFF(Settings.FILE_DOLPHIN, Settings.SECTION_DEBUG, "JitOff", false),
     MAIN_DEBUG_JIT_LOAD_STORE_OFF(
         Settings.FILE_DOLPHIN,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -230,6 +230,14 @@ class SettingsFragmentPresenter(
         sl.add(
             SwitchSetting(
                 context,
+                BooleanSetting.MAIN_AUTOMATIC_CONTROLLERS,
+                R.string.automatic_controllers,
+                R.string.automatic_controllers_description
+            )
+        )
+        sl.add(
+            SwitchSetting(
+                context,
                 BooleanSetting.MAIN_OVERRIDE_REGION_SETTINGS,
                 R.string.override_region_settings,
                 0

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
     <string name="dual_core">Dual Core (speedhack)</string>
     <string name="dual_core_description">Split workload to two CPU cores instead of one. Increases speed.</string>
     <string name="enable_cheats">Enable Cheats</string>
+    <string name="automatic_controllers">Automatic Controllers</string>
+    <string name="automatic_controllers_description">Map connected controllers and assign them to ports automatically. Press a button to take the next free port.</string>
     <string name="speed_limit">Speed Limit (0% = Unlimited)</string>
     <string name="overclock_warning">WARNING: Changing this from the default (100%) WILL break games and cause glitches. Please do not report bugs that occur with a non-default clock.</string>
     <string name="achievements_submenu">RetroAchievements</string>

--- a/Source/Android/jni/AutomaticControllers.h
+++ b/Source/Android/jni/AutomaticControllers.h
@@ -1,0 +1,12 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace AutomaticControllers
+{
+// Whether generated mappings are currently applied to the emulated GameCube controllers.
+// While they are, the controllers do not hold what the user configured, so saving them would
+// write the generated mappings over it.
+bool IsActive();
+}  // namespace AutomaticControllers

--- a/Source/Android/jni/Input/MappingCommon.cpp
+++ b/Source/Android/jni/Input/MappingCommon.cpp
@@ -17,6 +17,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/MappingCommon.h"
 #include "jni/AndroidCommon/AndroidCommon.h"
+#include "jni/AutomaticControllers.h"
 
 extern "C" {
 
@@ -36,7 +37,10 @@ Java_org_dolphinemu_dolphinemu_features_input_model_MappingCommon_getExpressionF
 JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_input_model_MappingCommon_save(JNIEnv* env, jclass)
 {
-  Pad::GetConfig()->SaveConfig();
+  // While controllers are being set up automatically the GameCube pads hold generated
+  // mappings rather than the user's, and saving would write those over the user's own.
+  if (!AutomaticControllers::IsActive())
+    Pad::GetConfig()->SaveConfig();
   Pad::GetGBAConfig()->SaveConfig();
   Keyboard::GetConfig()->SaveConfig();
   Wiimote::GetConfig()->SaveConfig();

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -1,11 +1,14 @@
 // Copyright 2003 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+#include <array>
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <optional>
 #include <string>
 #include <thread>
@@ -13,6 +16,7 @@
 #include <vector>
 
 #include <EGL/egl.h>
+#include <android/input.h>
 #include <android/log.h>
 #include <android/native_window_jni.h>
 #include <fmt/format.h>
@@ -22,11 +26,14 @@
 #include "Common/CPUDetect.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
+#include "Common/Contains.h"
 #include "Common/Event.h"
 #include "Common/FileUtil.h"
 #include "Common/Flag.h"
 #include "Common/IOFile.h"
 #include "Common/IniFile.h"
+#include "Common/Logging/Log.h"
 #include "Common/Logging/LogManager.h"
 #include "Common/MsgHandler.h"
 #include "Common/ScopeGuard.h"
@@ -37,11 +44,15 @@
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
 #include "Core/CommonTitles.h"
+#include "Core/Config/MainSettings.h"
+#include "Core/Config/UISettings.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/DolphinAnalytics.h"
 #include "Core/HW/DVD/DVDInterface.h"
+#include "Core/HW/GCPad.h"
+#include "Core/HW/SI/SI_Device.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/Host.h"
@@ -57,6 +68,11 @@
 #include "DiscIO/ScrubbedBlob.h"
 #include "DiscIO/Volume.h"
 
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerInterface/Android/Android.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "InputCommon/InputConfig.h"
+
 #include "UICommon/GameFile.h"
 #include "UICommon/UICommon.h"
 
@@ -66,6 +82,7 @@
 
 #include "jni/AndroidCommon/AndroidCommon.h"
 #include "jni/AndroidCommon/IDCache.h"
+#include "jni/AutomaticControllers.h"
 
 namespace
 {
@@ -188,12 +205,45 @@ void Host_YieldToUI()
 {
 }
 
+static void AutoSetupControllers();
+
+namespace
+{
+constexpr int NUM_GC_PORTS = 4;
+
+// The controller occupying each GameCube port, for the duration of one emulation session.
+// Guarded by s_controller_setup_mutex.
+std::mutex s_controller_setup_mutex;
+std::array<std::string, NUM_GC_PORTS> s_controller_ports;
+bool s_mappings_applied = false;
+}  // namespace
+
+namespace AutomaticControllers
+{
+bool IsActive()
+{
+  if (!Config::Get(Config::MAIN_AUTOMATIC_CONTROLLERS))
+    return false;
+
+  const std::lock_guard setup_lock(s_controller_setup_mutex);
+  return std::ranges::any_of(s_controller_ports,
+                             [](const std::string& owner) { return !owner.empty(); });
+}
+}  // namespace AutomaticControllers
+
 void Host_TitleChanged()
 {
   s_game_metadata_is_valid = true;
 
   JNIEnv* env = IDCache::GetEnvForThread();
   env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(), IDCache::GetOnTitleChanged());
+
+  // On Wii, an ES title change reloads the pad configs from disk right after this callback
+  // returns (TitleContext::Update calls SConfig::OnESTitleChanged after SetRunningGameMetadata),
+  // clobbering automatically generated controller mappings. Queue a re-application to run
+  // once the current CPU-thread callstack, including that reload, has finished; the job is
+  // serviced by the emulation run loop.
+  Core::QueueHostJob([](Core::System&) { AutoSetupControllers(); }, false);
 }
 
 std::unique_ptr<GBAHostInterface> Host_CreateGBAHost(std::weak_ptr<HW::GBA::Core> core)
@@ -547,6 +597,318 @@ static float GetRenderSurfaceScale(JNIEnv* env)
   return env->CallStaticFloatMethod(native_library_class, get_render_surface_scale_method);
 }
 
+static bool HasInput(const ciface::Core::Device& device, std::string_view name)
+{
+  return device.FindInput(name) != nullptr;
+}
+
+// Enough to swallow the noise an analog stick reports while it sits idle
+constexpr const char* DEAD_ZONE = "10.";
+
+static std::string AxisName(int axis, bool negative)
+{
+  return fmt::format("Axis {}{}", axis, negative ? '-' : '+');
+}
+
+// Android reports an axis either as centered, with a direction each way, or as one way only.
+// Which of the two it is depends on the axis alone: the sticks, the hat, AXIS_Z and AXIS_RZ
+// are always centered, while AXIS_LTRIGGER, AXIS_RTRIGGER, AXIS_BRAKE and AXIS_GAS are always
+// one way. It says nothing about what the control physically is.
+static bool HasCenteredAxis(const ciface::Core::Device& device, int axis)
+{
+  return HasInput(device, AxisName(axis, false)) && HasInput(device, AxisName(axis, true));
+}
+
+static bool HasOneWayAxis(const ciface::Core::Device& device, int axis)
+{
+  return HasInput(device, AxisName(axis, false)) && !HasInput(device, AxisName(axis, true));
+}
+
+// Builds an expression that triggers on whichever of the given controls the controller has,
+// so that one is enough but several are allowed, e.g. "`Up` | `Axis 16-`". Empty, leaving
+// the control unmapped, if it has none of them.
+static std::string AnyOf(const ciface::Core::Device& device,
+                         std::initializer_list<std::string_view> controls)
+{
+  std::string result;
+  for (std::string_view control : controls)
+  {
+    if (!HasInput(device, control))
+      continue;
+    if (!result.empty())
+      result += " | ";
+    result += fmt::format("`{}`", control);
+  }
+  return result;
+}
+
+// The first of the given axes that the controller reports as one way, if any
+static std::string FirstOneWayAxis(const ciface::Core::Device& device,
+                                   std::initializer_list<int> axes)
+{
+  for (int axis : axes)
+  {
+    if (HasOneWayAxis(device, axis))
+      return fmt::format("`{}`", AxisName(axis, false));
+  }
+  return {};
+}
+
+// Generates a standard GameCube mapping for an Android controller from the controls it
+// reports. Face buttons follow their physical position rather than their label, which is how
+// Android reports them for both Xbox-style and PlayStation-style controllers.
+static void GenerateAndroidGamepadConfig(const ciface::Core::Device& device,
+                                         Common::IniFile::Section* section)
+{
+  ciface::Core::DeviceQualifier qualifier;
+  qualifier.FromDevice(&device);
+  section->Set("Device", qualifier.ToString());
+
+  section->Set("Buttons/A", AnyOf(device, {"Button A"}));
+  section->Set("Buttons/B", AnyOf(device, {"Button X"}));
+  section->Set("Buttons/X", AnyOf(device, {"Button B"}));
+  section->Set("Buttons/Y", AnyOf(device, {"Button Y"}));
+  section->Set("Buttons/Z", AnyOf(device, {"Button R1"}));
+  section->Set("Buttons/Start", AnyOf(device, {"Start"}));
+
+  section->Set("Main Stick/Up", AnyOf(device, {AxisName(AMOTION_EVENT_AXIS_Y, true)}));
+  section->Set("Main Stick/Down", AnyOf(device, {AxisName(AMOTION_EVENT_AXIS_Y, false)}));
+  section->Set("Main Stick/Left", AnyOf(device, {AxisName(AMOTION_EVENT_AXIS_X, true)}));
+  section->Set("Main Stick/Right", AnyOf(device, {AxisName(AMOTION_EVENT_AXIS_X, false)}));
+  section->Set("Main Stick/Dead Zone", std::string(DEAD_ZONE));
+
+  // Which axes the right stick and the analog triggers use differs between controllers, and
+  // Android does not say which is which, because it decides whether an axis is centered from
+  // the axis alone. Controllers that follow Android's own layout put the right stick on
+  // AXIS_Z and AXIS_RZ and the triggers on axes of their own, while controllers that report
+  // themselves the way an Xbox controller does put the triggers on AXIS_Z and AXIS_RZ and the
+  // right stick on AXIS_RX and AXIS_RY. Having somewhere else for the triggers to be is what
+  // tells the two layouts apart.
+  const bool has_trigger_axes = HasOneWayAxis(device, AMOTION_EVENT_AXIS_LTRIGGER) ||
+                                HasOneWayAxis(device, AMOTION_EVENT_AXIS_RTRIGGER) ||
+                                HasOneWayAxis(device, AMOTION_EVENT_AXIS_BRAKE) ||
+                                HasOneWayAxis(device, AMOTION_EVENT_AXIS_GAS);
+  const bool has_trigger_buttons = HasInput(device, "Button L2") || HasInput(device, "Button R2");
+  const bool has_z_rz = HasCenteredAxis(device, AMOTION_EVENT_AXIS_Z) &&
+                        HasCenteredAxis(device, AMOTION_EVENT_AXIS_RZ);
+  const bool has_rx_ry = HasCenteredAxis(device, AMOTION_EVENT_AXIS_RX) &&
+                         HasCenteredAxis(device, AMOTION_EVENT_AXIS_RY);
+  const bool z_rz_are_triggers = has_z_rz && has_rx_ry && !has_trigger_axes && !has_trigger_buttons;
+
+  int c_stick_x = -1;
+  int c_stick_y = -1;
+  if (has_z_rz && !z_rz_are_triggers)
+  {
+    c_stick_x = AMOTION_EVENT_AXIS_Z;
+    c_stick_y = AMOTION_EVENT_AXIS_RZ;
+  }
+  else if (has_rx_ry)
+  {
+    c_stick_x = AMOTION_EVENT_AXIS_RX;
+    c_stick_y = AMOTION_EVENT_AXIS_RY;
+  }
+
+  if (c_stick_x >= 0)
+  {
+    section->Set("C-Stick/Up", fmt::format("`{}`", AxisName(c_stick_y, true)));
+    section->Set("C-Stick/Down", fmt::format("`{}`", AxisName(c_stick_y, false)));
+    section->Set("C-Stick/Left", fmt::format("`{}`", AxisName(c_stick_x, true)));
+    section->Set("C-Stick/Right", fmt::format("`{}`", AxisName(c_stick_x, false)));
+    section->Set("C-Stick/Dead Zone", std::string(DEAD_ZONE));
+  }
+
+  std::string l_analog =
+      FirstOneWayAxis(device, {AMOTION_EVENT_AXIS_LTRIGGER, AMOTION_EVENT_AXIS_BRAKE});
+  std::string r_analog =
+      FirstOneWayAxis(device, {AMOTION_EVENT_AXIS_RTRIGGER, AMOTION_EVENT_AXIS_GAS});
+  if (z_rz_are_triggers)
+  {
+    // A trigger on a centered axis rests at one end of it, so the whole of the axis is the
+    // travel of the trigger.
+    l_analog = fmt::format("`Full {}`", AxisName(AMOTION_EVENT_AXIS_Z, false));
+    r_analog = fmt::format("`Full {}`", AxisName(AMOTION_EVENT_AXIS_RZ, false));
+  }
+
+  // Controllers without analog triggers report them as buttons instead
+  const std::string l_button = AnyOf(device, {"Button L2"});
+  const std::string r_button = AnyOf(device, {"Button R2"});
+  if (l_analog.empty())
+    l_analog = l_button;
+  if (r_analog.empty())
+    r_analog = r_button;
+
+  section->Set("Triggers/L", l_button.empty() ? l_analog : l_button);
+  section->Set("Triggers/R", r_button.empty() ? r_analog : r_button);
+  section->Set("Triggers/L-Analog", l_analog);
+  section->Set("Triggers/R-Analog", r_analog);
+
+  // The d-pad arrives as buttons, as a hat, or as both
+  section->Set("D-Pad/Up", AnyOf(device, {"Up", AxisName(AMOTION_EVENT_AXIS_HAT_Y, true)}));
+  section->Set("D-Pad/Down", AnyOf(device, {"Down", AxisName(AMOTION_EVENT_AXIS_HAT_Y, false)}));
+  section->Set("D-Pad/Left", AnyOf(device, {"Left", AxisName(AMOTION_EVENT_AXIS_HAT_X, true)}));
+  section->Set("D-Pad/Right", AnyOf(device, {"Right", AxisName(AMOTION_EVENT_AXIS_HAT_X, false)}));
+
+  if (device.FindOutput("Motor 0") != nullptr)
+    section->Set("Rumble/Motor", std::string("`Motor 0`"));
+}
+
+// Whether a device can serve as a GameCube controller: Android's own markers of a gamepad,
+// plus the controls that a generated mapping needs.
+static bool IsUsableGamepad(const ciface::Core::Device& device,
+                            const ciface::Android::DeviceProperties& properties)
+{
+  return properties.is_gamepad && HasInput(device, "Button A") && HasInput(device, "Axis 0-") &&
+         HasInput(device, "Axis 0+") && HasInput(device, "Axis 1-") && HasInput(device, "Axis 1+");
+}
+
+// Gives the emulated controllers back the mappings the user configured. Called with the
+// setup lock held.
+static void RestoreControllerMappings()
+{
+  if (!s_mappings_applied)
+    return;
+
+  s_mappings_applied = false;
+  if (Pad::GetConfig()->GetControllerCount() >= NUM_GC_PORTS)
+    Pad::LoadConfig();
+}
+
+static void AutoSetupControllers()
+{
+  // Device changes and first inputs each run a setup on a thread of their own
+  const std::lock_guard setup_lock(s_controller_setup_mutex);
+
+  if (!Config::Get(Config::MAIN_AUTOMATIC_CONTROLLERS))
+  {
+    // Turning the setting off gives the ports back and starts the players over
+    RestoreControllerMappings();
+    if (!std::ranges::all_of(s_controller_ports, &std::string::empty))
+    {
+      s_controller_ports = {};
+      ciface::Android::ForgetDeliveredInput();
+      for (int port = 0; port < NUM_GC_PORTS; ++port)
+        Config::DeleteKey(Config::LayerType::CurrentRun, Config::GetInfoForSIDevice(port));
+    }
+    return;
+  }
+
+  struct Candidate
+  {
+    std::shared_ptr<ciface::Core::Device> device;
+    ciface::Android::DeviceProperties properties;
+  };
+
+  std::vector<Candidate> candidates;
+  for (const std::string& device_string : g_controller_interface.GetAllDeviceStrings())
+  {
+    ciface::Core::DeviceQualifier qualifier;
+    qualifier.FromString(device_string);
+
+    const std::shared_ptr<ciface::Core::Device> device =
+        g_controller_interface.FindDevice(qualifier);
+    if (!device)
+      continue;
+
+    const std::optional properties = ciface::Android::GetDeviceProperties(*device);
+    if (properties && IsUsableGamepad(*device, *properties))
+      candidates.emplace_back(device, *properties);
+  }
+
+  // Players claim their port by using their controller: the first controller to send input
+  // becomes player one, the next becomes player two, and so on. This is the only order that
+  // reflects what the players did, because Android reports the controllers that are already
+  // connected in a fixed order of its own. It also settles which of the devices Android
+  // reports for one controller to take the input from, since only the one a player is
+  // actually using ever sends any.
+  std::erase_if(candidates, [](const Candidate& c) { return !c.properties.input_order; });
+  std::ranges::sort(candidates, {}, [](const Candidate& c) { return *c.properties.input_order; });
+
+  // Ports are held by the controller rather than by the device it is reported as, because
+  // Android renames and renumbers those as controllers come and go.
+  const auto candidate_index = [&](const std::string& descriptor) {
+    if (descriptor.empty())
+      return -1;
+    const auto it = std::ranges::find(candidates, descriptor,
+                                      [](const Candidate& c) { return c.properties.descriptor; });
+    return it == candidates.end() ? -1 : static_cast<int>(it - candidates.begin());
+  };
+
+  const std::array previous_ports = s_controller_ports;
+
+  // A controller keeps its port until the setting is turned off or Dolphin is closed, so
+  // that leaving a game, or a controller running out of battery, does not shuffle the
+  // players around.
+  for (const Candidate& candidate : candidates)
+  {
+    if (candidate.properties.descriptor.empty() ||
+        Common::Contains(s_controller_ports, candidate.properties.descriptor))
+    {
+      continue;
+    }
+
+    const auto free_port = std::ranges::find(s_controller_ports, std::string{});
+    if (free_port == s_controller_ports.end())
+      break;
+    *free_port = candidate.properties.descriptor;
+  }
+
+  // Take over only the ports this feature has assigned, so that a port the user configured
+  // as something else, or left empty, keeps whatever they chose. The current-run layer keeps
+  // all of this out of their saved configuration, and while a game is running SerialInterface
+  // picks the change up on the CPU thread by itself.
+  for (int port = 0; port < NUM_GC_PORTS; ++port)
+  {
+    const auto& si_device = Config::GetInfoForSIDevice(port);
+    if (candidate_index(s_controller_ports[port]) >= 0)
+      Config::SetCurrent(si_device, SerialInterface::SIDEVICE_GC_CONTROLLER);
+    else
+      Config::DeleteKey(Config::LayerType::CurrentRun, si_device);
+  }
+
+  // The emulated controllers exist for as long as the process does, but a mapping cannot be
+  // applied before they have been created.
+  if (Pad::GetConfig()->GetControllerCount() < NUM_GC_PORTS)
+    return;
+
+  // Give every port back the mapping the user configured before handing out the generated
+  // ones, so that a port whose controller has left is usable again rather than left pointing
+  // at a controller that is no longer there. The mappings are handed out again on every pass
+  // because a Wii title change reloads them from disk behind our back.
+  Pad::LoadConfig();
+  s_mappings_applied = true;
+
+  for (int port = 0; port < NUM_GC_PORTS; ++port)
+  {
+    const int index = candidate_index(s_controller_ports[port]);
+    if (index < 0)
+      continue;
+
+    Common::IniFile ini;
+    Common::IniFile::Section* const section = ini.GetOrCreateSection("Generated");
+    GenerateAndroidGamepadConfig(*candidates[index].device, section);
+
+    ControllerEmu::EmulatedController* const controller = Pad::GetConfig()->GetController(port);
+    controller->LoadConfig(section);
+    controller->UpdateReferences(g_controller_interface);
+  }
+
+  if (s_controller_ports == previous_ports)
+    return;
+
+  // Tell the players which controller they ended up as, since nothing else says so while a
+  // game is running.
+  for (int port = 0; port < NUM_GC_PORTS; ++port)
+  {
+    const int index = candidate_index(s_controller_ports[port]);
+    if (index < 0)
+      continue;
+
+    const std::string& name = candidates[index].device->GetName();
+    INFO_LOG_FMT(CONTROLLERINTERFACE, "GameCube controller {}: {}", port + 1, name);
+    OSD::AddMessage(fmt::format("GameCube controller {}: {}", port + 1, name));
+  }
+}
+
 static void Run(JNIEnv* env, std::unique_ptr<BootParameters>&& boot, bool riivolution)
 {
   if (riivolution && std::holds_alternative<BootParameters::Disc>(boot->parameters))
@@ -558,6 +920,11 @@ static void Run(JNIEnv* env, std::unique_ptr<BootParameters>&& boot, bool riivol
                                           riivolution_dir, volume.GetGameID(), volume.GetRevision(),
                                           volume.GetDiscNumber()));
   }
+
+  // Get the port configuration in place before the core reads it at boot. Players keep the
+  // ports they have already claimed, so that leaving a game and starting another one does
+  // not make everyone claim their place again.
+  AutoSetupControllers();
 
   s_need_nonblocking_alert_msg = true;
   std::unique_lock<std::mutex> surface_guard(s_surface_lock);
@@ -572,6 +939,20 @@ static void Run(JNIEnv* env, std::unique_ptr<BootParameters>&& boot, bool riivol
     static constexpr int WAIT_STEP = 25;
     while (Core::GetState(Core::System::GetInstance()) == Core::State::Starting)
       std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_STEP));
+
+    AutoSetupControllers();
+
+    // Run the setup again whenever the set of controllers changes, and when a device first
+    // delivers input, which is what identifies it as a controller. The notifications arrive
+    // on the threads that handle input and hotplug, so the work is queued for the host.
+    const auto setup_on_change = [] {
+      if (Core::IsRunning(Core::System::GetInstance()))
+        Core::QueueHostJob([](Core::System&) { AutoSetupControllers(); });
+    };
+    static Common::EventHook devices_changed_hook =
+        g_controller_interface.RegisterDevicesChangedCallback(setup_on_change);
+    static Common::EventHook first_input_hook =
+        ciface::Android::RegisterFirstInputCallback(setup_on_change);
   }
 
   s_is_booting.Clear();
@@ -586,6 +967,11 @@ static void Run(JNIEnv* env, std::unique_ptr<BootParameters>&& boot, bool riivol
 
   s_game_metadata_is_valid = false;
   Core::Shutdown(Core::System::GetInstance());
+
+  {
+    const std::lock_guard setup_lock(s_controller_setup_mutex);
+    RestoreControllerMappings();
+  }
 
   env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(),
                             IDCache::GetFinishEmulationActivity());

--- a/Source/Core/Core/Config/UISettings.cpp
+++ b/Source/Core/Core/Config/UISettings.cpp
@@ -15,6 +15,8 @@ const Info<bool> MAIN_USE_GAME_COVERS{{System::Main, "General", "UseGameCovers"}
 #endif
 const Info<bool> MAIN_FOCUSED_HOTKEYS{{System::Main, "General", "HotkeysRequireFocus"}, true};
 const Info<bool> MAIN_RECURSIVE_ISO_PATHS{{System::Main, "General", "RecursiveISOPaths"}, false};
+const Info<bool> MAIN_AUTOMATIC_CONTROLLERS{{System::Main, "General", "AutomaticControllers"},
+                                            false};
 const Info<std::string> MAIN_CURRENT_STATE_PATH{{System::Main, "General", "CurrentStatePath"}, ""};
 
 }  // namespace Config

--- a/Source/Core/Core/Config/UISettings.h
+++ b/Source/Core/Core/Config/UISettings.h
@@ -19,6 +19,7 @@ extern const Info<bool> MAIN_USE_DISCORD_PRESENCE;
 extern const Info<bool> MAIN_USE_GAME_COVERS;
 extern const Info<bool> MAIN_FOCUSED_HOTKEYS;
 extern const Info<bool> MAIN_RECURSIVE_ISO_PATHS;
+extern const Info<bool> MAIN_AUTOMATIC_CONTROLLERS;
 extern const Info<std::string> MAIN_CURRENT_STATE_PATH;
 
 }  // namespace Config

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -6,10 +6,13 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -43,8 +46,19 @@ jmethodID s_input_device_get_device;
 jmethodID s_input_device_get_controller_number;
 jmethodID s_input_device_get_motion_ranges;
 jmethodID s_input_device_get_name;
+jmethodID s_input_device_get_descriptor;
 jmethodID s_input_device_get_sources;
 jmethodID s_input_device_has_keys;
+
+// Triggered when a device delivers its first gamepad input.
+Common::HookableEvent<> s_first_input_event;
+
+// The devices that have delivered gamepad input, in the order they first did so. Android
+// recreates its device objects whenever any of their properties change, so this is keyed by
+// the id it keeps for as long as the device is connected. Read by controller setup, written
+// by input dispatch.
+std::mutex s_delivered_input_mutex;
+std::vector<jint> s_devices_with_delivered_input;
 
 jclass s_motion_range_class;
 jmethodID s_motion_range_get_axis;
@@ -54,6 +68,7 @@ jmethodID s_motion_range_get_source;
 
 jclass s_input_event_class;
 jmethodID s_input_event_get_device_id;
+jmethodID s_input_event_get_source;
 
 jclass s_key_event_class;
 jmethodID s_key_event_get_action;
@@ -87,6 +102,8 @@ jintArray s_keycodes_array;
 using Clock = std::chrono::steady_clock;
 constexpr Clock::duration ACTIVE_INPUT_TIMEOUT = std::chrono::milliseconds(1000);
 
+// Read by input dispatch on the UI thread; written by hotplug handling on another thread.
+std::mutex s_device_id_map_mutex;
 std::unordered_map<jint, ciface::Core::DeviceQualifier> s_device_id_to_device_qualifier;
 
 constexpr int MAX_KEYCODE = AKEYCODE_PROFILE_SWITCH;  // Up to date as of SDK 31
@@ -426,14 +443,18 @@ std::string ConstructAxisName(int source, int axis, bool negative)
 
 std::shared_ptr<ciface::Core::Device> FindDevice(jint device_id)
 {
-  const auto it = s_device_id_to_device_qualifier.find(device_id);
-  if (it == s_device_id_to_device_qualifier.end())
+  ciface::Core::DeviceQualifier qualifier;
   {
-    ERROR_LOG_FMT(CONTROLLERINTERFACE, "Could not find device ID {}", device_id);
-    return nullptr;
+    std::lock_guard lk(s_device_id_map_mutex);
+    const auto it = s_device_id_to_device_qualifier.find(device_id);
+    if (it == s_device_id_to_device_qualifier.end())
+    {
+      ERROR_LOG_FMT(CONTROLLERINTERFACE, "Could not find device ID {}", device_id);
+      return nullptr;
+    }
+    qualifier = it->second;
   }
 
-  const ciface::Core::DeviceQualifier& qualifier = it->second;
   std::shared_ptr<ciface::Core::Device> device = g_controller_interface.FindDevice(qualifier);
   if (!device)
   {
@@ -624,6 +645,16 @@ public:
     m_name = GetJString(env, j_name);
     env->DeleteLocalRef(j_name);
 
+    // Kept for telling controllers apart across the device objects Android recreates,
+    // not shown to the user
+    jstring j_descriptor = reinterpret_cast<jstring>(
+        env->CallObjectMethod(input_device, s_input_device_get_descriptor));
+    if (j_descriptor != nullptr)
+    {
+      m_descriptor = GetJString(env, j_descriptor);
+      env->DeleteLocalRef(j_descriptor);
+    }
+
     DEBUG_LOG_FMT(CONTROLLERINTERFACE, "Sources for {}: {:08x}", GetQualifiedName(), m_source);
 
     AddKeys(env, input_device);
@@ -668,6 +699,12 @@ public:
 
     return -3;
   }
+
+  int GetSourceFlags() const { return m_source; }
+
+  int GetControllerNumber() const { return m_controller_number; }
+
+  const std::string& GetDescriptor() const { return m_descriptor; }
 
   std::optional<jint> GetDeviceID() const { return m_device_id; }
 
@@ -808,7 +845,25 @@ private:
   const int m_controller_number;
   const std::optional<jint> m_device_id;
   std::string m_name;
+  std::string m_descriptor;
 };
+
+// Records that a device has delivered gamepad input, announcing the first time it does.
+static void MarkDeviceInputDelivered(ciface::Core::Device* device)
+{
+  const std::optional<jint> device_id = static_cast<AndroidDevice*>(device)->GetDeviceID();
+  if (!device_id.has_value())
+    return;
+
+  {
+    const std::lock_guard lock(s_delivered_input_mutex);
+    if (Common::Contains(s_devices_with_delivered_input, *device_id))
+      return;
+    s_devices_with_delivered_input.push_back(*device_id);
+  }
+
+  s_first_input_event.Trigger();
+}
 
 // Creates an array that contains every possible keycode
 static jintArray CreateKeyCodesArray(JNIEnv* env)
@@ -846,6 +901,8 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
       env->GetMethodID(s_input_device_class, "getMotionRanges", "()Ljava/util/List;");
   s_input_device_get_name =
       env->GetMethodID(s_input_device_class, "getName", "()Ljava/lang/String;");
+  s_input_device_get_descriptor =
+      env->GetMethodID(s_input_device_class, "getDescriptor", "()Ljava/lang/String;");
   s_input_device_get_sources = env->GetMethodID(s_input_device_class, "getSources", "()I");
   s_input_device_has_keys = env->GetMethodID(s_input_device_class, "hasKeys", "([I)[Z");
   env->DeleteLocalRef(input_device_class);
@@ -861,6 +918,7 @@ InputBackend::InputBackend(ControllerInterface* controller_interface)
   const jclass input_event_class = env->FindClass("android/view/InputEvent");
   s_input_event_class = reinterpret_cast<jclass>(env->NewGlobalRef(input_event_class));
   s_input_event_get_device_id = env->GetMethodID(s_input_event_class, "getDeviceId", "()I");
+  s_input_event_get_source = env->GetMethodID(s_input_event_class, "getSource", "()I");
   env->DeleteLocalRef(input_event_class);
 
   const jclass key_event_class = env->FindClass("android/view/KeyEvent");
@@ -979,7 +1037,10 @@ void InputBackend::AddDevice(JNIEnv* env, jint device_id)
 
   INFO_LOG_FMT(CONTROLLERINTERFACE, "Added device ID {} as {}", device_id,
                device->GetQualifiedName());
-  s_device_id_to_device_qualifier.emplace(device_id, qualifier);
+  {
+    std::lock_guard lk(s_device_id_map_mutex);
+    s_device_id_to_device_qualifier.emplace(device_id, qualifier);
+  }
 
   jstring j_qualifier = ToJString(env, qualifier.ToString());
   env->CallVoidMethod(device->GetSensorEventListener(),
@@ -1017,7 +1078,62 @@ void InputBackend::RemoveDevice(jint device_id)
            static_cast<const AndroidDevice*>(device)->GetDeviceID() == device_id;
   });
 
-  s_device_id_to_device_qualifier.erase(device_id);
+  {
+    std::lock_guard lk(s_device_id_map_mutex);
+    s_device_id_to_device_qualifier.erase(device_id);
+  }
+}
+
+void ForgetDeliveredInput(int device_id)
+{
+  const std::lock_guard lock(s_delivered_input_mutex);
+  std::erase(s_devices_with_delivered_input, device_id);
+}
+
+Common::EventHook RegisterFirstInputCallback(Common::HookableEvent<>::CallbackType callback)
+{
+  return s_first_input_event.Register(std::move(callback));
+}
+
+// The position at which this device first delivered gamepad input, if it has
+static std::optional<int> GetInputOrder(std::optional<jint> device_id)
+{
+  if (!device_id.has_value())
+    return std::nullopt;
+
+  const std::lock_guard lock(s_delivered_input_mutex);
+  const auto it = std::ranges::find(s_devices_with_delivered_input, *device_id);
+  if (it == s_devices_with_delivered_input.end())
+    return std::nullopt;
+  return static_cast<int>(it - s_devices_with_delivered_input.begin());
+}
+
+void ForgetDeliveredInput()
+{
+  const std::lock_guard lock(s_delivered_input_mutex);
+  s_devices_with_delivered_input.clear();
+}
+
+std::optional<DeviceProperties> GetDeviceProperties(const ciface::Core::Device& device)
+{
+  if (device.GetSource() != SOURCE)
+    return std::nullopt;
+
+  const auto& android_device = static_cast<const AndroidDevice&>(device);
+
+  // Source flags are class-qualified bitfields, so they have to be masked rather than
+  // compared for equality. A positive controller number is Android's own marker for a
+  // gamepad or joystick; everything else, including a controller's touchpad and motion
+  // sensors, is left at zero.
+  const int sources = android_device.GetSourceFlags();
+  const bool is_gamepad_source = (sources & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD ||
+                                 (sources & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK;
+
+  return DeviceProperties{
+      .is_gamepad = is_gamepad_source && android_device.GetControllerNumber() > 0,
+      .descriptor = android_device.GetDescriptor(),
+      .input_order = GetInputOrder(android_device.GetDeviceID()),
+  };
 }
 
 void InputBackend::PopulateDevices()
@@ -1065,6 +1181,18 @@ Java_org_dolphinemu_dolphinemu_features_input_model_ControllerInterface_dispatch
   if (!device)
     return JNI_FALSE;
 
+  // Only a gamepad button press counts as proof that this is a real, functioning
+  // controller. A physical controller registers several devices with Android (the pad
+  // itself plus touchpad and motion-sensor nodes), and events must be filtered by their
+  // source, not just by which device they came from, so that a touchpad or sensor node
+  // cannot pass itself off as a live pad in automatic port assignment.
+  const jint key_source = env->CallIntMethod(key_event, s_input_event_get_source);
+  if (state != 0 && ((key_source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD ||
+                     (key_source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK))
+  {
+    ciface::Android::MarkDeviceInputDelivered(device.get());
+  }
+
   const jint keycode = env->CallIntMethod(key_event, s_key_event_get_keycode);
   const std::string input_name = ConstructKeyName(keycode);
 
@@ -1100,6 +1228,12 @@ Java_org_dolphinemu_dolphinemu_features_input_model_ControllerInterface_dispatch
 
   Clock::time_point last_polled{};
 
+  // A stick or trigger has to be pushed well past its resting position to count as input.
+  // Controllers report near-zero axis values continuously while they sit idle, and treating
+  // those as input would let any device claim a port without a player touching it.
+  constexpr float ACTIVITY_THRESHOLD = 0.5f;
+  bool significant_motion = false;
+
   for (ciface::Core::Device::Input* input : device->Inputs())
   {
     const std::string input_name = input->GetName();
@@ -1122,10 +1256,19 @@ Java_org_dolphinemu_dolphinemu_features_input_model_ControllerInterface_dispatch
       casted_input->SetState(value);
       last_polled = std::max(last_polled, casted_input->GetLastPolled());
 
+      if (std::abs(value) >= ACTIVITY_THRESHOLD)
+        significant_motion = true;
+
       DEBUG_LOG_FMT(CONTROLLERINTERFACE, "Set {} of {} to {}", input_name,
                     device->GetQualifiedName(), value);
     }
   }
+
+  // Only stick and trigger movement proves a live controller. Touchpad and motion-sensor
+  // nodes of the same physical controller also report motion, but not from a joystick
+  // source, and treating that as controller input lets them take a port from a real pad.
+  if (significant_motion && (source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK)
+    ciface::Android::MarkDeviceInputDelivered(device.get());
 
   return last_polled >= Clock::now() - ACTIVE_INPUT_TIMEOUT;
 }
@@ -1193,6 +1336,9 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_input_model_ControllerInterface_00024InputDeviceListener_onInputDeviceRemoved(
     JNIEnv*, jobject, jint device_id)
 {
+  // A controller that disconnects gives up its port, so that controllers connecting later
+  // claim their places anew instead of inheriting the ones they had before.
+  ciface::Android::ForgetDeliveredInput(device_id);
   ciface::Android::InputBackend::RemoveDevice(device_id);
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.h
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.h
@@ -3,10 +3,52 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+
+#include "Common/HookableEvent.h"
 #include "InputCommon/ControllerInterface/InputBackend.h"
+
+namespace ciface::Core
+{
+class Device;
+}
 
 namespace ciface::Android
 {
 std::unique_ptr<ciface::InputBackend> CreateInputBackend(ControllerInterface* controller_interface);
+
+// One physical controller is reported by Android as several input devices: the controller
+// itself plus, for instance, its touchpad and motion sensors. These properties tell the real
+// controller apart from the rest.
+struct DeviceProperties
+{
+  // Advertises a gamepad or joystick source and was given a positive controller number,
+  // which Android grants to no other kind of device.
+  bool is_gamepad = false;
+
+  // Identifies the physical controller this device belongs to. Android keeps it the same
+  // for as long as the controller exists, unlike the name and the controller number, which
+  // change as controllers come and go.
+  std::string descriptor;
+
+  // The position at which this device first delivered gamepad input, counting from zero, or
+  // nothing if it never has. This is what identifies a controller somebody is playing on:
+  // the devices Android reports alongside it never deliver any.
+  std::optional<int> input_order;
+};
+
+// Returns the properties of a device provided by this backend, or nothing for other devices.
+std::optional<DeviceProperties> GetDeviceProperties(const ciface::Core::Device& device);
+
+// Forgets which devices have delivered input, so that the next session starts over.
+void ForgetDeliveredInput();
+
+// Forgets that the given device delivered input, for when it disconnects.
+void ForgetDeliveredInput(int device_id);
+
+// Registers a listener to be called when a device delivers its first gamepad input.
+[[nodiscard]] Common::EventHook
+RegisterFirstInputCallback(Common::HookableEvent<>::CallbackType callback);
 
 }  // namespace ciface::Android


### PR DESCRIPTION
using dolphin on a docked android console/gaming device with 4 bluetooth controllers is crazy painful to configure by default. Everytime I sat down with friends to play on my Retroid pocket 6 hooked to my tv, I wasn't able to fully make all 4 bluetooth controllers work. Always at least one controller wouldnt accept the proper binding and give quick menu on circle button press. It was a mix of manual workflow complication, confusion because of one controller sometimes reporting multiple devices (ghost devices) and in general just bad handeling of what android and dolphin give us to work with. 

Now with the newly added feature, everything works fully automatic and as expected. The only workaround route we have to go rn (until we find something better) is that we can't assign player/port numbers by bluetooth controller connection/power on order, since android doesnt properly report that, but only the order in which they got paired. It's obviously not really helpful to write a logic based on that, coz then it will always give out the same fixed ports to the same controller. To workaround this, we now choose our player/port order through button press order. It's written up by the clanker down below. 

As of now, the controllers are automatically configured and mapped to be gamecube controllers with the known good button configurations. In future this feature could be expanded to allow choosing beforehand which type of remote/controller you want all bluetooth controllers to be configured to, and also which type of button mapping you prefer (could be split between custom configs and predefined stuff). 

Also, i was only able to test this with ps4 and ps5 controllers. It might need some love to work for every single supported bluetooth pad. 

Please consider adding this after review. I know Clanker commits have a certain reputation, and I too believe that every line of code written by clankers should be tripple-checked and taken with a grain of salt. I reviewed the code and didn't find anything wrong with it though, and so far on my end it works flawlessly. With this feature, I finally have an easy way to just sit down, turn everything on and start playing without having to configure everything manually everytime i start the emulator only for it to not even work completely. 

Cheers!

Clanker write up: 
# Description

Adds an **Automatic Controllers** setting, off by default, under Config > General.
While it is on, connecting controllers is all the setup there is: each controller
gets a standard GameCube mapping generated from the controls it reports, and a
port, with no manual mapping needed.

Android currently requires every physical controller to be mapped by hand before
it can be used, which is a lot of work for a four player setup and has to be
redone whenever the device identity changes.

### How ports are assigned

Players claim their port by using their controller. The first controller to send
input becomes player one, the next becomes player two, and so on, up to the four
ports, which are plugged and unplugged to match. A controller keeps its port
until it disconnects or the session ends, so nobody is renumbered mid-game, and
each session starts over.

Claiming by input is what makes this work at all, for two reasons:

1. **Android reports one physical controller as several devices.** A DualShock 4
   or DualSense adds a touchpad and motion sensors, and on some devices those
   extra entries advertise a gamepad source, a positive controller number, face
   buttons and stick axes, which makes them indistinguishable from the
   controller itself by any property I could find. Only the device a player is
   actually using ever sends input.
2. **The order devices are reported in is not the order they were connected.**
   Controllers that were already connected when the emulator started are
   reported in an order fixed by the Bluetooth stack, identical on every launch,
   so it cannot be used to decide who is player one.

Events are filtered by source as well as by device, so a touchpad or sensor
cannot claim a port with motion of its own, and a stick has to move well past
its resting position to count, so idle drift cannot claim one either.

### Scope

- The setting is off by default; with it off, nothing in this change runs.
- Only the ports this feature has assigned are touched. A port configured as a
  GBA, a keyboard, or nothing at all is left alone.
- The port configuration goes to the current-run config layer, so it is never
  written to the user's config and nothing is left behind when emulation ends.
- Generated mappings are reapplied after the Wii title change that reloads pad
  configuration from disk, and all triggers run through the host job queue so
  they cannot race that reload.

### Generated mapping

Face buttons follow physical position (south = A, west = B, east = X, north =
Y), which is how Android's key layouts report both Xbox-style and
PlayStation-style controllers. The right stick and analog triggers are chosen
together, since a controller with no dedicated trigger axes reports its triggers
on the axes another controller uses for the right stick. Rumble is bound when
the controller has a motor.