### PR TITLE
Flatpak: Use vendored-in SDL

### DIFF
--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -53,6 +53,8 @@ modules:
       - -DENABLE_SDL=ON
       - -DENABLE_EVDEV=ON
       - -DDISTRIBUTOR=dolphin-emu.org
+      # Use the vendored-in SDL since the one from the SDK usually lags far behind
+      - -DUSE_SYSTEM_SDL3=OFF
     cleanup:
       - /share/man
     post-install:


### PR DESCRIPTION
Flatpak currently has sub-par controller support due to having an outdated SDL version. The brand new 6.11 KDE SDK ships SDL 3.2.30, while we currently ship SDL 3.4.8 in Externals. This means Flatpak users currently miss out on a lot of controller support, notably for Switch 2 controllers and the Steam Controller (partly, SDL 3.4.10/12 fix a lot of Steam Controller features, I plan to open a PR bumping the version once the CMake changes get merged).