### PR TITLE
IOS/NetIPTopDevice: Zero-initialize sockaddr structs

### DIFF
--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -730,7 +730,7 @@ IPCReply NetIPTopDevice::HandleGetSockNameRequest(const IOCtlRequest& request)
 
   request.Log(GetDeviceName(), Common::Log::LogType::IOS_WC24);
 
-  sockaddr sa;
+  sockaddr sa{};
   socklen_t sa_len = sizeof(sa);
   const int ret =
       getsockname(GetEmulationKernel().GetSocketManager()->GetHostSocket(fd), &sa, &sa_len);
@@ -758,7 +758,7 @@ IPCReply NetIPTopDevice::HandleGetPeerNameRequest(const IOCtlRequest& request)
 
   u32 fd = memory.Read_U32(request.buffer_in);
 
-  sockaddr sa;
+  sockaddr sa{};
   socklen_t sa_len = sizeof(sa);
   const int ret =
       getpeername(GetEmulationKernel().GetSocketManager()->GetHostSocket(fd), &sa, &sa_len);


### PR DESCRIPTION
Fixes https://github.com/dolphin-emu/dolphin/security/advisories/GHSA-5fqv-9qrg-gm4j