### PR TITLE
Android: add dual-screen Wii pointer and GBA support

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
@@ -36,6 +36,10 @@ import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.databinding.ActivityEmulationBinding
 import org.dolphinemu.dolphinemu.databinding.DialogInputAdjustBinding
 import org.dolphinemu.dolphinemu.databinding.DialogNfcFiguresManagerBinding
+import org.dolphinemu.dolphinemu.features.dualscreen.ExternalDisplayManager
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaBootManager
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaHostBridge
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaLinkSettings
 import org.dolphinemu.dolphinemu.features.infinitybase.InfinityConfig
 import org.dolphinemu.dolphinemu.features.infinitybase.model.Figure
 import org.dolphinemu.dolphinemu.features.infinitybase.ui.FigureSlot
@@ -44,6 +48,7 @@ import org.dolphinemu.dolphinemu.features.input.model.ControllerInterface
 import org.dolphinemu.dolphinemu.features.input.model.DolphinSensorEventListener
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import org.dolphinemu.dolphinemu.features.settings.model.IntSetting
+import org.dolphinemu.dolphinemu.features.settings.model.NativeConfig
 import org.dolphinemu.dolphinemu.features.settings.model.Settings
 import org.dolphinemu.dolphinemu.features.settings.model.StringSetting
 import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag
@@ -53,6 +58,7 @@ import org.dolphinemu.dolphinemu.features.skylanders.model.Skylander
 import org.dolphinemu.dolphinemu.features.skylanders.ui.SkylanderSlot
 import org.dolphinemu.dolphinemu.features.skylanders.ui.SkylanderSlotAdapter
 import org.dolphinemu.dolphinemu.fragments.EmulationFragment
+import org.dolphinemu.dolphinemu.fragments.GbaPacksFragment
 import org.dolphinemu.dolphinemu.fragments.MenuFragment
 import org.dolphinemu.dolphinemu.fragments.SaveLoadStateFragment
 import org.dolphinemu.dolphinemu.fragments.SaveLoadStateFragment.SaveOrLoad
@@ -71,6 +77,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
     private var emulationFragment: EmulationFragment? = null
 
     private lateinit var settings: Settings
+    private lateinit var externalDisplayManager: ExternalDisplayManager
 
     override var themeId = 0
 
@@ -100,6 +107,43 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
     ) { uri: Uri? ->
         if (uri != null) {
             NativeLibrary.ChangeDisc(uri.toString())
+        }
+    }
+
+    private val requestGameBoyPlayerRomFile = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        if (uri == null) {
+            return@registerForActivityResult
+        }
+
+        val canonicalizedUri = contentResolver.canonicalize(uri) ?: uri
+        FileBrowserHelper.runAfterExtensionCheck(
+            this,
+            canonicalizedUri,
+            FileBrowserHelper.GBA_ROM_EXTENSIONS
+        ) {
+            try {
+                contentResolver.takePersistableUriPermission(
+                    canonicalizedUri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            } catch (_: SecurityException) {
+            }
+
+            val path = canonicalizedUri.toString()
+            StringSetting.MAIN_GB_PLAYER_ROM.setString(settings, path)
+            StringSetting.MAIN_GB_PLAYER_ROM.setString(NativeConfig.LAYER_BASE, path)
+            NativeConfig.save(NativeConfig.LAYER_BASE)
+
+            Toast.makeText(
+                this,
+                getString(
+                    R.string.emulation_gba_pack_updated,
+                    getString(R.string.emulation_gba_pack_player)
+                ),
+                Toast.LENGTH_LONG
+            ).show()
         }
     }
 
@@ -204,6 +248,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
 
         settings = Settings()
         settings.loadSettings()
+        externalDisplayManager = ExternalDisplayManager(this)
 
         // Set these options now so that the SurfaceView the game renders into is the right size.
         enableFullscreenImmersive()
@@ -286,6 +331,22 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
         }
     }
 
+    val isInternalGbaScreenVisible: Boolean
+        get() = emulationFragment?.isInternalGbaScreenVisible == true
+
+    fun shouldShowInternalGbaScreenMenu(): Boolean {
+        if (!isGameCubeWithEmulatedGbaPort()) {
+            return false
+        }
+
+        return !BooleanSetting.MAIN_DUAL_SCREEN_EXTERNAL_DISPLAY.boolean ||
+                !BooleanSetting.MAIN_GBA_LINK_EXTERNAL_DISPLAY.boolean ||
+                !::externalDisplayManager.isInitialized ||
+                !externalDisplayManager.hasPresentationDisplay()
+    }
+
+    fun shouldShowGbaPacksMenu(): Boolean = isGameCubeWithEmulatedGbaPort()
+
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         if (hasFocus) {
             enableFullscreenImmersive()
@@ -312,6 +373,12 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
         }
 
         DolphinSensorEventListener.setDeviceRotation(windowManager.defaultDisplay.rotation)
+        externalDisplayManager.start()
+    }
+
+    override fun onPause() {
+        externalDisplayManager.stop()
+        super.onPause()
     }
 
     override fun onStop() {
@@ -332,6 +399,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             emulationFragment?.refreshInputOverlay()
 
             updateDisplaySettings()
+            externalDisplayManager.refresh()
         } catch (_: IllegalStateException) {
             // Most likely the core delivered an onTitleChanged while emulation was shutting down.
             // Let's just ignore it, since we're about to shut down anyway.
@@ -339,6 +407,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
     }
 
     override fun onDestroy() {
+        externalDisplayManager.stop()
         super.onDestroy()
         settings.close()
     }
@@ -511,6 +580,8 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             MENU_ACTION_LOAD_SLOT5 -> NativeLibrary.LoadState(4)
             MENU_ACTION_LOAD_SLOT6 -> NativeLibrary.LoadState(5)
             MENU_ACTION_CHANGE_DISC -> requestChangeDisc.launch("*/*")
+            MENU_ACTION_TOGGLE_GBA_SCREEN -> toggleInternalGbaScreen()
+            MENU_ACTION_GBA_PACKS -> showGbaPacksSubMenu()
 
             MENU_SET_IR_MODE -> setIRMode()
             MENU_ACTION_CHOOSE_DOUBLETAP -> chooseDoubleTapButton()
@@ -913,6 +984,51 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             .show()
     }
 
+    private fun toggleInternalGbaScreen() {
+        if (!shouldShowInternalGbaScreenMenu()) {
+            return
+        }
+
+        if (!isInternalGbaScreenVisible && !GbaHostBridge.hasActiveCore()) {
+            Toast.makeText(this, R.string.emulation_gba_screen_no_core, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        emulationFragment?.toggleInternalGbaScreen()
+        closeMenu()
+    }
+
+    fun chooseGameBoyPlayerRom() {
+        closeSubmenu()
+        closeMenu()
+        requestGameBoyPlayerRomFile.launch(arrayOf("*/*"))
+    }
+
+    private fun showGbaPacksSubMenu() {
+        supportFragmentManager.popBackStack(
+            BACKSTACK_NAME_SUBMENU,
+            FragmentManager.POP_BACK_STACK_INCLUSIVE
+        )
+
+        val fragment: Fragment = GbaPacksFragment()
+        supportFragmentManager.beginTransaction()
+            .setCustomAnimations(
+                R.animator.menu_slide_in_from_end,
+                R.animator.menu_slide_out_to_end,
+                R.animator.menu_slide_in_from_end,
+                R.animator.menu_slide_out_to_end
+            )
+            .replace(R.id.frame_submenu, fragment)
+            .addToBackStack(BACKSTACK_NAME_SUBMENU)
+            .commit()
+    }
+
+    private fun isGameCubeWithEmulatedGbaPort(): Boolean {
+        return NativeLibrary.IsGameMetadataValid() &&
+                !NativeLibrary.IsEmulatingWii() &&
+                GbaLinkSettings.hasAnyEmulatedGbaPortConfigured()
+    }
+
     fun setSkylanderData(id: Int, variant: Int, name: String, slot: Int) {
         skylanderData = Skylander(id, variant, name)
         skylanderSlot = slot
@@ -1009,6 +1125,10 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
 
     fun initInputPointer() {
         emulationFragment?.initInputPointer()
+        if (::externalDisplayManager.isInitialized) {
+            externalDisplayManager.refreshPointerSettings()
+            externalDisplayManager.refresh()
+        }
     }
 
     override fun setTheme(themeId: Int) {
@@ -1077,6 +1197,8 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
         const val MENU_ACTION_SKYLANDERS = 36
         const val MENU_ACTION_INFINITY_BASE = 37
         const val MENU_ACTION_LATCHING_CONTROLS = 38
+        const val MENU_ACTION_TOGGLE_GBA_SCREEN = 39
+        const val MENU_ACTION_GBA_PACKS = 40
 
         init {
             buttonsActionsMap.apply {
@@ -1098,7 +1220,9 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             if (ignoreLaunchRequests)
                 return
 
-            performLaunchChecks(activity, fromIntent) { launchWithoutChecks(activity, filePaths, riivolution) }
+            performLaunchChecks(activity, fromIntent, filePaths) {
+                launchWithoutChecks(activity, filePaths, riivolution)
+            }
         }
 
         @JvmStatic
@@ -1117,11 +1241,29 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             activity.startActivity(launcher)
         }
 
-        private fun performLaunchChecks(activity: FragmentActivity, fromIntent: Boolean, continueCallback: Runnable) {
+        private fun performLaunchChecks(
+            activity: FragmentActivity,
+            fromIntent: Boolean,
+            filePaths: Array<String>?,
+            continueCallback: Runnable
+        ) {
             AfterDirectoryInitializationRunner().runWithLifecycle(activity) {
-                if (fromIntent) {
-                    activity.finish()
+                val continueLaunch = Runnable {
+                    if (fromIntent) {
+                        activity.finish()
+                    }
+                    continueCallback.run()
                 }
+
+                val runGbaBiosCheck = Runnable {
+                    GbaBootManager.continueAfterBiosCheck(
+                        activity,
+                        fromIntent,
+                        filePaths,
+                        continueLaunch
+                    )
+                }
+
                 if (!FileBrowserHelper.isPathEmptyOrValid(StringSetting.MAIN_DEFAULT_ISO) ||
                     !FileBrowserHelper.isPathEmptyOrValid(StringSetting.MAIN_FS_PATH) ||
                     !FileBrowserHelper.isPathEmptyOrValid(StringSetting.MAIN_DUMP_PATH) ||
@@ -1131,10 +1273,13 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
                     MaterialAlertDialogBuilder(activity)
                         .setMessage(R.string.unavailable_paths)
                         .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
+                            if (fromIntent) {
+                                activity.finish()
+                            }
                             SettingsActivity.launch(activity, MenuTag.CONFIG_PATHS)
                         }
                         .setNeutralButton(R.string.continue_anyway) { _: DialogInterface?, _: Int ->
-                            continueCallback.run()
+                            runGbaBiosCheck.run()
                         }
                         .show()
                 } else if (!FileBrowserHelper.isPathEmptyOrValid(StringSetting.MAIN_WII_SD_CARD_IMAGE_PATH) ||
@@ -1143,14 +1288,17 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
                     MaterialAlertDialogBuilder(activity)
                         .setMessage(R.string.unavailable_paths)
                         .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
+                            if (fromIntent) {
+                                activity.finish()
+                            }
                             SettingsActivity.launch(activity, MenuTag.CONFIG_WII)
                         }
                         .setNeutralButton(R.string.continue_anyway) { _: DialogInterface?, _: Int ->
-                            continueCallback.run()
+                            runGbaBiosCheck.run()
                         }
                         .show()
                 } else {
-                    continueCallback.run()
+                    runGbaBiosCheck.run()
                 }
             }
         }
@@ -1160,7 +1308,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             if (ignoreLaunchRequests)
                 return
 
-            performLaunchChecks(activity, false) { launchSystemMenuWithoutChecks(activity) }
+            performLaunchChecks(activity, false, null) { launchSystemMenuWithoutChecks(activity) }
         }
 
         private fun launchSystemMenuWithoutChecks(activity: FragmentActivity) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GbaGameAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GbaGameAdapter.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.adapters
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.FragmentActivity
+import androidx.recyclerview.widget.RecyclerView
+import org.dolphinemu.dolphinemu.databinding.ListItemGbaGameBinding
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaBootManager
+import org.dolphinemu.dolphinemu.model.GbaGameFile
+
+class GbaGameAdapter : RecyclerView.Adapter<GbaGameAdapter.GbaGameViewHolder>(),
+    View.OnClickListener {
+    private var gameFiles: List<GbaGameFile> = emptyList()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GbaGameViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ListItemGbaGameBinding.inflate(inflater, parent, false)
+        binding.root.setOnClickListener(this)
+        return GbaGameViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: GbaGameViewHolder, position: Int) {
+        val gameFile = gameFiles[position]
+        holder.gameFile = gameFile
+        holder.binding.textGbaTitle.text = gameFile.title
+        holder.binding.textGbaFolder.text = gameFile.folderLabel
+    }
+
+    override fun getItemCount(): Int = gameFiles.size
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun swapDataSet(nextGameFiles: List<GbaGameFile>) {
+        gameFiles = nextGameFiles
+        notifyDataSetChanged()
+    }
+
+    override fun onClick(view: View) {
+        val holder = view.tag as GbaGameViewHolder
+        GbaBootManager.launchGameBoyPlayer(view.context as FragmentActivity, holder.gameFile.path)
+    }
+
+    class GbaGameViewHolder(val binding: ListItemGbaGameBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        lateinit var gameFile: GbaGameFile
+
+        init {
+            binding.root.tag = this
+        }
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.kt
@@ -28,7 +28,8 @@ class PlatformPagerAdapter(
         val TAB_ICONS = intArrayOf(
             R.drawable.ic_gamecube,
             R.drawable.ic_wii,
-            R.drawable.ic_folder
+            R.drawable.ic_folder,
+            R.drawable.ic_gba
         )
     }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/DualScreenPresentation.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/DualScreenPresentation.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.dualscreen
+
+import android.app.Presentation
+import android.content.Context
+import android.os.Bundle
+import android.view.Display
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.widget.FrameLayout
+import androidx.core.view.isNotEmpty
+import org.dolphinemu.dolphinemu.features.input.model.ControllerInterface
+
+class DualScreenPresentation(
+    outerContext: Context,
+    display: Display
+) : Presentation(outerContext, display) {
+    enum class Mode {
+        EMPTY,
+        WII_POINTER,
+        GBA_SCREEN
+    }
+
+    private lateinit var container: FrameLayout
+    private var currentMode = Mode.EMPTY
+    private var pointerView: WiiPointerTouchpadView? = null
+    private var gbaView: GbaScreenView? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setCancelable(false)
+        setCanceledOnTouchOutside(false)
+        container = FrameLayout(context)
+        setContentView(container)
+        if (currentMode != Mode.EMPTY) {
+            showMode(currentMode)
+        }
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (currentMode == Mode.GBA_SCREEN && isGameControllerEvent(event)) {
+            gbaView?.requestInputFocus()
+        }
+        val handled = ControllerInterface.dispatchKeyEvent(event)
+        return handled || isGameControllerEvent(event) || super.dispatchKeyEvent(event)
+    }
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+        if (isGameControllerSource(event.source)) {
+            gbaView?.requestInputFocus()
+            ControllerInterface.dispatchGenericMotionEvent(event)
+            return true
+        }
+
+        return super.dispatchGenericMotionEvent(event)
+    }
+
+    fun showMode(mode: Mode) {
+        if (currentMode == mode && ::container.isInitialized && container.isNotEmpty()) {
+            return
+        }
+
+        currentMode = mode
+        if (!::container.isInitialized) {
+            return
+        }
+
+        container.removeAllViews()
+        when (mode) {
+            Mode.WII_POINTER -> {
+                pointerView = WiiPointerTouchpadView(context)
+                gbaView = null
+                container.addView(pointerView, fullSizeLayoutParams())
+            }
+
+            Mode.GBA_SCREEN -> {
+                gbaView = GbaScreenView(context)
+                pointerView = null
+                container.addView(gbaView, fullSizeLayoutParams())
+            }
+
+            Mode.EMPTY -> {
+                pointerView?.clearPointerState()
+                pointerView = null
+                gbaView = null
+            }
+        }
+    }
+
+    fun refreshPointerSettings() {
+        pointerView?.refreshSettings()
+    }
+
+    fun refreshGbaSettings() {
+        gbaView?.refreshSettings()
+    }
+
+    fun clearPointerState() {
+        pointerView?.clearPointerState()
+    }
+
+    private fun fullSizeLayoutParams() = FrameLayout.LayoutParams(
+        FrameLayout.LayoutParams.MATCH_PARENT,
+        FrameLayout.LayoutParams.MATCH_PARENT
+    )
+
+    private fun isGameControllerSource(source: Int): Boolean {
+        return source and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD ||
+                source and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
+    }
+
+    private fun isGameControllerEvent(event: KeyEvent): Boolean {
+        return isGameControllerSource(event.source) ||
+                event.device?.sources?.let { isGameControllerSource(it) } == true
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/ExternalDisplayManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/ExternalDisplayManager.kt
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.dualscreen
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.os.Handler
+import android.os.Looper
+import android.view.Display
+import org.dolphinemu.dolphinemu.NativeLibrary
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
+
+class ExternalDisplayManager(private val context: Context) : DisplayManager.DisplayListener,
+    GbaHostBridge.Listener {
+    private val displayManager =
+        context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var presentation: DualScreenPresentation? = null
+    private var started = false
+
+    fun start() {
+        if (started) {
+            refresh()
+            return
+        }
+
+        started = true
+        displayManager.registerDisplayListener(this, mainHandler)
+        GbaHostBridge.addListener(this)
+        refresh()
+    }
+
+    fun stop() {
+        if (!started) {
+            return
+        }
+
+        dismissPresentation()
+        GbaHostBridge.removeListener(this)
+        displayManager.unregisterDisplayListener(this)
+        started = false
+    }
+
+    fun refresh() {
+        if (!started || !BooleanSetting.MAIN_DUAL_SCREEN_EXTERNAL_DISPLAY.boolean) {
+            dismissPresentation()
+            return
+        }
+
+        val display = findPresentationDisplay(displayManager)
+        if (display == null) {
+            dismissPresentation()
+            return
+        }
+
+        val mode = resolveMode()
+        if (mode == DualScreenPresentation.Mode.EMPTY) {
+            dismissPresentation()
+            return
+        }
+
+        if (presentation?.display?.displayId != display.displayId) {
+            dismissPresentation()
+            presentation = DualScreenPresentation(context, display).also {
+                it.show()
+            }
+        }
+
+        presentation?.showMode(mode)
+        presentation?.refreshGbaSettings()
+    }
+
+    fun refreshPointerSettings() {
+        presentation?.refreshPointerSettings()
+    }
+
+    fun hasPresentationDisplay(): Boolean = findPresentationDisplay(displayManager) != null
+
+    override fun onDisplayAdded(displayId: Int) = refresh()
+
+    override fun onDisplayRemoved(displayId: Int) = refresh()
+
+    override fun onDisplayChanged(displayId: Int) = refresh()
+
+    override fun onGbaGameChanged(info: GbaHostBridge.CoreInfo) = refresh()
+
+    override fun onGbaVisibleDeviceChanged(deviceNumber: Int, info: GbaHostBridge.CoreInfo?) =
+        refresh()
+
+    private fun dismissPresentation() {
+        presentation?.clearPointerState()
+        presentation?.dismiss()
+        presentation = null
+    }
+
+    private fun resolveMode(): DualScreenPresentation.Mode {
+        if (!NativeLibrary.IsGameMetadataValid()) {
+            return DualScreenPresentation.Mode.EMPTY
+        }
+
+        if (NativeLibrary.IsEmulatingWii()) {
+            return if (
+                BooleanSetting.MAIN_DUAL_SCREEN_WII_POINTER_TOUCHPAD.boolean &&
+                NativeLibrary.IsRunning() &&
+                NativeLibrary.HasSurface()
+            ) {
+                DualScreenPresentation.Mode.WII_POINTER
+            } else {
+                DualScreenPresentation.Mode.EMPTY
+            }
+        }
+
+        return if (BooleanSetting.MAIN_GBA_LINK_EXTERNAL_DISPLAY.boolean &&
+            GbaLinkSettings.hasAnyEmulatedGbaPortConfigured() &&
+            GbaHostBridge.hasActiveCore()
+        ) {
+            DualScreenPresentation.Mode.GBA_SCREEN
+        } else {
+            DualScreenPresentation.Mode.EMPTY
+        }
+    }
+
+    companion object {
+        fun hasPresentationDisplay(context: Context): Boolean {
+            val displayManager =
+                context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+            return findPresentationDisplay(displayManager) != null
+        }
+
+        private fun findPresentationDisplay(displayManager: DisplayManager): Display? =
+            displayManager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION).firstOrNull {
+                it.displayId != Display.DEFAULT_DISPLAY && it.state == Display.STATE_ON
+            }
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaBootManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaBootManager.kt
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.dualscreen
+
+import android.content.DialogInterface
+import androidx.core.net.toUri
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.activities.EmulationActivity
+import org.dolphinemu.dolphinemu.features.settings.model.NativeConfig
+import org.dolphinemu.dolphinemu.features.settings.model.SharedPreferenceStringSetting
+import org.dolphinemu.dolphinemu.features.settings.model.StringSetting
+import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag
+import org.dolphinemu.dolphinemu.features.settings.ui.SettingsActivity
+import org.dolphinemu.dolphinemu.model.GameFile
+import org.dolphinemu.dolphinemu.ui.platform.Platform
+import org.dolphinemu.dolphinemu.utils.ContentHandler
+import org.dolphinemu.dolphinemu.utils.FileBrowserHelper
+import java.io.File
+
+object GbaBootManager {
+    fun isGbaRomPath(path: String): Boolean {
+        val extension = FileBrowserHelper.getExtension(displayNameFor(path), false)
+        return extension != null &&
+                FileBrowserHelper.GBA_ROM_EXTENSIONS.contains(extension.lowercase())
+    }
+
+    fun titleFor(path: String): String {
+        val displayName = displayNameFor(path)
+        return displayName.substringBeforeLast('.', displayName)
+    }
+
+    fun displayNameFor(path: String): String {
+        if (ContentHandler.isContentUri(path)) {
+            val displayName = ContentHandler.getDisplayName(path)
+            if (!displayName.isNullOrEmpty()) {
+                return displayName
+            }
+
+            val lastPathSegment = path.toUri().lastPathSegment
+            if (!lastPathSegment.isNullOrEmpty()) {
+                return lastPathSegment.substringAfterLast('/')
+            }
+        }
+
+        val fileName = File(path).name
+        return fileName.ifEmpty { path.substringAfterLast('/') }
+    }
+
+    fun launchGameBoyPlayer(activity: FragmentActivity, gbaPath: String) {
+        val bootPath = SharedPreferenceStringSetting.MAIN_ANDROID_GB_PLAYER_BOOT_PATH.string
+        if (bootPath.isEmpty() || !isPathValid(bootPath)) {
+            MaterialAlertDialogBuilder(activity)
+                .setMessage(R.string.gb_player_boot_path_required)
+                .setPositiveButton(R.string.yes) { _: DialogInterface?, _: Int ->
+                    SettingsActivity.launch(activity, MenuTag.CONFIG_GAME_CUBE)
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+            return
+        }
+
+        StringSetting.MAIN_GB_PLAYER_ROM.setString(NativeConfig.LAYER_BASE, gbaPath)
+        NativeConfig.save(NativeConfig.LAYER_BASE)
+        EmulationActivity.launch(activity, bootPath, false)
+    }
+
+    fun continueAfterBiosCheck(
+        activity: FragmentActivity,
+        fromIntent: Boolean,
+        filePaths: Array<String>?,
+        continueCallback: Runnable
+    ) {
+        if (filePaths.isNullOrEmpty()) {
+            continueCallback.run()
+            return
+        }
+
+        activity.lifecycleScope.launch {
+            val shouldWarn = withContext(Dispatchers.IO) {
+                GameFile.parse(filePaths[0])?.getPlatform() == Platform.GAMECUBE.toInt() &&
+                        GbaLinkSettings.shouldWarnAboutMissingBios()
+            }
+
+            if (!shouldWarn) {
+                continueCallback.run()
+                return@launch
+            }
+
+            MaterialAlertDialogBuilder(activity)
+                .setTitle(R.string.gba_bios_required_title)
+                .setMessage(R.string.gba_bios_required_message)
+                .setPositiveButton(R.string.configure_bios) { _: DialogInterface?, _: Int ->
+                    if (fromIntent) {
+                        activity.finish()
+                    }
+                    SettingsActivity.launch(activity, MenuTag.CONFIG_GAME_CUBE)
+                }
+                .setNeutralButton(R.string.continue_anyway) { _: DialogInterface?, _: Int ->
+                    continueCallback.run()
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+        }
+    }
+
+    private fun isPathValid(path: String): Boolean {
+        return if (ContentHandler.isContentUri(path)) {
+            ContentHandler.exists(path)
+        } else {
+            File(path).exists()
+        }
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaHostBridge.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaHostBridge.kt
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.dualscreen
+
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.Keep
+import java.util.concurrent.CopyOnWriteArraySet
+
+object GbaHostBridge {
+    private data class Frame(
+        val deviceNumber: Int,
+        val width: Int,
+        val height: Int,
+        val pixels: IntArray
+    )
+
+    data class CoreInfo(
+        val deviceNumber: Int,
+        val width: Int,
+        val height: Int,
+        val isGba: Boolean,
+        val hasRom: Boolean,
+        val title: String
+    )
+
+    interface Listener {
+        fun onGbaGameChanged(info: CoreInfo) {}
+        fun onGbaVisibleDeviceChanged(deviceNumber: Int, info: CoreInfo?) {}
+        fun onGbaFrame(deviceNumber: Int, width: Int, height: Int, pixels: IntArray) {}
+    }
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val infos = arrayOfNulls<CoreInfo>(DEVICE_COUNT)
+
+    private val listeners = CopyOnWriteArraySet<Listener>()
+    private val frameLock = Any()
+    private var pendingFrame: Frame? = null
+    private var frameDispatchPosted = false
+    private var frameConsumerCount = 0
+
+    @Volatile
+    var visibleDeviceNumber: Int = NO_DEVICE
+        private set
+
+    @JvmStatic
+    external fun setVisibleDevice(deviceNumber: Int)
+
+    fun addListener(listener: Listener) {
+        listeners.add(listener)
+        listener.onGbaVisibleDeviceChanged(visibleDeviceNumber, getVisibleInfo())
+    }
+
+    fun removeListener(listener: Listener) {
+        listeners.remove(listener)
+    }
+
+    fun registerFrameConsumer() {
+        frameConsumerCount++
+        refreshVisibleDevice()
+    }
+
+    fun unregisterFrameConsumer() {
+        frameConsumerCount--
+        refreshVisibleDevice()
+    }
+
+    fun hasActiveCore(): Boolean =
+        infos.any { it?.isGba == true || it?.hasRom == true }
+
+    private fun getVisibleInfo(): CoreInfo? =
+        if (visibleDeviceNumber in infos.indices) infos[visibleDeviceNumber] else null
+
+    private fun refreshVisibleDevice() {
+        val nextDevice = when {
+            frameConsumerCount == 0 -> NO_DEVICE
+            infos[GB_PLAYER_DEVICE]?.hasRom == true -> GB_PLAYER_DEVICE
+            else -> LINK_DEVICE_RANGE.firstOrNull { infos[it]?.hasRom == true }
+                ?: LINK_DEVICE_RANGE.firstOrNull { infos[it]?.isGba == true }
+                ?: NO_DEVICE
+        }
+
+        if (nextDevice != visibleDeviceNumber) {
+            visibleDeviceNumber = nextDevice
+            setVisibleDevice(nextDevice)
+            val info = getVisibleInfo()
+            for (listener in listeners) {
+                listener.onGbaVisibleDeviceChanged(nextDevice, info)
+            }
+        }
+    }
+
+    @Keep
+    @JvmStatic
+    fun onGameChanged(
+        deviceNumber: Int,
+        width: Int,
+        height: Int,
+        isGba: Boolean,
+        hasRom: Boolean,
+        title: String
+    ) {
+        mainHandler.post {
+            val info = CoreInfo(deviceNumber, width, height, isGba, hasRom, title)
+            infos[deviceNumber] = info
+            refreshVisibleDevice()
+            for (listener in listeners) {
+                listener.onGbaGameChanged(info)
+            }
+        }
+    }
+
+    @Keep
+    @JvmStatic
+    fun onCoreStopped(deviceNumber: Int) {
+        mainHandler.post {
+            infos[deviceNumber] = null
+            refreshVisibleDevice()
+        }
+    }
+
+    @Keep
+    @JvmStatic
+    fun onFrame(deviceNumber: Int, width: Int, height: Int, pixels: IntArray) {
+        if (deviceNumber != visibleDeviceNumber) {
+            return
+        }
+
+        synchronized(frameLock) {
+            pendingFrame = Frame(deviceNumber, width, height, pixels)
+            if (frameDispatchPosted) {
+                return
+            }
+            frameDispatchPosted = true
+        }
+        mainHandler.post(::dispatchPendingFrame)
+    }
+
+    private fun dispatchPendingFrame() {
+        val frame = synchronized(frameLock) {
+            frameDispatchPosted = false
+            pendingFrame.also { pendingFrame = null }
+        } ?: return
+
+        if (frame.deviceNumber == visibleDeviceNumber) {
+            for (listener in listeners) {
+                listener.onGbaFrame(
+                    frame.deviceNumber,
+                    frame.width,
+                    frame.height,
+                    frame.pixels
+                )
+            }
+        }
+    }
+
+    const val NO_DEVICE = -1
+    const val GB_PLAYER_DEVICE = 4
+
+    private const val DEVICE_COUNT = 5
+    private val LINK_DEVICE_RANGE = 0..3
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaInputFocusManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaInputFocusManager.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.dualscreen
+
+import org.dolphinemu.dolphinemu.features.input.model.InputOverrider
+
+object GbaInputFocusManager {
+    private var focusedDevice = GbaHostBridge.NO_DEVICE
+    private var blockedGameCubePorts = IntArray(0)
+
+    fun onGbaInputRegistered(deviceNumber: Int) {
+        if (deviceNumber in GBA_DEVICE_RANGE &&
+            GbaLinkSettings.hasIndependentPhysicalController(deviceNumber)
+        ) {
+            InputOverrider.setGbaInputEnabled(deviceNumber, true)
+        }
+    }
+
+    fun requestFocus(deviceNumber: Int) {
+        if (deviceNumber !in GBA_DEVICE_RANGE) {
+            return
+        }
+
+        if (focusedDevice != deviceNumber) {
+            clearFocus()
+            focusedDevice = deviceNumber
+            blockedGameCubePorts =
+                GbaLinkSettings.getGameCubePortsSharingPhysicalController(deviceNumber)
+        }
+
+        setGameCubeInputEnabled(blockedGameCubePorts, false)
+        InputOverrider.setGbaInputEnabled(deviceNumber, true)
+    }
+
+    fun clearFocus(deviceNumber: Int? = null) {
+        val currentDevice = focusedDevice
+        if (currentDevice !in GBA_DEVICE_RANGE ||
+            deviceNumber != null && deviceNumber != currentDevice
+        ) {
+            return
+        }
+
+        InputOverrider.setGbaInputEnabled(
+            currentDevice,
+            GbaLinkSettings.hasIndependentPhysicalController(currentDevice)
+        )
+        setGameCubeInputEnabled(blockedGameCubePorts, true)
+        blockedGameCubePorts = IntArray(0)
+        focusedDevice = GbaHostBridge.NO_DEVICE
+    }
+
+    private fun setGameCubeInputEnabled(controllerIndices: IntArray, enabled: Boolean) {
+        for (controllerIndex in controllerIndices) {
+            InputOverrider.registerGameCube(controllerIndex)
+            InputOverrider.setGameCubeInputEnabled(controllerIndex, enabled)
+        }
+    }
+
+    private val GBA_DEVICE_RANGE = 0..3
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaLinkSettings.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaLinkSettings.kt
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.dualscreen
+
+import org.dolphinemu.dolphinemu.features.input.model.ControllerInterface
+import org.dolphinemu.dolphinemu.features.input.model.controlleremu.EmulatedController
+import org.dolphinemu.dolphinemu.features.settings.model.IntSetting
+import org.dolphinemu.dolphinemu.features.settings.model.StringSetting
+import org.dolphinemu.dolphinemu.utils.ContentHandler
+import org.dolphinemu.dolphinemu.utils.DirectoryInitialization
+import java.io.File
+
+object GbaLinkSettings {
+    const val SIDEVICE_GC_GBA_EMULATED = 13
+
+    const val SCALE_MODE_FIT = 0
+    const val SCALE_MODE_STRETCH = 1
+    const val SCALE_MODE_INTEGER = 2
+
+    const val POSITION_CENTER = 0
+    const val POSITION_TOP = 1
+    const val POSITION_BOTTOM = 2
+    const val POSITION_LEFT = 3
+    const val POSITION_RIGHT = 4
+
+    fun normalizeScaleMode(scaleMode: Int): Int = when (scaleMode) {
+        SCALE_MODE_FIT,
+        SCALE_MODE_STRETCH,
+        SCALE_MODE_INTEGER -> scaleMode
+        else -> SCALE_MODE_FIT
+    }
+
+    fun normalizePosition(position: Int): Int = when (position) {
+        POSITION_CENTER,
+        POSITION_TOP,
+        POSITION_BOTTOM,
+        POSITION_LEFT,
+        POSITION_RIGHT -> position
+        else -> POSITION_CENTER
+    }
+
+    fun hasAnyEmulatedGbaPortConfigured(): Boolean =
+        siDeviceSettings.any { it.int == SIDEVICE_GC_GBA_EMULATED }
+
+    fun shouldWarnAboutMissingBios(): Boolean =
+        siDeviceSettings.indices.any { index ->
+            siDeviceSettings[index].int == SIDEVICE_GC_GBA_EMULATED &&
+                    gbaRomSettings[index].string.isBlank()
+        } && !hasUsableBios()
+
+    fun hasConfiguredPhysicalController(deviceNumber: Int): Boolean {
+        val defaultDevice = getGbaPhysicalDevice(deviceNumber) ?: return false
+        return ControllerInterface.getDevice(defaultDevice) != null
+    }
+
+    fun hasIndependentPhysicalController(deviceNumber: Int): Boolean =
+        getGbaPhysicalDevice(deviceNumber) != null &&
+                getGameCubePortsSharingPhysicalController(deviceNumber).isEmpty()
+
+    fun getGameCubePortsSharingPhysicalController(deviceNumber: Int): IntArray {
+        val gbaDevice = getGbaPhysicalDevice(deviceNumber) ?: return IntArray(0)
+        return GBA_DEVICE_RANGE.filter { controllerIndex ->
+            siDeviceSettings[controllerIndex].int in GAMECUBE_PAD_DEVICE_TYPES &&
+                    getPhysicalDevice(EmulatedController.getGcPad(controllerIndex)) == gbaDevice
+        }.toIntArray()
+    }
+
+    private fun getGbaPhysicalDevice(deviceNumber: Int): String? {
+        if (deviceNumber !in GBA_DEVICE_RANGE) {
+            return null
+        }
+
+        return getPhysicalDevice(EmulatedController.getGbaPad(deviceNumber))
+    }
+
+    private fun getPhysicalDevice(controller: EmulatedController): String? {
+        val defaultDevice = controller.getDefaultDevice()
+        return defaultDevice.takeIf {
+            it.isNotEmpty() && !it.endsWith("/Touchscreen")
+        }
+    }
+
+    private val GBA_DEVICE_RANGE = 0..3
+    private val GAMECUBE_PAD_DEVICE_TYPES = intArrayOf(
+        SIDEVICE_GC_CONTROLLER,
+        SIDEVICE_GC_STEERING,
+        SIDEVICE_DANCEMAT,
+        SIDEVICE_GC_TARUKONGA,
+        SIDEVICE_AM_BASEBOARD
+    )
+
+    private val siDeviceSettings = arrayOf(
+        IntSetting.MAIN_SI_DEVICE_0,
+        IntSetting.MAIN_SI_DEVICE_1,
+        IntSetting.MAIN_SI_DEVICE_2,
+        IntSetting.MAIN_SI_DEVICE_3
+    )
+
+    private val gbaRomSettings = arrayOf(
+        StringSetting.MAIN_GBA_ROM_1,
+        StringSetting.MAIN_GBA_ROM_2,
+        StringSetting.MAIN_GBA_ROM_3,
+        StringSetting.MAIN_GBA_ROM_4
+    )
+
+    private fun hasUsableBios(): Boolean {
+        val configuredPath = StringSetting.MAIN_GBA_BIOS_PATH.string
+        val path = configuredPath.ifBlank {
+            File(DirectoryInitialization.getUserDirectory(), "GBA/gba_bios.bin").path
+        }
+
+        val size = if (ContentHandler.isContentUri(path)) {
+            ContentHandler.getSizeAndIsDirectory(path)
+        } else {
+            val file = File(path)
+            if (file.isFile) file.length() else -1
+        }
+
+        return size == GBA_BIOS_SIZE
+    }
+
+    private const val GBA_BIOS_SIZE = 0x4000L
+    private const val SIDEVICE_GC_CONTROLLER = 6
+    private const val SIDEVICE_GC_STEERING = 8
+    private const val SIDEVICE_DANCEMAT = 9
+    private const val SIDEVICE_GC_TARUKONGA = 10
+    private const val SIDEVICE_AM_BASEBOARD = 11
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaScreenView.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/GbaScreenView.kt
@@ -1,0 +1,590 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.dualscreen
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.os.Handler
+import android.os.Looper
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.MotionEvent
+import android.view.View
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.scale
+import androidx.core.view.isVisible
+import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.features.input.model.InputOverrider
+import org.dolphinemu.dolphinemu.features.input.model.InputOverrider.ControlId
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
+import org.dolphinemu.dolphinemu.features.settings.model.IntSetting
+import org.dolphinemu.dolphinemu.overlay.InputOverlayDrawableButton
+import org.dolphinemu.dolphinemu.overlay.InputOverlayDrawableDpad
+import kotlin.math.floor
+
+class GbaScreenView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : View(context, attrs), GbaHostBridge.Listener {
+    private val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.BLACK
+        style = Paint.Style.FILL
+    }
+    private val framePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        isFilterBitmap = false
+    }
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textAlign = Paint.Align.CENTER
+        textSize = sp(22f)
+    }
+
+    private var bitmap: Bitmap? = null
+    private var visibleDevice = GbaHostBridge.NO_DEVICE
+    private var visibleInfo: GbaHostBridge.CoreInfo? = null
+    private var title = ""
+    private var titleVisible = true
+    private var consumingFrames = false
+    private var inputFocusRequested = false
+    private val buttons = LinkedHashMap<Int, RectF>()
+    private val drawableButtons = LinkedHashMap<Int, InputOverlayDrawableButton>()
+    private var drawableDpad: InputOverlayDrawableDpad? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val hideTitleRunnable = Runnable {
+        titleVisible = false
+        invalidate()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        GbaHostBridge.addListener(this)
+        updateFrameConsumerState()
+    }
+
+    override fun onDetachedFromWindow() {
+        setFrameConsumerEnabled(false)
+        clearGbaInput()
+        mainHandler.removeCallbacks(hideTitleRunnable)
+        inputFocusRequested = false
+        GbaInputFocusManager.clearFocus(visibleDevice)
+        unregisterVisibleGba()
+        GbaHostBridge.removeListener(this)
+        super.onDetachedFromWindow()
+    }
+
+    override fun onVisibilityChanged(changedView: View, visibility: Int) {
+        super.onVisibilityChanged(changedView, visibility)
+        if (changedView == this) {
+            updateFrameConsumerState()
+        }
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        rebuildButtons()
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), backgroundPaint)
+
+        val frame = bitmap
+        if (frame != null) {
+            canvas.drawBitmap(frame, null, frameRect(frame.width, frame.height), framePaint)
+        } else {
+            drawStatusText(canvas)
+        }
+
+        if (titleVisible && title.isNotEmpty()) {
+            canvas.drawText(title, width / 2f, sp(34f), textPaint)
+        }
+
+        if (shouldDrawTouchButtons()) {
+            drawButtons(canvas)
+        }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (visibleDevice !in 0..3) {
+            return true
+        }
+
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN,
+            MotionEvent.ACTION_POINTER_DOWN,
+            MotionEvent.ACTION_MOVE -> {
+                requestGbaInputFocus()
+                if (shouldDrawTouchButtons()) {
+                    updateButtons(event)
+                } else {
+                    clearGbaInput()
+                }
+            }
+
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_POINTER_UP,
+            MotionEvent.ACTION_CANCEL -> {
+                if (event.actionMasked == MotionEvent.ACTION_UP) {
+                    performClick()
+                }
+                if (event.pointerCount <= 1 || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+                    clearGbaInput()
+                } else {
+                    updateButtons(event, event.actionIndex)
+                }
+            }
+        }
+        return true
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
+    override fun onGbaGameChanged(info: GbaHostBridge.CoreInfo) {
+        if (info.deviceNumber == visibleDevice) {
+            visibleInfo = info
+            title = displayTitle(info)
+            resetTitleVisibility()
+            if (bitmap != null) {
+                scheduleTitleHide()
+            }
+            invalidate()
+        }
+    }
+
+    override fun onGbaVisibleDeviceChanged(deviceNumber: Int, info: GbaHostBridge.CoreInfo?) {
+        clearGbaInput()
+        GbaInputFocusManager.clearFocus(visibleDevice)
+        unregisterVisibleGba()
+        visibleDevice = deviceNumber
+        visibleInfo = info
+        title = displayTitle(info)
+        resetTitleVisibility()
+        bitmap = null
+        if (deviceNumber in 0..3) {
+            InputOverrider.registerGba(deviceNumber)
+            GbaInputFocusManager.onGbaInputRegistered(deviceNumber)
+            if (inputFocusRequested) {
+                requestGbaInputFocus()
+            }
+        }
+        invalidate()
+    }
+
+    fun setInputFocusEnabled(enabled: Boolean) {
+        inputFocusRequested = enabled
+        if (enabled) {
+            requestGbaInputFocus()
+        } else {
+            GbaInputFocusManager.clearFocus(visibleDevice)
+        }
+    }
+
+    fun requestInputFocus() = requestGbaInputFocus()
+
+    fun refreshSettings() {
+        rebuildButtons()
+        invalidate()
+    }
+
+    override fun onGbaFrame(deviceNumber: Int, width: Int, height: Int, pixels: IntArray) {
+        if (deviceNumber != visibleDevice || width <= 0 || height <= 0 ||
+            pixels.size < width * height
+        ) {
+            return
+        }
+
+        val firstFrame = bitmap == null
+        val nextBitmap = bitmap?.takeIf { it.width == width && it.height == height }
+            ?: createBitmap(width, height)
+        nextBitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+        bitmap = nextBitmap
+        if (firstFrame) {
+            scheduleTitleHide()
+        }
+        invalidate()
+    }
+
+    private fun rebuildButtons() {
+        buttons.clear()
+        drawableButtons.clear()
+        drawableDpad = null
+        if (width <= 0 || height <= 0) {
+            return
+        }
+
+        val density = resources.displayMetrics.density
+        val viewWidth = width.toFloat()
+        val viewHeight = height.toFloat()
+        val edge = 8f * density
+        val size = minOf(
+            minOf(viewWidth, viewHeight) * 0.12f,
+            viewWidth / 7.2f,
+            viewHeight / 5.6f
+        ).coerceAtLeast(1f)
+        val gap = size * 0.18f
+        val dpadCenterX = edge + size * 1.5f + gap
+        val clusterCenterY = viewHeight - edge - size * 1.5f - gap
+        val actionCenterX = viewWidth - edge - size * 1.5f - gap
+        val shoulderTop = maxOf(edge, textPaint.textSize + edge)
+        val shoulderWidth = size * 1.85f
+        val shoulderHeight = size * 0.62f
+        val startSelectWidth = size * 1.35f
+        val startSelectHeight = size * 0.62f
+        val startSelectY = viewHeight - edge - startSelectHeight / 2f
+        val dpadDrawableSize = size * 3f + gap * 2f
+
+        fun rectFromCenter(cx: Float, cy: Float, rectWidth: Float, rectHeight: Float): RectF {
+            val maxLeft = viewWidth - edge - rectWidth
+            val maxTop = viewHeight - edge - rectHeight
+            val left = if (maxLeft >= edge) {
+                (cx - rectWidth / 2f).coerceIn(edge, maxLeft)
+            } else {
+                (viewWidth - rectWidth) / 2f
+            }
+            val top = if (maxTop >= edge) {
+                (cy - rectHeight / 2f).coerceIn(edge, maxTop)
+            } else {
+                (viewHeight - rectHeight) / 2f
+            }
+            return RectF(left, top, left + rectWidth, top + rectHeight)
+        }
+
+        fun putButton(
+            control: Int,
+            cx: Float,
+            cy: Float,
+            rectWidth: Float = size,
+            rectHeight: Float = size
+        ) {
+            buttons[control] = rectFromCenter(cx, cy, rectWidth, rectHeight)
+        }
+
+        putButton(ControlId.GBA_DPAD_UP, dpadCenterX, clusterCenterY - size - gap)
+        putButton(ControlId.GBA_DPAD_DOWN, dpadCenterX, clusterCenterY + size + gap)
+        putButton(ControlId.GBA_DPAD_LEFT, dpadCenterX - size - gap, clusterCenterY)
+        putButton(ControlId.GBA_DPAD_RIGHT, dpadCenterX + size + gap, clusterCenterY)
+        putButton(
+            ControlId.GBA_B_BUTTON,
+            actionCenterX - size * 0.68f,
+            clusterCenterY + size * 0.45f
+        )
+        putButton(
+            ControlId.GBA_A_BUTTON,
+            actionCenterX + size * 0.68f,
+            clusterCenterY - size * 0.45f
+        )
+        buttons[ControlId.GBA_L_BUTTON] =
+            RectF(edge, shoulderTop, edge + shoulderWidth, shoulderTop + shoulderHeight)
+        buttons[ControlId.GBA_R_BUTTON] = RectF(
+            viewWidth - edge - shoulderWidth,
+            shoulderTop,
+            viewWidth - edge,
+            shoulderTop + shoulderHeight
+        )
+        putButton(
+            ControlId.GBA_SELECT_BUTTON,
+            viewWidth / 2f - startSelectWidth / 2f - gap / 2f,
+            startSelectY,
+            startSelectWidth,
+            startSelectHeight
+        )
+        putButton(
+            ControlId.GBA_START_BUTTON,
+            viewWidth / 2f + startSelectWidth / 2f + gap / 2f,
+            startSelectY,
+            startSelectWidth,
+            startSelectHeight
+        )
+
+        drawableDpad = createDpadDrawable(
+            rectFromCenter(dpadCenterX, clusterCenterY, dpadDrawableSize, dpadDrawableSize)
+        )
+        createButtonDrawable(
+            ControlId.GBA_A_BUTTON,
+            R.drawable.gcpad_a,
+            R.drawable.gcpad_a_pressed
+        )
+        createButtonDrawable(
+            ControlId.GBA_B_BUTTON,
+            R.drawable.gcpad_b,
+            R.drawable.gcpad_b_pressed
+        )
+        createButtonDrawable(
+            ControlId.GBA_L_BUTTON,
+            R.drawable.gcpad_l,
+            R.drawable.gcpad_l_pressed
+        )
+        createButtonDrawable(
+            ControlId.GBA_R_BUTTON,
+            R.drawable.gcpad_r,
+            R.drawable.gcpad_r_pressed
+        )
+        createButtonDrawable(
+            ControlId.GBA_SELECT_BUTTON,
+            R.drawable.wiimote_minus,
+            R.drawable.wiimote_minus_pressed
+        )
+        createButtonDrawable(
+            ControlId.GBA_START_BUTTON,
+            R.drawable.gcpad_start,
+            R.drawable.gcpad_start_pressed
+        )
+    }
+
+    private fun frameRect(frameWidth: Int, frameHeight: Int): RectF {
+        val viewWidth = width.toFloat()
+        val viewHeight = height.toFloat()
+        val scaleX = viewWidth / frameWidth.toFloat()
+        val scaleY = viewHeight / frameHeight.toFloat()
+        val fitScale = minOf(scaleX, scaleY)
+
+        val scaleMode = GbaLinkSettings.normalizeScaleMode(IntSetting.MAIN_GBA_LINK_SCALE_MODE.int)
+        val rectWidth: Float
+        val rectHeight: Float
+        if (scaleMode == GbaLinkSettings.SCALE_MODE_STRETCH) {
+            rectWidth = viewWidth
+            rectHeight = viewHeight
+        } else {
+            val scale = when (scaleMode) {
+                GbaLinkSettings.SCALE_MODE_INTEGER -> {
+                    if (fitScale >= 1f) floor(fitScale.toDouble()).toFloat().coerceAtLeast(1f)
+                    else fitScale
+                }
+                else -> fitScale
+            }
+            rectWidth = frameWidth * scale
+            rectHeight = frameHeight * scale
+        }
+
+        val position = GbaLinkSettings.normalizePosition(IntSetting.MAIN_GBA_LINK_POSITION.int)
+        val left = when (position) {
+            GbaLinkSettings.POSITION_LEFT -> 0f
+            GbaLinkSettings.POSITION_RIGHT -> viewWidth - rectWidth
+            else -> (viewWidth - rectWidth) / 2f
+        }
+        val top = when (position) {
+            GbaLinkSettings.POSITION_TOP -> 0f
+            GbaLinkSettings.POSITION_BOTTOM -> viewHeight - rectHeight
+            else -> (viewHeight - rectHeight) / 2f
+        }
+
+        return RectF(left, top, left + rectWidth, top + rectHeight)
+    }
+
+    private fun drawButtons(canvas: Canvas) {
+        drawableDpad?.draw(canvas)
+        for (button in drawableButtons.values) {
+            button.draw(canvas)
+        }
+    }
+
+    private fun drawStatusText(canvas: Canvas) {
+        val text = when {
+            visibleDevice == GbaHostBridge.NO_DEVICE ->
+                context.getString(R.string.gba_screen_no_active_link)
+
+            else ->
+                context.getString(R.string.gba_screen_waiting_for_frame, visibleDevice + 1)
+        }
+        canvas.drawText(text, width / 2f, height / 2f, textPaint)
+    }
+
+    private fun displayTitle(info: GbaHostBridge.CoreInfo?): String {
+        if (info == null || info.deviceNumber !in 0..3) {
+            return info?.title.orEmpty()
+        }
+
+        return if (info.title.isNotEmpty()) {
+            context.getString(
+                R.string.gba_screen_title_with_game,
+                info.deviceNumber + 1,
+                info.title
+            )
+        } else {
+            context.getString(R.string.gba_screen_title, info.deviceNumber + 1)
+        }
+    }
+
+    private fun resetTitleVisibility() {
+        titleVisible = true
+        mainHandler.removeCallbacks(hideTitleRunnable)
+    }
+
+    private fun scheduleTitleHide() {
+        if (title.isEmpty()) {
+            return
+        }
+
+        mainHandler.removeCallbacks(hideTitleRunnable)
+        mainHandler.postDelayed(hideTitleRunnable, TITLE_VISIBLE_MILLIS)
+    }
+
+    private fun updateButtons(event: MotionEvent, ignoredPointerIndex: Int = -1) {
+        val activeControls = mutableSetOf<Int>()
+        for (pointerIndex in 0 until event.pointerCount) {
+            if (pointerIndex == ignoredPointerIndex) {
+                continue
+            }
+
+            val x = event.getX(pointerIndex)
+            val y = event.getY(pointerIndex)
+            for ((control, rect) in buttons) {
+                if (rect.contains(x, y)) {
+                    activeControls.add(control)
+                }
+            }
+        }
+
+        for (control in buttons.keys) {
+            val active = activeControls.contains(control)
+            InputOverrider.setControlState(
+                visibleDevice,
+                control,
+                if (active) 1.0 else 0.0
+            )
+            drawableButtons[control]?.setPressedState(active)
+        }
+        updateDpadState(activeControls)
+        invalidate()
+    }
+
+    private fun requestGbaInputFocus() {
+        inputFocusRequested = true
+        if (visibleDevice in 0..3) {
+            GbaInputFocusManager.requestFocus(visibleDevice)
+        }
+    }
+
+    private fun shouldDrawTouchButtons(): Boolean {
+        if (visibleDevice !in 0..3) {
+            return false
+        }
+
+        return !BooleanSetting.MAIN_GBA_LINK_HIDE_TOUCH_IF_CONTROLLER.boolean ||
+                !GbaLinkSettings.hasConfiguredPhysicalController(visibleDevice)
+    }
+
+    private fun clearGbaInput() {
+        if (visibleDevice !in 0..3) {
+            return
+        }
+
+        for (control in buttons.keys) {
+            InputOverrider.clearControlState(visibleDevice, control)
+        }
+        drawableButtons.values.forEach { it.setPressedState(false) }
+        drawableDpad?.setState(InputOverlayDrawableDpad.STATE_DEFAULT)
+        invalidate()
+    }
+
+    private fun unregisterVisibleGba() {
+        if (visibleDevice in 0..3) {
+            InputOverrider.unregisterGba(visibleDevice)
+        }
+    }
+
+    private fun updateFrameConsumerState() {
+        setFrameConsumerEnabled(isAttachedToWindow && isVisible)
+    }
+
+    private fun setFrameConsumerEnabled(enabled: Boolean) {
+        if (consumingFrames == enabled) {
+            return
+        }
+
+        consumingFrames = enabled
+        if (enabled) {
+            GbaHostBridge.registerFrameConsumer()
+        } else {
+            GbaHostBridge.unregisterFrameConsumer()
+        }
+    }
+
+    private fun createButtonDrawable(control: Int, defaultResId: Int, pressedResId: Int) {
+        val rect = buttons[control] ?: return
+        val targetWidth = rect.width().toInt().coerceAtLeast(1)
+        val targetHeight = rect.height().toInt().coerceAtLeast(1)
+        val defaultBitmap =
+            BitmapFactory.decodeResource(resources, defaultResId).scale(targetWidth, targetHeight)
+        val pressedBitmap =
+            BitmapFactory.decodeResource(resources, pressedResId).scale(targetWidth, targetHeight)
+        drawableButtons[control] = InputOverlayDrawableButton(
+            resources,
+            defaultBitmap,
+            pressedBitmap,
+            -1,
+            control,
+            false
+        ).apply {
+            setPosition(rect.left.toInt(), rect.top.toInt())
+            setBounds(rect.left.toInt(), rect.top.toInt(), rect.right.toInt(), rect.bottom.toInt())
+            setOpacity(controlOpacity())
+        }
+    }
+
+    private fun createDpadDrawable(rect: RectF): InputOverlayDrawableDpad {
+        val targetWidth = rect.width().toInt().coerceAtLeast(1)
+        val targetHeight = rect.height().toInt().coerceAtLeast(1)
+        val defaultBitmap = BitmapFactory.decodeResource(resources, R.drawable.gcwii_dpad)
+            .scale(targetWidth, targetHeight)
+        val pressedOneDirectionBitmap = BitmapFactory.decodeResource(
+            resources,
+            R.drawable.gcwii_dpad_pressed_one_direction
+        ).scale(targetWidth, targetHeight)
+        val pressedTwoDirectionsBitmap = BitmapFactory.decodeResource(
+            resources,
+            R.drawable.gcwii_dpad_pressed_two_directions
+        ).scale(targetWidth, targetHeight)
+        return InputOverlayDrawableDpad(
+            resources,
+            defaultBitmap,
+            pressedOneDirectionBitmap,
+            pressedTwoDirectionsBitmap,
+            -1,
+            ControlId.GBA_DPAD_UP,
+            ControlId.GBA_DPAD_DOWN,
+            ControlId.GBA_DPAD_LEFT,
+            ControlId.GBA_DPAD_RIGHT
+        ).apply {
+            setPosition(rect.left.toInt(), rect.top.toInt())
+            setBounds(rect.left.toInt(), rect.top.toInt(), rect.right.toInt(), rect.bottom.toInt())
+            setOpacity(controlOpacity())
+        }
+    }
+
+    private fun updateDpadState(activeControls: Set<Int>) {
+        val up = activeControls.contains(ControlId.GBA_DPAD_UP)
+        val down = activeControls.contains(ControlId.GBA_DPAD_DOWN)
+        val left = activeControls.contains(ControlId.GBA_DPAD_LEFT)
+        val right = activeControls.contains(ControlId.GBA_DPAD_RIGHT)
+        val state = when {
+            up && left -> InputOverlayDrawableDpad.STATE_PRESSED_UP_LEFT
+            up && right -> InputOverlayDrawableDpad.STATE_PRESSED_UP_RIGHT
+            down && left -> InputOverlayDrawableDpad.STATE_PRESSED_DOWN_LEFT
+            down && right -> InputOverlayDrawableDpad.STATE_PRESSED_DOWN_RIGHT
+            up -> InputOverlayDrawableDpad.STATE_PRESSED_UP
+            down -> InputOverlayDrawableDpad.STATE_PRESSED_DOWN
+            left -> InputOverlayDrawableDpad.STATE_PRESSED_LEFT
+            right -> InputOverlayDrawableDpad.STATE_PRESSED_RIGHT
+            else -> InputOverlayDrawableDpad.STATE_DEFAULT
+        }
+        drawableDpad?.setState(state)
+    }
+
+    private fun controlOpacity(): Int = IntSetting.MAIN_CONTROL_OPACITY.int * 255 / 100
+
+    private fun sp(value: Float): Float =
+        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, value, resources.displayMetrics)
+
+    companion object {
+        private const val TITLE_VISIBLE_MILLIS = 10_000L
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/WiiPointerTouchpadView.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/dualscreen/WiiPointerTouchpadView.kt
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.dualscreen
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.util.TypedValue
+import android.view.MotionEvent
+import android.view.View
+import org.dolphinemu.dolphinemu.NativeLibrary
+import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.features.input.model.InputOverrider
+import org.dolphinemu.dolphinemu.features.input.model.InputOverrider.ControlId
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
+import org.dolphinemu.dolphinemu.features.settings.model.IntSetting
+import org.dolphinemu.dolphinemu.overlay.InputOverlayPointer
+
+class WiiPointerTouchpadView(context: Context) : View(context) {
+    private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.rgb(13, 18, 23)
+        style = Paint.Style.FILL
+    }
+    private val linePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.rgb(92, 207, 230)
+        strokeWidth = 2f
+        style = Paint.Style.STROKE
+    }
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textAlign = Paint.Align.CENTER
+        textSize = sp(28f)
+    }
+
+    private var pointer: InputOverlayPointer? = null
+    private var controllerIndex = 0
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        rebuildPointer()
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        val activePointer = pointer ?: rebuildPointer() ?: return true
+        activePointer.onTouch(event)
+        if (event.actionMasked == MotionEvent.ACTION_UP) {
+            performClick()
+        }
+        InputOverrider.setControlState(
+            controllerIndex,
+            ControlId.WIIMOTE_IR_X,
+            activePointer.x.toDouble()
+        )
+        InputOverrider.setControlState(
+            controllerIndex,
+            ControlId.WIIMOTE_IR_Y,
+            -activePointer.y.toDouble()
+        )
+
+        invalidate()
+        return true
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), fillPaint)
+        canvas.drawLine(width / 2f, 0f, width / 2f, height.toFloat(), linePaint)
+        canvas.drawLine(0f, height / 2f, width.toFloat(), height / 2f, linePaint)
+        canvas.drawRect(8f, 8f, width - 8f, height - 8f, linePaint)
+        canvas.drawText(
+            context.getString(R.string.dual_screen_wii_pointer_touchpad_label),
+            width / 2f,
+            height / 2f - 20f,
+            textPaint
+        )
+    }
+
+    fun refreshSettings() {
+        pointer?.setMode(IntSetting.MAIN_IR_MODE.int)
+        pointer?.setRecenter(BooleanSetting.MAIN_IR_ALWAYS_RECENTER.boolean)
+    }
+
+    fun clearPointerState() {
+        InputOverrider.clearControlState(controllerIndex, ControlId.WIIMOTE_IR_X)
+        InputOverrider.clearControlState(controllerIndex, ControlId.WIIMOTE_IR_Y)
+    }
+
+    private fun rebuildPointer(): InputOverlayPointer? {
+        if (
+            width <= 0 ||
+            height <= 0 ||
+            !NativeLibrary.IsGameMetadataValid() ||
+            !NativeLibrary.IsRunning() ||
+            !NativeLibrary.HasSurface()
+        ) {
+            return null
+        }
+
+        if (!NativeLibrary.IsEmulatingWii()) {
+            return null
+        }
+
+        controllerIndex = (IntSetting.MAIN_OVERLAY_WII_CONTROLLER.int - 4).coerceIn(0, 3)
+        InputOverrider.registerWii(controllerIndex)
+
+        var doubleTapControl = ControlId.WIIMOTE_A_BUTTON
+        when (IntSetting.MAIN_DOUBLE_TAP_BUTTON.int) {
+            NativeLibrary.ButtonType.WIIMOTE_BUTTON_B ->
+                doubleTapControl = ControlId.WIIMOTE_B_BUTTON
+
+            NativeLibrary.ButtonType.WIIMOTE_BUTTON_2 ->
+                doubleTapControl = ControlId.WIIMOTE_TWO_BUTTON
+        }
+
+        pointer = InputOverlayPointer(
+            Rect(0, 0, width, height),
+            doubleTapControl,
+            IntSetting.MAIN_IR_MODE.int,
+            BooleanSetting.MAIN_IR_ALWAYS_RECENTER.boolean,
+            controllerIndex,
+            adjustForGameAspectRatio = false,
+            clampToGameBounds = true
+        )
+        return pointer
+    }
+
+    private fun sp(value: Float): Float =
+        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, value, resources.displayMetrics)
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/InputOverrider.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/InputOverrider.kt
@@ -7,9 +7,17 @@ object InputOverrider {
 
     external fun registerWii(controllerIndex: Int)
 
+    external fun registerGba(controllerIndex: Int)
+
     external fun unregisterGameCube(controllerIndex: Int)
 
     external fun unregisterWii(controllerIndex: Int)
+
+    external fun unregisterGba(controllerIndex: Int)
+
+    external fun setGameCubeInputEnabled(controllerIndex: Int, enabled: Boolean)
+
+    external fun setGbaInputEnabled(controllerIndex: Int, enabled: Boolean)
 
     external fun setControlState(controllerIndex: Int, control: Int, state: Double)
 
@@ -78,5 +86,16 @@ object InputOverrider {
         const val CLASSIC_LEFT_STICK_Y = 53
         const val CLASSIC_RIGHT_STICK_X = 54
         const val CLASSIC_RIGHT_STICK_Y = 55
+
+        const val GBA_B_BUTTON = 56
+        const val GBA_A_BUTTON = 57
+        const val GBA_L_BUTTON = 58
+        const val GBA_R_BUTTON = 59
+        const val GBA_SELECT_BUTTON = 60
+        const val GBA_START_BUTTON = 61
+        const val GBA_DPAD_UP = 62
+        const val GBA_DPAD_DOWN = 63
+        const val GBA_DPAD_LEFT = 64
+        const val GBA_DPAD_RIGHT = 65
     }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/controlleremu/EmulatedController.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/input/model/controlleremu/EmulatedController.kt
@@ -53,6 +53,9 @@ class EmulatedController private constructor(private val pointer: Long) : Contro
         external fun getGcKeyboard(controllerIndex: Int): EmulatedController
 
         @JvmStatic
+        external fun getGbaPad(controllerIndex: Int): EmulatedController
+
+        @JvmStatic
         external fun getWiimote(controllerIndex: Int): EmulatedController
 
         @JvmStatic

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.kt
@@ -282,6 +282,36 @@ enum class BooleanSetting(
         "ShowInputOverlay",
         true
     ),
+    MAIN_DUAL_SCREEN_EXTERNAL_DISPLAY(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "DualScreenExternalDisplay",
+        true
+    ),
+    MAIN_DUAL_SCREEN_WII_POINTER_TOUCHPAD(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "DualScreenWiiPointerTouchpad",
+        false
+    ),
+    MAIN_GBA_LINK_EXTERNAL_DISPLAY(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "GBALinkExternalDisplay",
+        true
+    ),
+    MAIN_GBA_LINK_HIDE_TOUCH_IF_CONTROLLER(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "GBALinkHideTouchControlsIfController",
+        false
+    ),
+    MAIN_GBA_LINK_MUTE_AUDIO(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_GBA,
+        "MuteLinkAudio",
+        false
+    ),
     MAIN_IR_ALWAYS_RECENTER(
         Settings.FILE_DOLPHIN,
         Settings.SECTION_INI_ANDROID,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.kt
@@ -76,6 +76,18 @@ enum class IntSetting(
         "IRMode",
         InputOverlayPointer.MODE_FOLLOW
     ),
+    MAIN_GBA_LINK_SCALE_MODE(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "GBALinkScaleMode",
+        0
+    ),
+    MAIN_GBA_LINK_POSITION(
+        Settings.FILE_DOLPHIN,
+        Settings.SECTION_INI_ANDROID,
+        "GBALinkPosition",
+        0
+    ),
     MAIN_DOUBLE_TAP_BUTTON(
         Settings.FILE_DOLPHIN,
         Settings.SECTION_INI_ANDROID_OVERLAY_BUTTONS,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/SharedPreferenceStringSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/SharedPreferenceStringSetting.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.settings.model
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import org.dolphinemu.dolphinemu.DolphinApplication
+
+class SharedPreferenceStringSetting(
+    private val key: String,
+    private val defaultValue: String = ""
+) : AbstractStringSetting {
+    private val context: Context
+        get() = DolphinApplication.getAppContext()
+
+    override val isOverridden: Boolean
+        get() = false
+
+    override val isRuntimeEditable: Boolean
+        get() = true
+
+    override fun delete(settings: Settings): Boolean {
+        PreferenceManager.getDefaultSharedPreferences(context).edit { remove(key) }
+        return true
+    }
+
+    override val string: String
+        get() = PreferenceManager.getDefaultSharedPreferences(context)
+            .getString(key, defaultValue)
+            .orEmpty()
+
+    override fun setString(settings: Settings, newValue: String) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit { putString(key, newValue) }
+    }
+
+    companion object {
+        private const val GB_PLAYER_BOOT_PATH_KEY = "DualScreenGBPlayerBootPath"
+        val MAIN_ANDROID_GB_PLAYER_BOOT_PATH =
+            SharedPreferenceStringSetting(GB_PLAYER_BOOT_PATH_KEY)
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
@@ -70,6 +70,10 @@ enum class StringSetting(
     ),
     MAIN_WFS_PATH(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GENERAL, "WFSPath", ""),
     MAIN_GBA_BIOS_PATH(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GBA, "BIOS", ""),
+    MAIN_GBA_ROM_1(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GBA, "Rom1", ""),
+    MAIN_GBA_ROM_2(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GBA, "Rom2", ""),
+    MAIN_GBA_ROM_3(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GBA, "Rom3", ""),
+    MAIN_GBA_ROM_4(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GBA, "Rom4", ""),
     MAIN_GB_PLAYER_ROM(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GBA, "GBPlayerRom", ""),
     MAIN_GBA_SAVES_PATH(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GBA, "SavesPath", ""),
     MAIN_TRIFORCE_IP_REDIRECTIONS(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.kt
@@ -26,12 +26,17 @@ enum class MenuTag {
     STATISTICS("statistics"),
     ADVANCED_GRAPHICS("advanced_graphics"),
     GCPAD_TYPE("gc_pad_type"),
+    GBA_LINK("gba_link"),
     WIIMOTE("wiimote"),
     WIIMOTE_EXTENSION("wiimote_extension"),
     GCPAD_1("gcpad", 0),
     GCPAD_2("gcpad", 1),
     GCPAD_3("gcpad", 2),
     GCPAD_4("gcpad", 3),
+    GBA_1("gba", 0),
+    GBA_2("gba", 1),
+    GBA_3("gba", 2),
+    GBA_4("gba", 3),
     WIIMOTE_1("wiimote", 0),
     WIIMOTE_2("wiimote", 1),
     WIIMOTE_3("wiimote", 2),
@@ -75,15 +80,22 @@ enum class MenuTag {
     }
 
     val correspondingEmulatedController: EmulatedController
-        get() = if (isGCPadMenu) EmulatedController.getGcPad(subType) else if (isWiimoteMenu) EmulatedController.getWiimote(
-            subType
-        ) else throw UnsupportedOperationException()
+        get() = if (isGCPadMenu) {
+            EmulatedController.getGcPad(subType)
+        } else if (isGBAPadMenu) {
+            EmulatedController.getGbaPad(subType)
+        } else if (isWiimoteMenu) {
+            EmulatedController.getWiimote(subType)
+        } else throw UnsupportedOperationException()
 
     val isSerialPort1Menu: Boolean
         get() = this == CONFIG_SERIALPORT1
 
     val isGCPadMenu: Boolean
         get() = this == GCPAD_1 || this == GCPAD_2 || this == GCPAD_3 || this == GCPAD_4
+
+    val isGBAPadMenu: Boolean
+        get() = this == GBA_1 || this == GBA_2 || this == GBA_3 || this == GBA_4
 
     val isWiimoteMenu: Boolean
         get() = this == WIIMOTE_1 || this == WIIMOTE_2 || this == WIIMOTE_3 || this == WIIMOTE_4
@@ -103,6 +115,11 @@ enum class MenuTag {
         @JvmStatic
         fun getGCPadMenuTag(subtype: Int): MenuTag {
             return getMenuTag("gcpad", subtype)
+        }
+
+        @JvmStatic
+        fun getGBAPadMenuTag(subtype: Int): MenuTag {
+            return getMenuTag("gba", subtype)
         }
 
         @JvmStatic

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.kt
@@ -5,6 +5,7 @@ package org.dolphinemu.dolphinemu.features.settings.ui
 import android.os.Bundle
 import android.text.TextUtils
 import androidx.appcompat.app.AppCompatActivity
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaLinkSettings
 import org.dolphinemu.dolphinemu.features.settings.model.Settings
 import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner
 import org.dolphinemu.dolphinemu.utils.Log
@@ -95,8 +96,14 @@ class SettingsActivityPresenter(
         }
         if (menuTag.isGCPadMenu) {
             // Not disabled
-            if (value != 0)
-            {
+            if (value == GbaLinkSettings.SIDEVICE_GC_GBA_EMULATED) {
+                activityView.showSettingsFragment(
+                    MenuTag.getGBAPadMenuTag(menuTag.subType),
+                    null,
+                    true,
+                    gameId!!
+                )
+            } else if (value != 0) {
                 val bundle = Bundle()
                 bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value)
                 activityView.showSettingsFragment(menuTag, bundle, true, gameId!!)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.kt
@@ -280,12 +280,17 @@ class SettingsFragment : Fragment(), SettingsFragmentView {
             titles[MenuTag.ADVANCED_GRAPHICS] = R.string.advanced_graphics_submenu
             titles[MenuTag.CONFIG_LOG] = R.string.log_submenu
             titles[MenuTag.GCPAD_TYPE] = R.string.gcpad_settings
+            titles[MenuTag.GBA_LINK] = R.string.gba_link_settings
             titles[MenuTag.WIIMOTE] = R.string.wiimote_settings
             titles[MenuTag.WIIMOTE_EXTENSION] = R.string.wiimote_extensions
             titles[MenuTag.GCPAD_1] = R.string.controller_0
             titles[MenuTag.GCPAD_2] = R.string.controller_1
             titles[MenuTag.GCPAD_3] = R.string.controller_2
             titles[MenuTag.GCPAD_4] = R.string.controller_3
+            titles[MenuTag.GBA_1] = R.string.gba_controller_0
+            titles[MenuTag.GBA_2] = R.string.gba_controller_1
+            titles[MenuTag.GBA_3] = R.string.gba_controller_2
+            titles[MenuTag.GBA_4] = R.string.gba_controller_3
             titles[MenuTag.WIIMOTE_1] = R.string.wiimote_0
             titles[MenuTag.WIIMOTE_2] = R.string.wiimote_1
             titles[MenuTag.WIIMOTE_3] = R.string.wiimote_2

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.withContext
 import org.dolphinemu.dolphinemu.NativeLibrary
 import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.activities.UserDataActivity
+import org.dolphinemu.dolphinemu.features.dualscreen.ExternalDisplayManager
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaLinkSettings
 import org.dolphinemu.dolphinemu.features.input.model.ControlGroupEnabledSetting
 import org.dolphinemu.dolphinemu.features.input.model.InputMappingBooleanSetting
 import org.dolphinemu.dolphinemu.features.input.model.InputMappingDoubleSetting
@@ -52,6 +54,19 @@ class SettingsFragmentPresenter(
     private var controllerNumber = 0
     private var controllerType = 0
 
+    private val gbaRomSettings = arrayOf(
+        StringSetting.MAIN_GBA_ROM_1,
+        StringSetting.MAIN_GBA_ROM_2,
+        StringSetting.MAIN_GBA_ROM_3,
+        StringSetting.MAIN_GBA_ROM_4
+    )
+    private val gbaRomTitles = intArrayOf(
+        R.string.gba_rom_1,
+        R.string.gba_rom_2,
+        R.string.gba_rom_3,
+        R.string.gba_rom_4
+    )
+
     var gpuDriver: GpuDriverMetadata? = null
     private val libNameSetting: StringSetting = StringSetting.GFX_DRIVER_LIB_NAME
 
@@ -62,7 +77,7 @@ class SettingsFragmentPresenter(
         if (menuTag.isGCPadMenu || menuTag.isWiimoteExtensionMenu) {
             controllerNumber = menuTag.subType
             controllerType = extras.getInt(ARG_CONTROLLER_TYPE)
-        } else if (menuTag.isWiimoteMenu || menuTag.isWiimoteSubmenu) {
+        } else if (menuTag.isGBAPadMenu || menuTag.isWiimoteMenu || menuTag.isWiimoteSubmenu) {
             controllerNumber = menuTag.subType
         } else if (menuTag.isSerialPort1Menu) {
             serialPort1Type = extras.getInt(ARG_SERIALPORT1_TYPE)
@@ -115,6 +130,7 @@ class SettingsFragmentPresenter(
             MenuTag.GRAPHICS -> addGraphicsSettings(sl)
             MenuTag.CONFIG_SERIALPORT1 -> addSerialPortSubSettings(sl, serialPort1Type)
             MenuTag.GCPAD_TYPE -> addGcPadSettings(sl)
+            MenuTag.GBA_LINK -> addGbaLinkSettings(sl)
             MenuTag.WIIMOTE -> addWiimoteSettings(sl)
             MenuTag.ENHANCEMENTS -> addEnhanceSettings(sl)
             MenuTag.COLOR_CORRECTION -> addColorCorrectionSettings(sl)
@@ -131,6 +147,14 @@ class SettingsFragmentPresenter(
                 sl,
                 controllerNumber,
                 controllerType
+            )
+
+            MenuTag.GBA_1,
+            MenuTag.GBA_2,
+            MenuTag.GBA_3,
+            MenuTag.GBA_4 -> addGbaPadSubSettings(
+                sl,
+                controllerNumber
             )
 
             MenuTag.WIIMOTE_1,
@@ -186,6 +210,7 @@ class SettingsFragmentPresenter(
         sl.add(SubmenuSetting(context, R.string.graphics_settings, MenuTag.GRAPHICS))
 
         sl.add(SubmenuSetting(context, R.string.gcpad_settings, MenuTag.GCPAD_TYPE))
+        sl.add(SubmenuSetting(context, R.string.gba_link_settings, MenuTag.GBA_LINK))
         if (settings!!.isWii) {
             sl.add(SubmenuSetting(context, R.string.wiimote_settings, MenuTag.WIIMOTE))
         }
@@ -339,6 +364,14 @@ class SettingsFragmentPresenter(
                 BooleanSetting.MAIN_OSD_MESSAGES,
                 R.string.osd_messages,
                 R.string.osd_messages_description
+            )
+        )
+        sl.add(
+            SwitchSetting(
+                context,
+                BooleanSetting.MAIN_DUAL_SCREEN_EXTERNAL_DISPLAY,
+                R.string.dual_screen_external_display,
+                R.string.dual_screen_external_display_description
             )
         )
         sl.add(
@@ -711,7 +744,47 @@ class SettingsFragmentPresenter(
                 R.string.gba_bios_path,
                 0,
                 fragmentView.activityResultLaunchers.requestBinFile,
-                "/GBA/gba_bios.bin"
+                null
+            )
+        )
+        sl.add(
+            FilePicker(
+                context,
+                StringSetting.MAIN_GBA_ROM_1,
+                R.string.gba_rom_1,
+                0,
+                fragmentView.activityResultLaunchers.requestGbaRomFile,
+                null
+            )
+        )
+        sl.add(
+            FilePicker(
+                context,
+                StringSetting.MAIN_GBA_ROM_2,
+                R.string.gba_rom_2,
+                0,
+                fragmentView.activityResultLaunchers.requestGbaRomFile,
+                null
+            )
+        )
+        sl.add(
+            FilePicker(
+                context,
+                StringSetting.MAIN_GBA_ROM_3,
+                R.string.gba_rom_3,
+                0,
+                fragmentView.activityResultLaunchers.requestGbaRomFile,
+                null
+            )
+        )
+        sl.add(
+            FilePicker(
+                context,
+                StringSetting.MAIN_GBA_ROM_4,
+                R.string.gba_rom_4,
+                0,
+                fragmentView.activityResultLaunchers.requestGbaRomFile,
+                null
             )
         )
         sl.add(
@@ -721,6 +794,16 @@ class SettingsFragmentPresenter(
                 R.string.gb_player_rom,
                 0,
                 fragmentView.activityResultLaunchers.requestGbaRomFile,
+                null
+            )
+        )
+        sl.add(
+            FilePicker(
+                context,
+                SharedPreferenceStringSetting.MAIN_ANDROID_GB_PLAYER_BOOT_PATH,
+                R.string.gb_player_boot_path,
+                R.string.gb_player_boot_path_description,
+                fragmentView.activityResultLaunchers.requestGameFile,
                 null
             )
         )
@@ -1405,6 +1488,53 @@ class SettingsFragmentPresenter(
                 R.array.gcpadTypeEntries,
                 R.array.gcpadTypeValues,
                 MenuTag.getGCPadMenuTag(3)
+            )
+        )
+    }
+
+    private fun addGbaLinkSettings(sl: ArrayList<SettingsItem>) {
+        sl.add(
+            SwitchSetting(
+                context,
+                BooleanSetting.MAIN_GBA_LINK_EXTERNAL_DISPLAY,
+                R.string.gba_link_external_display,
+                R.string.gba_link_external_display_description
+            )
+        )
+        sl.add(
+            SingleChoiceSetting(
+                context,
+                IntSetting.MAIN_GBA_LINK_SCALE_MODE,
+                R.string.gba_link_scale_mode,
+                R.string.gba_link_scale_mode_description,
+                R.array.gbaLinkScaleModeEntries,
+                R.array.gbaLinkScaleModeValues
+            )
+        )
+        sl.add(
+            SingleChoiceSetting(
+                context,
+                IntSetting.MAIN_GBA_LINK_POSITION,
+                R.string.gba_link_position,
+                R.string.gba_link_position_description,
+                R.array.gbaLinkPositionEntries,
+                R.array.gbaLinkPositionValues
+            )
+        )
+        sl.add(
+            SwitchSetting(
+                context,
+                BooleanSetting.MAIN_GBA_LINK_HIDE_TOUCH_IF_CONTROLLER,
+                R.string.gba_link_hide_touch_controls,
+                R.string.gba_link_hide_touch_controls_description
+            )
+        )
+        sl.add(
+            SwitchSetting(
+                context,
+                BooleanSetting.MAIN_GBA_LINK_MUTE_AUDIO,
+                R.string.gba_link_mute_audio,
+                R.string.gba_link_mute_audio_description
             )
         )
     }
@@ -2518,6 +2648,31 @@ class SettingsFragmentPresenter(
                     )
                 )
             }
+            GbaLinkSettings.SIDEVICE_GC_GBA_EMULATED -> {
+                addGbaPadSubSettings(sl, gcPadNumber)
+            }
+        }
+    }
+
+    private fun addGbaPadSubSettings(sl: ArrayList<SettingsItem>, gbaPadNumber: Int) {
+        val gbaPad = EmulatedController.getGbaPad(gbaPadNumber)
+
+        sl.add(
+            FilePicker(
+                context,
+                gbaRomSettings[gbaPadNumber],
+                gbaRomTitles[gbaPadNumber],
+                0,
+                fragmentView.activityResultLaunchers.requestGbaRomFile,
+                null
+            )
+        )
+
+        if (!TextUtils.isEmpty(gameId)) {
+            addControllerPerGameSettings(sl, gbaPad, gbaPadNumber)
+        } else {
+            addControllerMetaSettings(sl, gbaPad)
+            addControllerMappingSettings(sl, gbaPad, null)
         }
     }
 
@@ -2601,6 +2756,17 @@ class SettingsFragmentPresenter(
     }
 
     private fun addWiimoteMotionInputSubSettings(sl: ArrayList<SettingsItem>, wiimoteNumber: Int) {
+        if (ExternalDisplayManager.hasPresentationDisplay(context)) {
+            sl.add(
+                SwitchSetting(
+                    context,
+                    BooleanSetting.MAIN_DUAL_SCREEN_WII_POINTER_TOUCHPAD,
+                    R.string.dual_screen_wii_pointer_touchpad,
+                    R.string.dual_screen_wii_pointer_touchpad_description
+                )
+            )
+        }
+
         addControllerMappingSettings(
             sl, EmulatedController.getWiimote(wiimoteNumber),
             ArraySet(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
@@ -2,13 +2,16 @@
 
 package org.dolphinemu.dolphinemu.fragments
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Rect
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.SurfaceHolder
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -19,6 +22,7 @@ import kotlinx.coroutines.launch
 import org.dolphinemu.dolphinemu.NativeLibrary
 import org.dolphinemu.dolphinemu.activities.EmulationActivity
 import org.dolphinemu.dolphinemu.databinding.FragmentEmulationBinding
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaInputFocusManager
 import org.dolphinemu.dolphinemu.features.netplay.NetplayManager
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import org.dolphinemu.dolphinemu.features.settings.model.Settings
@@ -70,10 +74,17 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
         return binding.root
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         // The new Surface created here will get passed to the native code via onSurfaceChanged.
         val surfaceView = binding.surfaceEmulation
         surfaceView.holder.addCallback(this)
+        surfaceView.setOnTouchListener { _, event ->
+            if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                GbaInputFocusManager.clearFocus()
+            }
+            false
+        }
 
         inputOverlay = binding.surfaceInputOverlay
 
@@ -97,6 +108,7 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     }
 
     override fun onDestroyView() {
+        GbaInputFocusManager.clearFocus()
         super.onDestroyView()
         _binding = null
     }
@@ -145,6 +157,20 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
     fun refreshOverlayPointer() = inputOverlay?.refreshOverlayPointer()
 
     fun resetInputOverlay() = inputOverlay?.resetButtonPlacement()
+
+    val isInternalGbaScreenVisible: Boolean
+        get() = _binding != null && binding.surfaceGbaScreen.isVisible
+
+    fun toggleInternalGbaScreen(): Boolean {
+        val showGbaScreen = !isInternalGbaScreenVisible
+        setInternalGbaScreenVisible(showGbaScreen)
+        return showGbaScreen
+    }
+
+    fun setInternalGbaScreenVisible(visible: Boolean) {
+        binding.surfaceGbaScreen.isVisible = visible
+        binding.surfaceGbaScreen.setInputFocusEnabled(visible)
+    }
 
     override fun surfaceCreated(holder: SurfaceHolder) {
         // We purposely don't do anything here.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/GbaPacksFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/GbaPacksFragment.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.activities.EmulationActivity
+import org.dolphinemu.dolphinemu.databinding.FragmentGbaPacksBinding
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaBootManager
+import org.dolphinemu.dolphinemu.features.settings.model.StringSetting
+
+class GbaPacksFragment : Fragment() {
+    private var _binding: FragmentGbaPacksBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentGbaPacksBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding.gbaPackPlayer.text = getString(
+            R.string.emulation_gba_pack_player_with_value,
+            titleForGameBoyPlayer()
+        )
+        binding.gbaPackPlayer.setOnClickListener {
+            (requireActivity() as EmulationActivity).chooseGameBoyPlayerRom()
+        }
+        binding.layoutGbaPacks.requestFocus()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun titleForGameBoyPlayer(): String {
+        val path = StringSetting.MAIN_GB_PLAYER_ROM.string
+        return if (path.isEmpty()) {
+            getString(R.string.emulation_gba_pack_empty)
+        } else {
+            GbaBootManager.titleFor(path)
+        }
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.kt
@@ -56,11 +56,27 @@ class MenuFragment : Fragment(), View.OnClickListener {
             binding.menuOverlayControls.visibility = View.GONE
         }
 
-        if (!requireArguments().getBoolean(KEY_WII, true)) {
+        val activity = requireActivity() as EmulationActivity
+        val isWii = requireArguments().getBoolean(KEY_WII, true)
+        if (!isWii) {
             binding.menuRefreshWiimotes.visibility = View.GONE
             binding.menuSkylanders.visibility = View.GONE
             binding.menuInfinityBase.visibility = View.GONE
+            binding.menuToggleGbaScreen.visibility =
+                if (activity.shouldShowInternalGbaScreenMenu()) View.VISIBLE else View.GONE
+            binding.menuGbaPacks.visibility =
+                if (activity.shouldShowGbaPacksMenu()) View.VISIBLE else View.GONE
+        } else {
+            binding.menuToggleGbaScreen.visibility = View.GONE
+            binding.menuGbaPacks.visibility = View.GONE
         }
+
+        binding.menuToggleGbaScreen.text =
+            if (activity.isInternalGbaScreenVisible) {
+                getString(R.string.emulation_show_gamecube_screen)
+            } else {
+                getString(R.string.emulation_show_gba_screen)
+            }
 
         if (!BooleanSetting.MAIN_EMULATE_SKYLANDER_PORTAL.boolean) {
             binding.menuSkylanders.visibility = View.GONE
@@ -189,6 +205,14 @@ class MenuFragment : Fragment(), View.OnClickListener {
             buttonsActionsMap.append(
                 R.id.menu_overlay_controls,
                 EmulationActivity.MENU_ACTION_OVERLAY_CONTROLS
+            )
+            buttonsActionsMap.append(
+                R.id.menu_toggle_gba_screen,
+                EmulationActivity.MENU_ACTION_TOGGLE_GBA_SCREEN
+            )
+            buttonsActionsMap.append(
+                R.id.menu_gba_packs,
+                EmulationActivity.MENU_ACTION_GBA_PACKS
             )
             buttonsActionsMap.append(
                 R.id.menu_refresh_wiimotes,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GbaGameFile.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GbaGameFile.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.model
+
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaBootManager
+
+data class GbaGameFile(val path: String, val rootPath: String) {
+    val title = GbaBootManager.titleFor(path)
+    val folderLabel: String
+
+    init {
+        val rootPrefix = rootPath.trimEnd('/')
+        val relativePath = if (path.startsWith("$rootPrefix/")) {
+            path.removePrefix("$rootPrefix/")
+        } else {
+            GbaBootManager.displayNameFor(path)
+        }
+
+        val relativeFolder = relativePath.substringBeforeLast('/', "")
+        folderLabel = relativeFolder.ifEmpty { GbaBootManager.displayNameFor(rootPath) }
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.kt
@@ -22,6 +22,7 @@ import org.dolphinemu.dolphinemu.DolphinApplication
 import org.dolphinemu.dolphinemu.NativeLibrary
 import org.dolphinemu.dolphinemu.NativeLibrary.ButtonType
 import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaInputFocusManager
 import org.dolphinemu.dolphinemu.features.input.model.InputMappingBooleanSetting
 import org.dolphinemu.dolphinemu.features.input.model.InputOverrider
 import org.dolphinemu.dolphinemu.features.input.model.InputOverrider.ControlId
@@ -137,6 +138,10 @@ class InputOverlay(context: Context?, attrs: AttributeSet?) : SurfaceView(contex
         }
 
         val action = event.actionMasked
+        if (action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN) {
+            GbaInputFocusManager.clearFocus()
+        }
+
         val firstPointer = action != MotionEvent.ACTION_POINTER_DOWN &&
                 action != MotionEvent.ACTION_POINTER_UP
         val pointerIndex = if (firstPointer) 0 else event.actionIndex

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.kt
@@ -14,7 +14,9 @@ class InputOverlayPointer(
     private val doubleTapControl: Int,
     private var mode: Int,
     private var recenter: Boolean,
-    private val controllerIndex: Int
+    private val controllerIndex: Int,
+    private val adjustForGameAspectRatio: Boolean = true,
+    private val clampToGameBounds: Boolean = false
 ) {
     var x = 0.0f
     var y = 0.0f
@@ -39,15 +41,17 @@ class InputOverlayPointer(
         var gameWidth = (surfacePosition.right - surfacePosition.left).toFloat()
         var gameHeight = (surfacePosition.bottom - surfacePosition.top).toFloat()
 
-        // Adjusting for device's black bars.
-        val surfaceAR = gameWidth / gameHeight
-        val gameAR = NativeLibrary.GetGameAspectRatio()
-        if (gameAR <= surfaceAR) {
-            // Black bars on left/right
-            gameWidth = gameHeight * gameAR
-        } else {
-            // Black bars on top/bottom
-            gameHeight = gameWidth / gameAR
+        if (adjustForGameAspectRatio) {
+            // Adjusting for device's black bars.
+            val surfaceAR = gameWidth / gameHeight
+            val gameAR = NativeLibrary.GetGameAspectRatio()
+            if (gameAR <= surfaceAR) {
+                // Black bars on left/right
+                gameWidth = gameHeight * gameAR
+            } else {
+                // Black bars on top/bottom
+                gameHeight = gameWidth / gameAR
+            }
         }
 
         gameWidthHalfInv = 1f / (gameWidth * 0.5f)
@@ -70,9 +74,13 @@ class InputOverlayPointer(
             }
 
             MotionEvent.ACTION_UP,
-            MotionEvent.ACTION_POINTER_UP -> {
-                if (trackId == event.getPointerId(pointerIndex))
+            MotionEvent.ACTION_POINTER_UP,
+            MotionEvent.ACTION_CANCEL -> {
+                if (action == MotionEvent.ACTION_CANCEL ||
+                    trackId == event.getPointerId(pointerIndex)
+                ) {
                     trackId = -1
+                }
                 if (mode == MODE_DRAG)
                     updateOldAxes()
                 if (recenter)
@@ -90,6 +98,11 @@ class InputOverlayPointer(
         } else if (mode == MODE_DRAG) {
             x = oldX + (event.getX(eventPointerIndex) - touchStartX) * gameWidthHalfInv
             y = oldY + (event.getY(eventPointerIndex) - touchStartY) * gameHeightHalfInv
+        }
+
+        if (clampToGameBounds) {
+            x = x.coerceIn(-1f, 1f)
+            y = y.coerceIn(-1f, 1f)
         }
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
@@ -10,6 +10,7 @@ import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import org.dolphinemu.dolphinemu.features.settings.model.ConfigChangedCallback
 import org.dolphinemu.dolphinemu.model.GameFile
 import org.dolphinemu.dolphinemu.model.GameFileCache
+import org.dolphinemu.dolphinemu.model.GbaGameFile
 import org.dolphinemu.dolphinemu.ui.platform.Platform
 import org.dolphinemu.dolphinemu.ui.platform.PlatformTab
 import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner
@@ -23,6 +24,7 @@ import java.util.concurrent.Executors
 object GameFileCacheManager {
     private var gameFileCache: GameFileCache? = null
     private val gameFiles = MutableLiveData(emptyArray<GameFile>())
+    private val gbaGameFiles = MutableLiveData(emptyArray<GbaGameFile>())
     private var firstLoadDone = false
     private var runRescanAfterLoad = false
     private var recursiveScanEnabled = false
@@ -37,7 +39,16 @@ object GameFileCacheManager {
     }
 
     @JvmStatic
+    fun getGbaGameFilesLiveData(): LiveData<Array<GbaGameFile>> {
+        return gbaGameFiles
+    }
+
+    @JvmStatic
     fun getGameFilesForPlatformTab(platformTab: PlatformTab): List<GameFile> {
+        if (platformTab == PlatformTab.GBA) {
+            return emptyList()
+        }
+
         val allGames = gameFiles.value!!
         val platformTabGames = ArrayList<GameFile>()
         for (game in allGames) {
@@ -46,6 +57,11 @@ object GameFileCacheManager {
             }
         }
         return platformTabGames
+    }
+
+    @JvmStatic
+    fun getGbaGameFiles(): List<GbaGameFile> {
+        return gbaGameFiles.value!!.toList()
     }
 
     @JvmStatic
@@ -173,6 +189,7 @@ object GameFileCacheManager {
             if (gameFileCache!!.getSize() != 0) {
                 updateGameFileArray()
             }
+            loadCachedGbaGameFiles()
         }
 
         if (runRescanAfterLoad) {
@@ -186,6 +203,8 @@ object GameFileCacheManager {
         if (runRescanAfterLoad) {
             runRescanAfterLoad = false
             rescan()
+        } else {
+            updateGbaGameFiles()
         }
     }
 
@@ -200,6 +219,7 @@ object GameFileCacheManager {
             runRescanAfterLoad = true
         } else {
             val gamePaths = GameFileCache.getAllGamePaths()
+            updateGbaGameFiles()
 
             val changed = gameFileCache!!.update(gamePaths)
             if (changed) {
@@ -225,6 +245,17 @@ object GameFileCacheManager {
             lhs.getTitle().compareTo(rhs.getTitle(), ignoreCase = true)
         }
         gameFiles.postValue(gameFilesTemp)
+    }
+
+    private fun updateGbaGameFiles() {
+        val recursiveScan = BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.boolean
+        val gbaFiles = GbaGameFileCache.scan(GameFileCache.getIsoPaths(), recursiveScan)
+        gbaGameFiles.postValue(gbaFiles)
+        GbaGameFileCache.save(gbaFiles)
+    }
+
+    private fun loadCachedGbaGameFiles() {
+        GbaGameFileCache.load()?.let(gbaGameFiles::postValue)
     }
 
     private fun createGameFileCacheIfNeeded() {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GbaGameFileCache.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GbaGameFileCache.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.services
+
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import org.dolphinemu.dolphinemu.DolphinApplication
+import org.dolphinemu.dolphinemu.model.GbaGameFile
+import org.dolphinemu.dolphinemu.utils.ContentHandler
+import org.dolphinemu.dolphinemu.utils.FileBrowserHelper
+import org.json.JSONArray
+import org.json.JSONException
+import java.io.File
+
+object GbaGameFileCache {
+    private const val CACHE_KEY = "GbaGameListCacheV1"
+
+    fun load(): Array<GbaGameFile>? {
+        val serialized = preferences.getString(CACHE_KEY, null) ?: return null
+        return try {
+            val entries = JSONArray(serialized)
+            Array(entries.length()) { index ->
+                val entry = entries.getJSONArray(index)
+                GbaGameFile(entry.getString(0), entry.getString(1))
+            }
+        } catch (_: JSONException) {
+            null
+        }
+    }
+
+    fun scan(folderPaths: Array<String>, recursiveScan: Boolean): Array<GbaGameFile> =
+        folderPaths
+            .flatMap { folderPath ->
+                findPaths(folderPath, recursiveScan).map { GbaGameFile(it, folderPath) }
+            }
+            .sortedBy { it.title.lowercase() }
+            .toTypedArray()
+
+    fun save(gameFiles: Array<GbaGameFile>) {
+        val entries = JSONArray()
+        gameFiles.forEach {
+            entries.put(JSONArray().put(it.path).put(it.rootPath))
+        }
+        preferences.edit { putString(CACHE_KEY, entries.toString()) }
+    }
+
+    private fun findPaths(folderPath: String, recursiveScan: Boolean): List<String> {
+        if (ContentHandler.isContentUri(folderPath)) {
+            val extensions = FileBrowserHelper.GBA_ROM_EXTENSIONS.map { ".$it" }.toTypedArray()
+            return ContentHandler.doFileSearch(folderPath, extensions, recursiveScan).toList()
+        }
+
+        val folder = File(folderPath)
+        val files = if (recursiveScan) {
+            folder.walkTopDown().asSequence()
+        } else {
+            folder.listFiles()?.asSequence() ?: emptySequence()
+        }
+        return files
+            .filter {
+                it.isFile && it.extension.lowercase() in FileBrowserHelper.GBA_ROM_EXTENSIONS
+            }
+            .map { it.absolutePath }
+            .toList()
+    }
+
+    private val preferences
+        get() = PreferenceManager.getDefaultSharedPreferences(DolphinApplication.getAppContext())
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.kt
@@ -16,12 +16,13 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.dolphinemu.dolphinemu.BuildConfig
 import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.activities.EmulationActivity
+import org.dolphinemu.dolphinemu.features.dualscreen.GbaBootManager
+import org.dolphinemu.dolphinemu.features.netplay.ui.NetplaySetupActivity
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag
 import org.dolphinemu.dolphinemu.features.sysupdate.ui.SystemMenuNotInstalledDialogFragment
 import org.dolphinemu.dolphinemu.features.sysupdate.ui.SystemUpdateProgressBarDialogFragment
 import org.dolphinemu.dolphinemu.features.sysupdate.ui.SystemUpdateViewModel
-import org.dolphinemu.dolphinemu.features.netplay.ui.NetplaySetupActivity
 import org.dolphinemu.dolphinemu.fragments.AboutDialogFragment
 import org.dolphinemu.dolphinemu.model.GameFileCache
 import org.dolphinemu.dolphinemu.services.GameFileCacheManager
@@ -61,7 +62,14 @@ class MainPresenter(private val mainView: MainView, private val activity: Fragme
         if (uri != null) {
             FileBrowserHelper.runAfterExtensionCheck(
                 activity, uri, FileBrowserHelper.GAME_LIKE_EXTENSIONS
-            ) { EmulationActivity.launch(activity, uri.toString(), false) }
+            ) {
+                val path = uri.toString()
+                if (GbaBootManager.isGbaRomPath(path)) {
+                    GbaBootManager.launchGameBoyPlayer(activity, path)
+                } else {
+                    EmulationActivity.launch(activity, path, false)
+                }
+            }
         } else {
             skipRescanningLibrary()
         }
@@ -113,6 +121,7 @@ class MainPresenter(private val mainView: MainView, private val activity: Fragme
         mainView.setVersionString(versionName)
 
         GameFileCacheManager.getGameFiles().observe(activity) { mainView.showGames() }
+        GameFileCacheManager.getGbaGameFilesLiveData().observe(activity) { mainView.showGames() }
         val refreshObserver =
             Observer<Boolean> { _: Boolean? -> mainView.setRefreshing(GameFileCacheManager.isLoadingOrRescanning()) }
         GameFileCacheManager.isLoading().observe(activity, refreshObserver)
@@ -123,7 +132,7 @@ class MainPresenter(private val mainView: MainView, private val activity: Fragme
         val intent = if (DirectoryInitialization.preferOldFolderPicker(activity)) {
             FileBrowserHelper.createDirectoryPickerIntent(
                 activity,
-                FileBrowserHelper.GAME_EXTENSIONS,
+                FileBrowserHelper.GAME_LIKE_EXTENSIONS,
             )
         } else {
             Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
@@ -231,7 +240,7 @@ class MainPresenter(private val mainView: MainView, private val activity: Fragme
         val recursive = BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.boolean
         val childNames = ContentHandler.getChildNames(uri, recursive)
         if (Arrays.stream(childNames).noneMatch {
-                FileBrowserHelper.GAME_EXTENSIONS.contains(
+                FileBrowserHelper.GAME_LIKE_EXTENSIONS.contains(
                     FileBrowserHelper.getExtension(
                         it, false
                     )
@@ -240,7 +249,9 @@ class MainPresenter(private val mainView: MainView, private val activity: Fragme
             MaterialAlertDialogBuilder(activity).setMessage(
                 activity.getString(
                     R.string.wrong_file_extension_in_directory,
-                    FileBrowserHelper.setToSortedDelimitedString(FileBrowserHelper.GAME_EXTENSIONS)
+                    FileBrowserHelper.setToSortedDelimitedString(
+                        FileBrowserHelper.GAME_LIKE_EXTENSIONS
+                    )
                 )
             ).setPositiveButton(android.R.string.ok, null).show()
         }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.kt
@@ -9,15 +9,18 @@ import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import com.google.android.material.color.MaterialColors
 import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.adapters.GbaGameAdapter
 import org.dolphinemu.dolphinemu.adapters.GameAdapter
 import org.dolphinemu.dolphinemu.databinding.FragmentGridBinding
 import org.dolphinemu.dolphinemu.layout.AutofitGridLayoutManager
 import org.dolphinemu.dolphinemu.services.GameFileCacheManager
+import org.dolphinemu.dolphinemu.utils.SerializableHelper.serializable
 
 class PlatformGamesFragment : Fragment(), PlatformGamesView {
     private var swipeRefresh: SwipeRefreshLayout? = null
@@ -37,16 +40,21 @@ class PlatformGamesFragment : Fragment(), PlatformGamesView {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         swipeRefresh = binding.swipeRefresh
-        val gameAdapter = GameAdapter()
+        val platformTab = requireArguments().serializable<PlatformTab>(ARG_PLATFORM_TAB)!!
+        val gameAdapter = if (platformTab == PlatformTab.GBA) GbaGameAdapter() else GameAdapter()
         gameAdapter.stateRestorationPolicy =
             RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
 
         binding.gridGames.apply {
             adapter = gameAdapter
-            layoutManager = AutofitGridLayoutManager(
-                requireContext(),
-                resources.getDimensionPixelSize(R.dimen.card_width)
-            )
+            layoutManager = if (platformTab == PlatformTab.GBA) {
+                LinearLayoutManager(requireContext())
+            } else {
+                AutofitGridLayoutManager(
+                    requireContext(),
+                    resources.getDimensionPixelSize(R.dimen.card_width)
+                )
+            }
         }
 
         // Set theme color to the refresh animation's background
@@ -73,15 +81,21 @@ class PlatformGamesFragment : Fragment(), PlatformGamesView {
             return
 
         if (binding.gridGames.adapter != null) {
-            val platformTab = requireArguments().getSerializable(ARG_PLATFORM_TAB) as PlatformTab
-            (binding.gridGames.adapter as GameAdapter?)!!.swapDataSet(
-                GameFileCacheManager.getGameFilesForPlatformTab(platformTab)
-            )
+            val platformTab = requireArguments().serializable<PlatformTab>(ARG_PLATFORM_TAB)!!
+            if (platformTab == PlatformTab.GBA) {
+                (binding.gridGames.adapter as GbaGameAdapter).swapDataSet(
+                    GameFileCacheManager.getGbaGameFiles()
+                )
+            } else {
+                (binding.gridGames.adapter as GameAdapter).swapDataSet(
+                    GameFileCacheManager.getGameFilesForPlatformTab(platformTab)
+                )
+            }
         }
     }
 
     override fun refetchMetadata() {
-        (binding.gridGames.adapter as GameAdapter).refetchMetadata()
+        (binding.gridGames.adapter as? GameAdapter)?.refetchMetadata()
     }
 
     fun setOnRefreshListener(listener: OnRefreshListener?) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformTab.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformTab.kt
@@ -12,7 +12,8 @@ import org.dolphinemu.dolphinemu.R
 enum class PlatformTab(private val value: Int, val headerName: Int, val idString: String) {
     GAMECUBE(0, R.string.platform_gamecube, "GameCube Games"),
     WII(1, R.string.platform_wii, "Wii Games"),
-    WIIWARE(2, R.string.platform_wiiware, "WiiWare Games");
+    WIIWARE(2, R.string.platform_wiiware, "WiiWare Games"),
+    GBA(3, R.string.platform_gba, "GBA Games");
 
     fun toInt(): Int {
         return value

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.kt
@@ -35,14 +35,15 @@ object FileBrowserHelper {
     )
 
     @JvmField
-    val GAME_LIKE_EXTENSIONS: HashSet<String> = HashSet(GAME_EXTENSIONS).apply {
-        add("dff")
-    }
-
-    @JvmField
     val GBA_ROM_EXTENSIONS: HashSet<String> = hashSetOf(
         "gba", "gbc", "gb", "agb", "mb", "rom", "bin"
     )
+
+    @JvmField
+    val GAME_LIKE_EXTENSIONS: HashSet<String> = HashSet(GAME_EXTENSIONS).apply {
+        add("dff")
+        addAll(GBA_ROM_EXTENSIONS)
+    }
 
     @JvmField
     val BIN_EXTENSION: HashSet<String> = hashSetOf("bin")

--- a/Source/Android/app/src/main/res/drawable/ic_gba.xml
+++ b/Source/Android/app/src/main/res/drawable/ic_gba.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorPrimary"
+        android:pathData="M21.58,16.09l-1.09,-7.66C20.21,6.46 18.52,5 16.53,5H7.47C5.48,5 3.79,6.46 3.51,8.43l-1.09,7.66C2.2,17.63 3.39,19 4.94,19c0.68,0 1.32,-0.27 1.8,-0.75L9,16h6l2.25,2.25c0.48,0.48 1.13,0.75 1.8,0.75C20.61,19 21.8,17.63 21.58,16.09zM11,11H9v2H8v-2H6v-1h2V8h1v2h2v1zM15,10c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1 1,0.45 1,1 -0.45,1 -1,1zM17,13c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1 1,0.45 1,1 -0.45,1 -1,1z" />
+</vector>

--- a/Source/Android/app/src/main/res/layout-notouch/fragment_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-notouch/fragment_emulation.xml
@@ -11,4 +11,10 @@
         android:focusable="false"
         android:focusableInTouchMode="false" />
 
+    <org.dolphinemu.dolphinemu.features.dualscreen.GbaScreenView
+        android:id="@+id/surface_gba_screen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/Source/Android/app/src/main/res/layout-port-notouch/fragment_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-port-notouch/fragment_emulation.xml
@@ -11,4 +11,10 @@
         android:focusable="false"
         android:focusableInTouchMode="false" />
 
+    <org.dolphinemu.dolphinemu.features.dualscreen.GbaScreenView
+        android:id="@+id/surface_gba_screen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
 </FrameLayout>

--- a/Source/Android/app/src/main/res/layout-port/fragment_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-port/fragment_emulation.xml
@@ -38,6 +38,12 @@
         android:focusable="true"
         android:focusableInTouchMode="true" />
 
+    <org.dolphinemu.dolphinemu.features.dualscreen.GbaScreenView
+        android:id="@+id/surface_gba_screen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
     <Button
         android:id="@+id/done_control_config"
         android:layout_width="wrap_content"

--- a/Source/Android/app/src/main/res/layout/fragment_emulation.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_emulation.xml
@@ -23,6 +23,12 @@
         android:focusable="true"
         android:focusableInTouchMode="true" />
 
+    <org.dolphinemu.dolphinemu.features.dualscreen.GbaScreenView
+        android:id="@+id/surface_gba_screen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
     <Button
         android:id="@+id/done_control_config"
         android:layout_width="wrap_content"

--- a/Source/Android/app/src/main/res/layout/fragment_gba_packs.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_gba_packs.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_gba_packs"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:background="#af000000"
+    android:orientation="vertical"
+    tools:ignore="Overdraw">
+
+    <Button
+        android:id="@+id/gba_pack_player"
+        style="@style/OverlayInGameMenuOption"
+        android:layout_width="260dp"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -92,6 +92,16 @@
                 android:text="@string/emulation_overlay_controls" />
 
             <Button
+                android:id="@+id/menu_toggle_gba_screen"
+                style="@style/InGameMenuOption"
+                android:text="@string/emulation_show_gba_screen" />
+
+            <Button
+                android:id="@+id/menu_gba_packs"
+                style="@style/InGameMenuOption"
+                android:text="@string/emulation_gba_packs" />
+
+            <Button
                 android:id="@+id/menu_refresh_wiimotes"
                 android:text="@string/emulation_refresh_wiimotes"
                 style="@style/InGameMenuOption" />

--- a/Source/Android/app/src/main/res/layout/list_item_gba_game.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_gba_game.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:minHeight="64dp"
+    android:paddingStart="@dimen/spacing_large"
+    android:paddingTop="@dimen/spacing_small"
+    android:paddingEnd="@dimen/spacing_large"
+    android:paddingBottom="@dimen/spacing_small">
+
+    <ImageView
+        android:id="@+id/image_gba_icon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:contentDescription="@string/platform_gba"
+        android:src="@drawable/ic_gba"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?attr/colorOnSurface" />
+
+    <TextView
+        android:id="@+id/text_gba_title"
+        style="@style/TextAppearance.MaterialComponents.Body1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="middle"
+        android:maxLines="1"
+        android:textAlignment="viewStart"
+        app:layout_constraintBottom_toTopOf="@+id/text_gba_folder"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/image_gba_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        android:layout_marginStart="@dimen/spacing_large"
+        tools:text="The Legend of Zelda - The Minish Cap" />
+
+    <TextView
+        android:id="@+id/text_gba_folder"
+        style="@style/TextAppearance.MaterialComponents.Caption"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="start"
+        android:maxLines="1"
+        android:textAlignment="viewStart"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/text_gba_title"
+        app:layout_constraintStart_toStartOf="@+id/text_gba_title"
+        app:layout_constraintTop_toBottomOf="@+id/text_gba_title"
+        tools:text="GBA/Action RPG" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -379,6 +379,7 @@
         <item>@string/gcpad_taru_konga</item>
         <item>@string/gcpad_am_baseboard</item>
         <item>@string/gcpad_gc_adapter</item>
+        <item>@string/gcpad_emulated_gba</item>
     </string-array>
     <integer-array name="gcpadTypeValues">
         <item>0</item>
@@ -389,6 +390,33 @@
         <item>10</item>
         <item>11</item>
         <item>12</item>
+        <item>13</item>
+    </integer-array>
+
+    <string-array name="gbaLinkScaleModeEntries">
+        <item>@string/gba_link_scale_fit</item>
+        <item>@string/gba_link_scale_stretch</item>
+        <item>@string/gba_link_scale_integer</item>
+    </string-array>
+    <integer-array name="gbaLinkScaleModeValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
+
+    <string-array name="gbaLinkPositionEntries">
+        <item>@string/gba_link_position_center</item>
+        <item>@string/gba_link_position_top</item>
+        <item>@string/gba_link_position_bottom</item>
+        <item>@string/gba_link_position_left</item>
+        <item>@string/gba_link_position_right</item>
+    </string-array>
+    <integer-array name="gbaLinkPositionValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
     </integer-array>
 
     <string-array name="wiimoteTypeEntries">

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Title of the app -->
     <string name="app_name">Dolphin Emulator</string>
@@ -66,6 +66,29 @@
     <string name="config">Config</string>
     <string name="graphics_settings">Graphics Settings</string>
     <string name="gcpad_settings">GameCube Input</string>
+    <string name="gba_link_settings">GBA Link</string>
+    <string name="gba_controller_0">GBA Input 1 (Port 1)</string>
+    <string name="gba_controller_1">GBA Input 2 (Port 2)</string>
+    <string name="gba_controller_2">GBA Input 3 (Port 3)</string>
+    <string name="gba_controller_3">GBA Input 4 (Port 4)</string>
+    <string name="gba_link_scale_mode">GBA Screen Scale</string>
+    <string name="gba_link_scale_mode_description">Controls how the GBA image is scaled on the internal or external display.</string>
+    <string name="gba_link_scale_fit">Fit, keep aspect ratio</string>
+    <string name="gba_link_scale_stretch">Stretch to full screen</string>
+    <string name="gba_link_scale_integer">Integer scale</string>
+    <string name="gba_link_external_display">Use External Display for GBA Link</string>
+    <string name="gba_link_external_display_description">Shows the active GBA Link screen on a valid external presentation display when one is connected.</string>
+    <string name="gba_link_position">GBA Screen Position</string>
+    <string name="gba_link_position_description">Controls where the GBA image is anchored when it does not fill the display.</string>
+    <string name="gba_link_position_center">Center</string>
+    <string name="gba_link_position_top">Top</string>
+    <string name="gba_link_position_bottom">Bottom</string>
+    <string name="gba_link_position_left">Left</string>
+    <string name="gba_link_position_right">Right</string>
+    <string name="gba_link_hide_touch_controls">Hide Touch Controls with Controller</string>
+    <string name="gba_link_hide_touch_controls_description">Hides the on-screen GBA buttons only when the selected GBA input device is configured and connected.</string>
+    <string name="gba_link_mute_audio">Mute GBA Link</string>
+    <string name="gba_link_mute_audio_description">Silences audio from emulated GBA Link ports without disconnecting the GBA game.</string>
     <string name="wiimote_settings">Wii Input</string>
 
     <!-- General Preference Fragment -->
@@ -87,7 +110,17 @@
     <string name="serial_port_1_device">GameCube Serial Port 1 Device</string>
     <string name="gba_settings">GBA Settings</string>
     <string name="gba_bios_path">BIOS</string>
+    <string name="gba_bios_required_title">GBA BIOS Required</string>
+    <string name="gba_bios_required_message">Configure a 16 KB GBA BIOS when an Emulated GBA port has no ROM.</string>
+    <string name="configure_bios">Configure BIOS</string>
+    <string name="gba_rom_1">GBA ROM 1 (Port 1)</string>
+    <string name="gba_rom_2">GBA ROM 2 (Port 2)</string>
+    <string name="gba_rom_3">GBA ROM 3 (Port 3)</string>
+    <string name="gba_rom_4">GBA ROM 4 (Port 4)</string>
     <string name="gb_player_rom">Game Boy Player ROM</string>
+    <string name="gb_player_boot_path">Game Boy Player Boot Path</string>
+    <string name="gb_player_boot_path_description">Disc, DOL, or ELF used to boot Game Boy Player mode before loading the selected GBA ROM.</string>
+    <string name="gb_player_boot_path_required">Set a Game Boy Player boot path before launching GBA ROMs.</string>
     <string name="gba_saves_path">Saves</string>
     <string name="wii_submenu">Wii</string>
     <string name="wii_misc_settings">Misc Settings</string>
@@ -498,6 +531,7 @@
     <string name="platform_gamecube">GameCube Games</string>
     <string name="platform_wii">Wii Games</string>
     <string name="platform_wiiware">WiiWare Games</string>
+    <string name="platform_gba">GBA Games</string>
     <string name="add_games">Add Games</string>
     <string name="add_directory_title">Add Folder to Library</string>
     <string name="grid_menu_settings">Settings</string>
@@ -633,6 +667,18 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_quickload">Quick Load</string>
     <string name="emulation_refresh_wiimotes">Refresh Wii Remotes</string>
     <string name="emulation_overlay_controls">Overlay Controls</string>
+    <string name="emulation_show_gba_screen">Show GBA Screen</string>
+    <string name="emulation_show_gamecube_screen">Show GameCube Screen</string>
+    <string name="emulation_gba_packs">GBA Packs</string>
+    <string name="emulation_gba_pack_player">Game Boy Player ROM</string>
+    <string name="emulation_gba_pack_player_with_value">Game Boy Player ROM\n%1$s</string>
+    <string name="emulation_gba_pack_empty">Not configured</string>
+    <string name="emulation_gba_pack_updated">%1$s updated. Reconnect or restart the GBA link if the running game does not reload it automatically.</string>
+    <string name="emulation_gba_screen_no_core">No active GBA screen is available yet.</string>
+    <string name="gba_screen_no_active_link">No GBA link active</string>
+    <string name="gba_screen_title" tools:ignore="PluralsCandidate">GBA %1$d</string>
+    <string name="gba_screen_title_with_game" tools:ignore="PluralsCandidate">GBA %1$d: %2$s</string>
+    <string name="gba_screen_waiting_for_frame" tools:ignore="PluralsCandidate">Waiting for GBA %1$d frame</string>
     <string name="emulation_edit_layout">Edit Layout</string>
     <string name="emulation_done">Done</string>
     <string name="emulation_toggle_controls">Toggle Controls</string>
@@ -834,6 +880,13 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="gcpad_taru_konga">DK Bongos</string>
     <string name="gcpad_am_baseboard">Triforce Baseboard</string>
     <string name="gcpad_gc_adapter">GameCube Adapter</string>
+    <string name="gcpad_emulated_gba">Emulated GBA</string>
+
+    <string name="dual_screen_external_display">Use External Display</string>
+    <string name="dual_screen_external_display_description">Automatically use an external display when GBA Link or Wii pointer touchpad support is configured.</string>
+    <string name="dual_screen_wii_pointer_touchpad">Use External Display as Wii Pointer Touchpad</string>
+    <string name="dual_screen_wii_pointer_touchpad_description">Uses the external display as a touch surface for Wii pointer input when a Wii game is running.</string>
+    <string name="dual_screen_wii_pointer_touchpad_label">Wii Pointer Touchpad</string>
 
     <!-- Wiimote Types -->
     <string name="wiimote_disabled">None</string>

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -18,6 +18,11 @@ static jmethodID s_update_touch_pointer;
 static jmethodID s_on_title_changed;
 static jmethodID s_finish_emulation_activity;
 
+static jclass s_gba_host_bridge_class;
+static jmethodID s_gba_host_bridge_on_game_changed;
+static jmethodID s_gba_host_bridge_on_core_stopped;
+static jmethodID s_gba_host_bridge_on_frame;
+
 static jclass s_game_file_class;
 static jfieldID s_game_file_pointer;
 static jmethodID s_game_file_constructor;
@@ -209,6 +214,26 @@ jmethodID GetOnTitleChanged()
 jmethodID GetFinishEmulationActivity()
 {
   return s_finish_emulation_activity;
+}
+
+jclass GetGbaHostBridgeClass()
+{
+  return s_gba_host_bridge_class;
+}
+
+jmethodID GetGbaHostBridgeOnGameChanged()
+{
+  return s_gba_host_bridge_on_game_changed;
+}
+
+jmethodID GetGbaHostBridgeOnCoreStopped()
+{
+  return s_gba_host_bridge_on_core_stopped;
+}
+
+jmethodID GetGbaHostBridgeOnFrame()
+{
+  return s_gba_host_bridge_on_frame;
 }
 
 jclass GetAnalyticsClass()
@@ -749,6 +774,17 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
       env->GetStaticMethodID(s_native_library_class, "finishEmulationActivity", "()V");
   env->DeleteLocalRef(native_library_class);
 
+  const jclass gba_host_bridge_class =
+      env->FindClass("org/dolphinemu/dolphinemu/features/dualscreen/GbaHostBridge");
+  s_gba_host_bridge_class = reinterpret_cast<jclass>(env->NewGlobalRef(gba_host_bridge_class));
+  s_gba_host_bridge_on_game_changed = env->GetStaticMethodID(
+      s_gba_host_bridge_class, "onGameChanged", "(IIIZZLjava/lang/String;)V");
+  s_gba_host_bridge_on_core_stopped =
+      env->GetStaticMethodID(s_gba_host_bridge_class, "onCoreStopped", "(I)V");
+  s_gba_host_bridge_on_frame =
+      env->GetStaticMethodID(s_gba_host_bridge_class, "onFrame", "(III[I)V");
+  env->DeleteLocalRef(gba_host_bridge_class);
+
   const jclass game_file_class = env->FindClass("org/dolphinemu/dolphinemu/model/GameFile");
   s_game_file_class = reinterpret_cast<jclass>(env->NewGlobalRef(game_file_class));
   s_game_file_pointer = env->GetFieldID(game_file_class, "pointer", "J");
@@ -1025,6 +1061,7 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved)
     return;
 
   env->DeleteGlobalRef(s_native_library_class);
+  env->DeleteGlobalRef(s_gba_host_bridge_class);
   env->DeleteGlobalRef(s_game_file_class);
   env->DeleteGlobalRef(s_game_file_cache_class);
   env->DeleteGlobalRef(s_netplay_session_class);

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -18,6 +18,11 @@ jmethodID GetUpdateTouchPointer();
 jmethodID GetOnTitleChanged();
 jmethodID GetFinishEmulationActivity();
 
+jclass GetGbaHostBridgeClass();
+jmethodID GetGbaHostBridgeOnGameChanged();
+jmethodID GetGbaHostBridgeOnCoreStopped();
+jmethodID GetGbaHostBridgeOnFrame();
+
 jclass GetAnalyticsClass();
 jmethodID GetAnalyticsValue();
 

--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(main SHARED
   Config/ConfigChangedCallback.cpp
   Config/NativeConfig.cpp
   Config/PostProcessing.cpp
+  GBA/AndroidGBAHost.cpp
+  GBA/AndroidGBAHost.h
   GameList/GameFile.cpp
   GameList/GameFile.h
   GameList/GameFileCache.cpp

--- a/Source/Android/jni/GBA/AndroidGBAHost.cpp
+++ b/Source/Android/jni/GBA/AndroidGBAHost.cpp
@@ -1,0 +1,153 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "jni/GBA/AndroidGBAHost.h"
+
+#include <atomic>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include <android/log.h>
+#include <jni.h>
+
+#include "Common/CommonTypes.h"
+#include "Core/HW/GBACore.h"
+#include "jni/AndroidCommon/AndroidCommon.h"
+#include "jni/AndroidCommon/IDCache.h"
+
+namespace
+{
+constexpr const char* DOLPHIN_TAG = "DolphinEmuNative";
+
+std::atomic<int> s_visible_device{-1};
+
+void ClearPendingException(JNIEnv* env, const char* callback)
+{
+  if (!env->ExceptionCheck())
+    return;
+
+  __android_log_print(ANDROID_LOG_ERROR, DOLPHIN_TAG, "[AndroidGBAHost] Java exception in %s",
+                      callback);
+  env->ExceptionDescribe();
+  env->ExceptionClear();
+}
+
+jint ToAndroidArgb(u32 pixel)
+{
+  return static_cast<jint>(0xff000000 | ((pixel & 0x000000ff) << 16) | (pixel & 0x0000ff00) |
+                           ((pixel & 0x00ff0000) >> 16));
+}
+
+class AndroidGBAHost final : public GBAHostInterface
+{
+public:
+  explicit AndroidGBAHost(std::weak_ptr<HW::GBA::Core> core) : m_core(std::move(core))
+  {
+    if (const std::shared_ptr<HW::GBA::Core> core_ptr = m_core.lock())
+      m_device_number = core_ptr->GetCoreInfo().device_number;
+    GameChanged();
+  }
+
+  ~AndroidGBAHost() override
+  {
+    if (m_device_number < 0)
+      return;
+
+    JNIEnv* env = IDCache::GetEnvForThread();
+    env->CallStaticVoidMethod(IDCache::GetGbaHostBridgeClass(),
+                              IDCache::GetGbaHostBridgeOnCoreStopped(),
+                              static_cast<jint>(m_device_number));
+    ClearPendingException(env, "GbaHostBridge.onCoreStopped");
+  }
+
+  void GameChanged() override
+  {
+    const std::shared_ptr<HW::GBA::Core> core = m_core.lock();
+    if (!core)
+      return;
+
+    const HW::GBA::CoreInfo info = core->GetCoreInfo();
+    JNIEnv* env = IDCache::GetEnvForThread();
+    jstring title = ToJString(env, info.game_title);
+    if (env->ExceptionCheck())
+    {
+      ClearPendingException(env, "ToJString");
+      return;
+    }
+
+    env->CallStaticVoidMethod(IDCache::GetGbaHostBridgeClass(),
+                              IDCache::GetGbaHostBridgeOnGameChanged(),
+                              static_cast<jint>(info.device_number), static_cast<jint>(info.width),
+                              static_cast<jint>(info.height), static_cast<jboolean>(info.is_gba),
+                              static_cast<jboolean>(info.has_rom), title);
+    env->DeleteLocalRef(title);
+    ClearPendingException(env, "GbaHostBridge.onGameChanged");
+  }
+
+  void FrameEnded(std::span<const u32> video_buffer) override
+  {
+    const std::shared_ptr<HW::GBA::Core> core = m_core.lock();
+    if (!core)
+      return;
+
+    const HW::GBA::CoreInfo info = core->GetCoreInfo();
+    if (s_visible_device.load(std::memory_order_relaxed) != static_cast<int>(info.device_number))
+      return;
+
+    const size_t pixel_count = static_cast<size_t>(info.width) * static_cast<size_t>(info.height);
+    if (pixel_count == 0 || video_buffer.size() < pixel_count)
+      return;
+
+    JNIEnv* env = IDCache::GetEnvForThread();
+    jintArray pixels = env->NewIntArray(static_cast<jsize>(pixel_count));
+    if (!pixels)
+    {
+      ClearPendingException(env, "NewIntArray");
+      return;
+    }
+
+    m_pixels.resize(pixel_count);
+    for (size_t i = 0; i < pixel_count; ++i)
+      m_pixels[i] = ToAndroidArgb(video_buffer[i]);
+
+    env->SetIntArrayRegion(pixels, 0, static_cast<jsize>(pixel_count), m_pixels.data());
+    if (env->ExceptionCheck())
+    {
+      env->DeleteLocalRef(pixels);
+      ClearPendingException(env, "SetIntArrayRegion");
+      return;
+    }
+
+    env->CallStaticVoidMethod(IDCache::GetGbaHostBridgeClass(), IDCache::GetGbaHostBridgeOnFrame(),
+                              static_cast<jint>(info.device_number), static_cast<jint>(info.width),
+                              static_cast<jint>(info.height), pixels);
+    env->DeleteLocalRef(pixels);
+    ClearPendingException(env, "GbaHostBridge.onFrame");
+  }
+
+private:
+  std::weak_ptr<HW::GBA::Core> m_core;
+  std::vector<jint> m_pixels;
+  int m_device_number = -1;
+};
+}  // namespace
+
+std::unique_ptr<GBAHostInterface> CreateAndroidGBAHost(std::weak_ptr<HW::GBA::Core> core)
+{
+#ifdef HAS_LIBMGBA
+  return std::make_unique<AndroidGBAHost>(std::move(core));
+#else
+  return nullptr;
+#endif
+}
+
+extern "C" {
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_dualscreen_GbaHostBridge_setVisibleDevice(
+    JNIEnv*, jclass, jint device_number)
+{
+  s_visible_device.store(static_cast<int>(device_number), std::memory_order_relaxed);
+}
+}

--- a/Source/Android/jni/GBA/AndroidGBAHost.h
+++ b/Source/Android/jni/GBA/AndroidGBAHost.h
@@ -1,0 +1,15 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <memory>
+
+#include "Core/Host.h"
+
+namespace HW::GBA
+{
+class Core;
+}
+
+std::unique_ptr<GBAHostInterface> CreateAndroidGBAHost(std::weak_ptr<HW::GBA::Core> core);

--- a/Source/Android/jni/GameList/GameFileCache.cpp
+++ b/Source/Android/jni/GameList/GameFileCache.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include <jni.h>

--- a/Source/Android/jni/Input/EmulatedController.cpp
+++ b/Source/Android/jni/Input/EmulatedController.cpp
@@ -5,6 +5,7 @@
 
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Core/HW/GBAPad.h"
 #include "Core/HW/GCKeyboard.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/Wiimote.h"
@@ -182,6 +183,13 @@ Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedContro
     JNIEnv* env, jclass, jint controller_index)
 {
   return EmulatedControllerToJava(env, Keyboard::GetConfig()->GetController(controller_index));
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_controlleremu_EmulatedController_getGbaPad(
+    JNIEnv* env, jclass, jint controller_index)
+{
+  return EmulatedControllerToJava(env, Pad::GetGBAConfig()->GetController(controller_index));
 }
 
 JNIEXPORT jobject JNICALL

--- a/Source/Android/jni/Input/InputOverrider.cpp
+++ b/Source/Android/jni/Input/InputOverrider.cpp
@@ -23,6 +23,13 @@ Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_registerWii(J
 }
 
 JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_registerGba(JNIEnv*, jclass,
+                                                                               int controller_index)
+{
+  ciface::Touch::RegisterGBAInputOverrider(controller_index);
+}
+
+JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_unregisterGameCube(
     JNIEnv*, jclass, int controller_index)
 {
@@ -34,6 +41,27 @@ Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_unregisterWii
     JNIEnv*, jclass, int controller_index)
 {
   ciface::Touch::UnregisterWiiInputOverrider(controller_index);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_unregisterGba(
+    JNIEnv*, jclass, int controller_index)
+{
+  ciface::Touch::UnregisterGBAInputOverrider(controller_index);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_setGbaInputEnabled(
+    JNIEnv*, jclass, int controller_index, jboolean enabled)
+{
+  ciface::Touch::SetGBAInputEnabled(controller_index, enabled == JNI_TRUE);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_features_input_model_InputOverrider_setGameCubeInputEnabled(
+    JNIEnv*, jclass, int controller_index, jboolean enabled)
+{
+  ciface::Touch::SetGameCubeInputEnabled(controller_index, enabled == JNI_TRUE);
 }
 
 JNIEXPORT void JNICALL

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -66,6 +66,7 @@
 
 #include "jni/AndroidCommon/AndroidCommon.h"
 #include "jni/AndroidCommon/IDCache.h"
+#include "jni/GBA/AndroidGBAHost.h"
 
 namespace
 {
@@ -198,7 +199,7 @@ void Host_TitleChanged()
 
 std::unique_ptr<GBAHostInterface> Host_CreateGBAHost(std::weak_ptr<HW::GBA::Core> core)
 {
-  return nullptr;
+  return CreateAndroidGBAHost(std::move(core));
 }
 
 static bool MsgAlert(const char* caption, const char* text, bool yes_no, Common::MsgType style)

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -407,6 +407,7 @@ const std::array<Info<std::string>, 5> MAIN_GBA_ROM_PATHS{
 };
 const Info<std::string> MAIN_GBA_SAVES_PATH{{System::Main, "GBA", "SavesPath"}, ""};
 const Info<bool> MAIN_GBA_SAVES_IN_ROM_PATH{{System::Main, "GBA", "SavesInRomPath"}, false};
+const Info<bool> MAIN_GBA_LINK_MUTED{{System::Main, "GBA", "MuteLinkAudio"}, false};
 #endif
 
 // Main.Network

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -227,6 +227,7 @@ extern const Info<std::string> MAIN_GBA_BIOS_PATH;
 extern const std::array<Info<std::string>, 5> MAIN_GBA_ROM_PATHS;
 extern const Info<std::string> MAIN_GBA_SAVES_PATH;
 extern const Info<bool> MAIN_GBA_SAVES_IN_ROM_PATH;
+extern const Info<bool> MAIN_GBA_LINK_MUTED;
 
 static constexpr std::size_t GBPLAYER_GBA_INDEX = 4;
 #endif

--- a/Source/Core/Core/HW/GBACore.cpp
+++ b/Source/Core/Core/HW/GBACore.cpp
@@ -465,13 +465,16 @@ static void ReadAudioBufferIntoMixer(mAudioBuffer* audio_buffer, Mixer* mixer,
                                      std::size_t device_number)
 {
   std::array<s16, AUDIO_BUFFER_SIZE> sample_buffer;
+  const bool mute_link_audio =
+      device_number != Config::GBPLAYER_GBA_INDEX && Config::Get(Config::MAIN_GBA_LINK_MUTED);
   const auto read_size = sample_buffer.size() / audio_buffer->channels;
   while (true)
   {
     const auto sample_count = mAudioBufferRead(audio_buffer, sample_buffer.data(), read_size);
     if (sample_count == 0)
       break;
-    mixer->PushGBASamples(device_number, sample_buffer.data(), sample_count);
+    if (!mute_link_audio)
+      mixer->PushGBASamples(device_number, sample_buffer.data(), sample_count);
   }
 }
 

--- a/Source/Core/Core/HW/SI/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI/SI_Device.cpp
@@ -183,6 +183,9 @@ std::unique_ptr<ISIDevice> SIDevice_Create(Core::System& system, const SIDevices
 
   case SIDEVICE_GC_GBA_EMULATED:
 #ifdef HAS_LIBMGBA
+    if (system.IsWii())
+      return std::make_unique<CSIDevice_Null>(system, SIDEVICE_NONE, port_number);
+
     return std::make_unique<CSIDevice_GBAEmu>(system, device, port_number);
 #else
     PanicAlertFmtT("Error: This build does not support emulated GBA controllers");

--- a/Source/Core/InputCommon/ControllerInterface/Touch/InputOverrider.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/InputOverrider.cpp
@@ -5,6 +5,8 @@
 #include "InputCommon/ControllerInterface/Touch/InputOverrider.h"
 
 #include <array>
+#include <atomic>
+#include <cmath>
 #include <map>
 #include <optional>
 #include <string>
@@ -13,6 +15,8 @@
 
 #include "Common/Assert.h"
 
+#include "Core/HW/GBAPad.h"
+#include "Core/HW/GBAPadEmu.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/GCPadEmu.h"
 #include "Core/HW/Wiimote.h"
@@ -34,14 +38,16 @@ namespace
 struct InputState
 {
   ControlState normal_state = 0;
-  ControlState override_state = 0;
-  bool overriding = false;
+  std::atomic<ControlState> override_state = 0;
+  std::atomic_bool overriding = false;
 };
 
 using ControlsMap = std::map<std::pair<std::string_view, std::string_view>, ControlID>;
 using StateArray = std::array<InputState, ControlID::NUMBER_OF_CONTROLS>;
 
 std::array<StateArray, 4> s_state_arrays;
+std::array<std::atomic_bool, 4> s_gamecube_input_enabled = {true, true, true, true};
+std::array<std::atomic_bool, 4> s_gba_input_enabled;
 
 const ControlsMap s_gcpad_controls_map = {{
     {{GCPad::BUTTONS_GROUP, GCPad::A_BUTTON}, ControlID::GCPAD_A_BUTTON},
@@ -145,26 +151,55 @@ const ControlsMap s_classic_controls_map = {{
      ControlID::CLASSIC_RIGHT_STICK_Y},
 }};
 
-ControllerEmu::InputOverrideFunction GetInputOverrideFunction(const ControlsMap& controls_map,
-                                                              size_t i)
-{
-  StateArray& state_array = s_state_arrays[i];
+const ControlsMap s_gba_controls_map = {{
+    {{GBAPad::BUTTONS_GROUP, GBAPad::B_BUTTON}, ControlID::GBA_B_BUTTON},
+    {{GBAPad::BUTTONS_GROUP, GBAPad::A_BUTTON}, ControlID::GBA_A_BUTTON},
+    {{GBAPad::BUTTONS_GROUP, GBAPad::L_BUTTON}, ControlID::GBA_L_BUTTON},
+    {{GBAPad::BUTTONS_GROUP, GBAPad::R_BUTTON}, ControlID::GBA_R_BUTTON},
+    {{GBAPad::BUTTONS_GROUP, GBAPad::SELECT_BUTTON}, ControlID::GBA_SELECT_BUTTON},
+    {{GBAPad::BUTTONS_GROUP, GBAPad::START_BUTTON}, ControlID::GBA_START_BUTTON},
+    {{GBAPad::DPAD_GROUP, DIRECTION_UP}, ControlID::GBA_DPAD_UP},
+    {{GBAPad::DPAD_GROUP, DIRECTION_DOWN}, ControlID::GBA_DPAD_DOWN},
+    {{GBAPad::DPAD_GROUP, DIRECTION_LEFT}, ControlID::GBA_DPAD_LEFT},
+    {{GBAPad::DPAD_GROUP, DIRECTION_RIGHT}, ControlID::GBA_DPAD_RIGHT},
+}};
 
-  return [&](std::string_view group_name, std::string_view control_name,
-             ControlState controller_state) -> std::optional<ControlState> {
+bool InputStatesDiffer(ControlState lhs, ControlState rhs)
+{
+  return lhs != rhs && !(std::isnan(lhs) && std::isnan(rhs));
+}
+
+std::optional<ControlState> GetOverrideState(const InputState& input_state)
+{
+  if (!input_state.overriding.load(std::memory_order_acquire))
+    return std::nullopt;
+
+  return input_state.override_state.load(std::memory_order_acquire);
+}
+
+ControllerEmu::InputOverrideFunction
+GetInputOverrideFunction(const ControlsMap& controls_map, size_t i,
+                         const std::atomic_bool* input_enabled = nullptr)
+{
+  return [&controls_map, i,
+          input_enabled](std::string_view group_name, std::string_view control_name,
+                         ControlState controller_state) -> std::optional<ControlState> {
     const auto it = controls_map.find(std::make_pair(group_name, control_name));
     if (it == controls_map.end())
       return std::nullopt;
 
     const ControlID control = it->second;
-    InputState& input_state = state_array[control];
-    if (input_state.normal_state != controller_state)
+    InputState& input_state = s_state_arrays[i][control];
+    if (InputStatesDiffer(input_state.normal_state, controller_state))
     {
       input_state.normal_state = controller_state;
-      input_state.overriding = false;
+      input_state.overriding.store(false, std::memory_order_release);
     }
 
-    return input_state.overriding ? std::make_optional(input_state.override_state) : std::nullopt;
+    if (input_enabled && !input_enabled->load(std::memory_order_relaxed))
+      return 0.0;
+
+    return GetOverrideState(input_state);
   };
 }
 
@@ -174,7 +209,8 @@ void RegisterGameCubeInputOverrider(int controller_index)
 {
   Pad::GetConfig()
       ->GetController(controller_index)
-      ->SetInputOverrideFunction(GetInputOverrideFunction(s_gcpad_controls_map, controller_index));
+      ->SetInputOverrideFunction(GetInputOverrideFunction(
+          s_gcpad_controls_map, controller_index, &s_gamecube_input_enabled[controller_index]));
 }
 
 void RegisterWiiInputOverrider(int controller_index)
@@ -195,12 +231,22 @@ void RegisterWiiInputOverrider(int controller_index)
       GetInputOverrideFunction(s_classic_controls_map, controller_index));
 }
 
+void RegisterGBAInputOverrider(int controller_index)
+{
+  s_gba_input_enabled[controller_index].store(false);
+  Pad::GetGBAConfig()
+      ->GetController(controller_index)
+      ->SetInputOverrideFunction(GetInputOverrideFunction(s_gba_controls_map, controller_index,
+                                                          &s_gba_input_enabled[controller_index]));
+}
+
 void UnregisterGameCubeInputOverrider(int controller_index)
 {
   Pad::GetConfig()->GetController(controller_index)->ClearInputOverrideFunction();
+  s_gamecube_input_enabled[controller_index].store(true);
 
   for (size_t i = ControlID::FIRST_GC_CONTROL; i <= ControlID::LAST_GC_CONTROL; ++i)
-    s_state_arrays[controller_index][i].overriding = false;
+    s_state_arrays[controller_index][i].overriding.store(false, std::memory_order_release);
 }
 
 void UnregisterWiiInputOverrider(int controller_index)
@@ -218,22 +264,41 @@ void UnregisterWiiInputOverrider(int controller_index)
   attachments[WiimoteEmu::ExtensionNumber::CLASSIC]->ClearInputOverrideFunction();
 
   for (size_t i = ControlID::FIRST_WII_CONTROL; i <= ControlID::LAST_WII_CONTROL; ++i)
-    s_state_arrays[controller_index][i].overriding = false;
+    s_state_arrays[controller_index][i].overriding.store(false, std::memory_order_release);
+}
+
+void UnregisterGBAInputOverrider(int controller_index)
+{
+  Pad::GetGBAConfig()->GetController(controller_index)->ClearInputOverrideFunction();
+  s_gba_input_enabled[controller_index].store(false);
+
+  for (size_t i = ControlID::FIRST_GBA_CONTROL; i <= ControlID::LAST_GBA_CONTROL; ++i)
+    s_state_arrays[controller_index][i].overriding.store(false, std::memory_order_release);
+}
+
+void SetGBAInputEnabled(int controller_index, bool enabled)
+{
+  s_gba_input_enabled[controller_index].store(enabled);
+}
+
+void SetGameCubeInputEnabled(int controller_index, bool enabled)
+{
+  s_gamecube_input_enabled[controller_index].store(enabled);
 }
 
 void SetControlState(int controller_index, ControlID control, double state)
 {
   InputState& input_state = s_state_arrays[controller_index][control];
 
-  input_state.override_state = state;
-  input_state.overriding = true;
+  input_state.override_state.store(state, std::memory_order_release);
+  input_state.overriding.store(true, std::memory_order_release);
 }
 
 void ClearControlState(int controller_index, ControlID control)
 {
   InputState& input_state = s_state_arrays[controller_index][control];
 
-  input_state.overriding = false;
+  input_state.overriding.store(false, std::memory_order_release);
 }
 
 double GetGateRadiusAtAngle(int controller_index, ControlID stick, double angle)

--- a/Source/Core/InputCommon/ControllerInterface/Touch/InputOverrider.h
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/InputOverrider.h
@@ -68,18 +68,35 @@ enum ControlID
   CLASSIC_RIGHT_STICK_X = 54,
   CLASSIC_RIGHT_STICK_Y = 55,
 
+  GBA_B_BUTTON = 56,
+  GBA_A_BUTTON = 57,
+  GBA_L_BUTTON = 58,
+  GBA_R_BUTTON = 59,
+  GBA_SELECT_BUTTON = 60,
+  GBA_START_BUTTON = 61,
+  GBA_DPAD_UP = 62,
+  GBA_DPAD_DOWN = 63,
+  GBA_DPAD_LEFT = 64,
+  GBA_DPAD_RIGHT = 65,
+
   NUMBER_OF_CONTROLS,
 
   FIRST_GC_CONTROL = GCPAD_A_BUTTON,
   LAST_GC_CONTROL = GCPAD_C_STICK_Y,
   FIRST_WII_CONTROL = WIIMOTE_A_BUTTON,
   LAST_WII_CONTROL = CLASSIC_RIGHT_STICK_Y,
+  FIRST_GBA_CONTROL = GBA_B_BUTTON,
+  LAST_GBA_CONTROL = GBA_DPAD_RIGHT,
 
 };
 void RegisterGameCubeInputOverrider(int controller_index);
 void RegisterWiiInputOverrider(int controller_index);
+void RegisterGBAInputOverrider(int controller_index);
 void UnregisterGameCubeInputOverrider(int controller_index);
 void UnregisterWiiInputOverrider(int controller_index);
+void UnregisterGBAInputOverrider(int controller_index);
+void SetGameCubeInputEnabled(int controller_index, bool enabled);
+void SetGBAInputEnabled(int controller_index, bool enabled);
 
 void SetControlState(int controller_index, ControlID control, double state);
 void ClearControlState(int controller_index, ControlID control);


### PR DESCRIPTION
## Summary

Adds dual-screen support to Dolphin on Android.

Android presentation displays can be used as:

- A touchpad for the Wii pointer.
- A display and input surface for Dolphin's integrated GBA instances.
- A Game Boy Player screen when launching GBA software.

The feature also works on single-screen devices by allowing the user to switch between the GameCube and GBA screens from the in-game menu.

Related work: #14605. This implementation focuses on Android presentation displays and one visible GBA instance rather than movable multi-window overlays.

## User-facing changes

### GameCube and GBA

- Adds `Emulated GBA` as a GameCube controller type for ports 1 through 4.
- Adds per-port GBA ROM and input configuration.
- Supports GC-GBA games that load a matching GBA ROM.
- Supports MultiBoot games that download software to a BIOS-only GBA, such as Four Swords Adventures.
- Displays the active GBA on an external display when enabled.
- Adds a single-screen fallback through `Show GBA Screen`.
- Routes shared physical-controller input according to the focused GameCube or GBA screen.
- Adds touch controls using Dolphin's existing controller overlay assets.
- Adds fit, stretch and integer scaling with configurable screen alignment.
- Adds optional GBA Link audio muting.
- Adds an option to hide touch controls when a configured physical controller is connected.

### Game Boy Player and library

- Adds a simple GBA library tab for supported ROM files.
- GBA library entries can launch through a user-configured Game Boy Player disc, DOL or ELF.
- Adds Game Boy Player ROM selection to the in-game `GBA Packs` menu.
- No BIOS, ROM, Game Boy Player software or other copyrighted files are included.

### Wii pointer

- Adds an optional external-display Wii pointer touchpad.
- Uses relative pointer movement and maps the complete touch surface to the Wii pointer range.
- Reuses the existing Wii pointer mode, recenter and double-tap settings.
- The external presentation is only opened for Wii when the pointer touchpad option is enabled.

## Implementation

- Uses Android `DisplayManager` and `Presentation` for secondary displays.
- Ignores displays that are not exposed through `DISPLAY_CATEGORY_PRESENTATION`.
- Adds an Android `GBAHostInterface` implementation and JNI bridge for integrated GBA frames.
- Copies frames only for the visible GBA and coalesces pending UI delivery.
- Extends the touch `InputOverrider` with explicit GBA controls and input enablement.
- Keeps additional GBA instances running headless when they are not selected for display.
- Adds a cached Android-side GBA file scanner without forcing GBA files through `UICommon::GameFile`.
- Shared core changes are limited to GBA input hooks, link-audio muting and preventing an Emulated GBA SI device from starting during Wii sessions.
- There are no desktop UI changes and default desktop behavior is unchanged.

## Configuration

### GC-GBA Link

1. Set a GameCube port to `Emulated GBA`.
2. Configure the matching GBA ROM from that port's controller settings.
3. For MultiBoot games, leave the port ROM empty and configure a 16 KB GBA BIOS.
4. Enable `Use External Display for GBA Link` to use a connected secondary display.

### Wii pointer

1. Open the desired Wii Remote settings.
2. Open `Motion Input`.
3. Enable `Use External Display as Wii Pointer Touchpad`.
4. Keep the global `Use External Display` option enabled.

## Testing

Build validation:

- `Tools/lint.sh` passes against upstream master.
- `:app:lintDebug` passes.
- `:app:assembleDebug` passes for `arm64-v8a` and `x86_64`.

Manual testing on an AYN Thor Lite:

- GC-GBA Link with 007: Everything or Nothing and its matching GBA game.
- BIOS-only MultiBoot with The Legend of Zelda: Four Swords Adventures.
- External-display GBA rendering, touch controls and physical-controller focus.
- Single-screen GameCube/GBA screen switching.
- External-display connect and disconnect lifecycle.

## Known limitations

- Only one GBA screen is visible at a time. Other linked GBA instances continue headless.
- A secondary screen must be reported by Android as a presentation display.
- Foldable devices that expose both panels as one Android display are not handled.
- GBA library entries use a simple file list and do not provide cover metadata.
- Launching GBA files through Game Boy Player requires user-provided boot software.

## Screenshots

<img width="300" height="400" alt="1" src="https://github.com/user-attachments/assets/b956f6a0-8b5f-4730-beab-8a610337c55b" />

<img width="300" height="400" alt="20260709_011051" src="https://github.com/user-attachments/assets/afdacbfe-b9b8-41e0-a5fc-c99caf725dd2" />
