### PR TITLE
DO NOT MERGE: disable address translation below 0x8000'0000

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -533,7 +533,7 @@ u32 MMU::Read_Opcode(u32 address)
 TryReadInstResult MMU::TryReadInstruction(u32 address)
 {
   bool from_bat = true;
-  if (m_ppc_state.msr.IR)
+  if (m_ppc_state.msr.IR && (address & 0x8000'0000) != 0)
   {
     auto tlb_addr = TranslateAddress<XCheckTLBFlag::Opcode>(address);
     if (!tlb_addr.Success())


### PR DESCRIPTION
In Dolphin, setting the MSR.IR bit takes effect immediately whereas on hardware the I$ is probably still valid.

This PR is just to provide a hacky build for testing.