### PR TITLE
Forbid EGL_PLATFORM to be "wayland"

### DIFF
--- a/Source/Core/Common/GL/GLInterface/EGLX11.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGLX11.cpp
@@ -3,6 +3,23 @@
 
 #include "Common/GL/GLInterface/EGLX11.h"
 
+#include <cstdlib>
+
+#include "Common/StringUtil.h"
+
+GLContextEGLX11::GLContextEGLX11()
+{
+  // HACK: If EGL_PLATFORM is set to "wayland", Dolphin will still use GLContextEGLX11 due to our
+  // lack of proper Wayland support, and crash.
+  // Some distros have started aggressively setting that environment variable, bypassing the usual
+  // runtime detection. Thus, clear that environment variable if it forces wayland.
+  const char* current_egl_platform = getenv("EGL_PLATFORM");
+  const bool replace_egl_platform =
+      current_egl_platform != nullptr &&
+      Common::CaseInsensitiveContains(current_egl_platform, "wayland");
+  setenv("EGL_PLATFORM", "", replace_egl_platform);
+}
+
 GLContextEGLX11::~GLContextEGLX11()
 {
   // The context must be destroyed before the window.

--- a/Source/Core/Common/GL/GLInterface/EGLX11.h
+++ b/Source/Core/Common/GL/GLInterface/EGLX11.h
@@ -11,6 +11,7 @@
 class GLContextEGLX11 final : public GLContextEGL
 {
 public:
+  GLContextEGLX11();
   ~GLContextEGLX11() override;
 
   void Update() override;


### PR DESCRIPTION
Recently we have gotten several user reports that opening settings crashes Dolphin, with traces similar to this:

```
Message: Process 35295 (dolphin-emu) of user 1000 dumped core.

                Stack trace of thread 12:
                #0  0x00007f37d469ec14 n/a (/usr/lib/x86_64-linux-gnu/libc.so.6 + 0x9dc14)
                #1  0x00007f37bea26b6f n/a (/usr/lib/x86_64-linux-gnu/GL/nvidia-595-84/lib/libnvidia-egl-wayland.so.1.1.20 + 0x5b6f)
```
         
In all cases, `EGL_PLATFORM` was set to `wayland` from some mystery source, which forces the use of egl-wayland when we query for the GPU, which crashes Dolphin. Running Dolphin with `EGL_PLATFORM= dolphin-emu` has resolved all these cases.

Edit:
After some research, it looks like Fedora (and as such, all Fedora-based distros like Nobarra and Bazzite) started aggressively setting `EGL_PLATFORM` to `wayland`, which causes issues with a lot of apps