### PR TITLE
Flatpak: Bump `libevdev` to the latest version

### DIFF
--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -31,8 +31,8 @@ modules:
       - -Ddocumentation=disabled
     sources:
       - type: archive
-        url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.3.tar.xz
-        sha256: abf1aace86208eebdd5d3550ffded4c8d73bb405b796d51c389c9d0604cbcfbf
+        url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.6.tar.xz
+        sha256: 73f215eccbd8233f414737ac06bca2687e67c44b97d2d7576091aa9718551110
         x-checker-data:
           type: anitya
           project-id: 20540


### PR DESCRIPTION
The Flathub package of Dolphin (https://github.com/flathub/org.DolphinEmu.dolphin-emu) has been using version `1.13.6` of `libevdev` for many months now. I think it would make sense to bump it to the latest version as well.