### PR TITLE
Settings: Simplify debug mode

### DIFF
--- a/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
+++ b/Source/Core/DolphinQt/Achievements/AchievementSettingsWidget.cpp
@@ -285,6 +285,8 @@ void AchievementSettingsWidget::ToggleRAIntegration()
     instance.Init(reinterpret_cast<void*>(winId()));
   else
     instance.Shutdown();
+  emit Settings::Instance().HardcoreModeChanged(Config::Get(Config::RA_ENABLED) &&
+                                                Config::Get(Config::RA_HARDCORE_ENABLED));
 }
 
 void AchievementSettingsWidget::Login()
@@ -322,6 +324,7 @@ void AchievementSettingsWidget::ToggleHardcore()
     }
   }
   SaveSettings();
+  emit Settings::Instance().HardcoreModeChanged(Config::Get(Config::RA_HARDCORE_ENABLED));
 }
 
 void AchievementSettingsWidget::ToggleUnofficial()

--- a/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipWidget.h
+++ b/Source/Core/DolphinQt/Config/ToolTipControls/ToolTipWidget.h
@@ -25,6 +25,7 @@ public:
   void SetTitle(QString title) { m_title = std::move(title); }
 
   void SetDescription(QString description) { m_description = std::move(description); }
+  QString GetDescription() { return m_description; }
 
 private:
   void enterEvent(QEnterEvent* const event) override

--- a/Source/Core/DolphinQt/Debugger/AssemblerWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/AssemblerWidget.cpp
@@ -234,8 +234,7 @@ AssemblerWidget::AssemblerWidget(QWidget* parent)
   setWindowTitle(tr("Assembler"));
   setObjectName(QStringLiteral("assemblerwidget"));
 
-  setHidden(!Settings::Instance().IsAssemblerVisible() ||
-            !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsAssemblerVisible() || !Config::IsDebuggingEnabled());
 
   this->setVisible(true);
   CreateWidgets();

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -98,8 +98,7 @@ BreakpointWidget::BreakpointWidget(QWidget* parent)
   setWindowTitle(tr("Breakpoints"));
   setObjectName(QStringLiteral("breakpoints"));
 
-  setHidden(!Settings::Instance().IsBreakpointsVisible() ||
-            !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsBreakpointsVisible() || !Config::IsDebuggingEnabled());
 
   setAllowedAreas(Qt::AllDockWidgetAreas);
 

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -46,7 +46,7 @@ CodeWidget::CodeWidget(QWidget* parent)
   setWindowTitle(tr("Code"));
   setObjectName(QStringLiteral("code"));
 
-  setHidden(!Settings::Instance().IsCodeVisible() || !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsCodeVisible() || !Config::IsDebuggingEnabled());
 
   setAllowedAreas(Qt::AllDockWidgetAreas);
 

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -285,7 +285,7 @@ void JITWidget::LoadQSettings()
   auto& settings = Settings::GetQSettings();
 
   restoreGeometry(settings.value(QStringLiteral("jitwidget/geometry")).toByteArray());
-  setHidden(!Settings::Instance().IsJITVisible() || !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsJITVisible() || !Config::IsDebuggingEnabled());
   // macOS: setFloating() needs to be after setHidden() for proper window presentation
   // according to Settings
   setFloating(settings.value(QStringLiteral("jitwidget/floating")).toBool());

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -45,7 +45,7 @@ MemoryWidget::MemoryWidget(Core::System& system, QWidget* parent)
   setWindowTitle(tr("Memory"));
   setObjectName(QStringLiteral("memory"));
 
-  setHidden(!Settings::Instance().IsMemoryVisible() || !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsMemoryVisible() || !Config::IsDebuggingEnabled());
 
   setAllowedAreas(Qt::AllDockWidgetAreas);
 

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -194,7 +194,7 @@ NetworkWidget::NetworkWidget(QWidget* parent) : QDockWidget(parent)
   setWindowTitle(tr("Network"));
   setObjectName(QStringLiteral("network"));
 
-  setHidden(!Settings::Instance().IsNetworkVisible() || !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsNetworkVisible() || !Config::IsDebuggingEnabled());
 
   setAllowedAreas(Qt::AllDockWidgetAreas);
 

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -27,8 +27,7 @@ RegisterWidget::RegisterWidget(QWidget* parent)
   setWindowTitle(tr("Registers"));
   setObjectName(QStringLiteral("registers"));
 
-  setHidden(!Settings::Instance().IsRegistersVisible() ||
-            !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsRegistersVisible() || !Config::IsDebuggingEnabled());
 
   setAllowedAreas(Qt::AllDockWidgetAreas);
 

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -26,7 +26,7 @@ ThreadWidget::ThreadWidget(QWidget* parent) : QDockWidget(parent)
   setWindowTitle(tr("Threads"));
   setObjectName(QStringLiteral("threads"));
 
-  setHidden(!Settings::Instance().IsThreadsVisible() || !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsThreadsVisible() || !Config::IsDebuggingEnabled());
 
   setAllowedAreas(Qt::AllDockWidgetAreas);
 

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -31,7 +31,7 @@ WatchWidget::WatchWidget(QWidget* parent)
   setWindowTitle(tr("Watch"));
   setObjectName(QStringLiteral("watch"));
 
-  setHidden(!Settings::Instance().IsWatchVisible() || !Settings::Instance().IsDebugModeEnabled());
+  setHidden(!Settings::Instance().IsWatchVisible() || !Config::IsDebuggingEnabled());
 
   setAllowedAreas(Qt::AllDockWidgetAreas);
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -263,8 +263,6 @@ MainWindow::MainWindow(Core::System& system, std::unique_ptr<BootParameters> boo
 
 #ifdef USE_RETRO_ACHIEVEMENTS
   AchievementManager::GetInstance().Init(reinterpret_cast<void*>(winId()));
-  if (AchievementManager::GetInstance().IsHardcoreModeActive())
-    Settings::Instance().SetDebugModeEnabled(false);
   // This needs to trigger on both RA_HARDCORE_ENABLED and RA_ENABLED
   m_config_changed_callback_id = Config::AddConfigChangedCallback(
       [this] { QueueOnObject(this, [this] { this->OnHardcoreChanged(); }); });
@@ -2095,8 +2093,6 @@ void MainWindow::ShowAchievementSettings()
 void MainWindow::OnHardcoreChanged()
 {
   bool hardcore_active = AchievementManager::GetInstance().IsHardcoreModeActive();
-  if (hardcore_active)
-    Settings::Instance().SetDebugModeEnabled(false);
   // EmulationStateChanged causes several dialogs to redraw, including anything affected by hardcore
   // mode. Every dialog that depends on hardcore mode is redrawn by EmulationStateChanged.
   if (hardcore_active != m_former_hardcore_setting)

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -166,7 +166,7 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   UpdateStateSlotMenu();
   UpdateToolsMenu(state);
 
-  OnDebugModeToggled(Settings::Instance().IsDebugModeEnabled());
+  OnDebugModeToggled(Config::IsDebuggingEnabled());
 }
 
 void MenuBar::OnConfigChanged()

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -90,6 +90,13 @@ Settings::Settings()
       QueueOnObject(this, [this] { emit DevicesChanged(); });
     }
   });
+
+  connect(this, &Settings::HardcoreModeChanged, this, [this](bool hardcore) {
+    if (hardcore)
+      emit DebugModeToggled(false);
+    else if (Config::IsDebuggingEnabled())
+      emit DebugModeToggled(true);
+  });
 }
 
 Settings::~Settings()
@@ -699,22 +706,6 @@ bool Settings::GetCheatsEnabled() const
   return Config::Get(Config::MAIN_ENABLE_CHEATS);
 }
 
-void Settings::SetDebugModeEnabled(bool enabled)
-{
-  if (AchievementManager::GetInstance().IsHardcoreModeActive())
-    enabled = false;
-  if (IsDebugModeEnabled() != enabled)
-  {
-    Config::SetBaseOrCurrent(Config::MAIN_ENABLE_DEBUGGING, enabled);
-    emit DebugModeToggled(enabled);
-  }
-}
-
-bool Settings::IsDebugModeEnabled() const
-{
-  return Config::Get(Config::MAIN_ENABLE_DEBUGGING);
-}
-
 void Settings::SetRegistersVisible(bool enabled)
 {
   if (IsRegistersVisible() != enabled)
@@ -847,7 +838,7 @@ bool Settings::IsAssemblerVisible() const
 
 void Settings::RefreshWidgetVisibility()
 {
-  emit DebugModeToggled(IsDebugModeEnabled());
+  emit DebugModeToggled(Config::IsDebuggingEnabled());
   emit LogVisibilityChanged(IsLogVisible());
   emit LogConfigVisibilityChanged(IsLogConfigVisible());
   emit GameCountVisibilityChanged(IsGameCountVisible());

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -154,8 +154,6 @@ public:
   bool GetCheatsEnabled() const;
 
   // Debug
-  void SetDebugModeEnabled(bool enabled);
-  bool IsDebugModeEnabled() const;
   void SetRegistersVisible(bool enabled);
   bool IsRegistersVisible() const;
   void SetThreadsVisible(bool enabled);
@@ -234,6 +232,7 @@ signals:
   void WiiSpeakMuteChanged(bool muted);
   void EnableGfxModsChanged(bool enabled);
   void GameCountVisibilityChanged(bool visible);
+  void HardcoreModeChanged(bool enabled);
 
 private:
   Settings();

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -19,6 +19,7 @@
 #include "Common/StringUtil.h"
 
 #include "Core/AchievementManager.h"
+#include "Core/Config/AchievementSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"
 #include "Core/Core.h"
@@ -88,16 +89,17 @@ static ConfigStringChoice* MakeLanguageComboBox()
 InterfacePane::InterfacePane(QWidget* parent) : QWidget(parent)
 {
   CreateLayout();
-  UpdateShowDebuggingCheckbox();
   LoadUserStyle();
   ConnectLayout();
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
-          &InterfacePane::UpdateShowDebuggingCheckbox);
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &InterfacePane::OnEmulationStateChanged);
+  connect(&Settings::Instance(), &Settings::HardcoreModeChanged, this,
+          &InterfacePane::OnHardcoreModeChanged);
 
   OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()));
+  OnHardcoreModeChanged(Config::Get(Config::RA_ENABLED) &&
+                        Config::Get(Config::RA_HARDCORE_ENABLED));
 }
 
 void InterfacePane::CreateLayout()
@@ -173,7 +175,8 @@ void InterfacePane::CreateUI()
   m_checkbox_use_covers =
       new ConfigBool(tr("Download Game Covers from GameTDB.com for Use in Grid Mode"),
                      Config::MAIN_USE_GAME_COVERS);
-  m_checkbox_show_debugging_ui = new ToolTipCheckBox(tr("Enable Debugging UI"));
+  m_checkbox_show_debugging_ui =
+      new ConfigBool(tr("Enable Debugging UI"), Config::MAIN_ENABLE_DEBUGGING);
   m_checkbox_focused_hotkeys =
       new ConfigBool(tr("Hotkeys Require Window Focus"), Config::MAIN_FOCUSED_HOTKEYS);
   m_checkbox_disable_screensaver =
@@ -245,8 +248,9 @@ void InterfacePane::ConnectLayout()
           &Settings::GameListRefreshRequested);
   connect(m_checkbox_use_covers, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::MetadataRefreshRequested);
-  connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, &Settings::Instance(),
-          &Settings::SetDebugModeEnabled);
+  connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, &Settings::Instance(), [] {
+    emit Settings::Instance().DebugModeToggled(Config::Get(Config::MAIN_ENABLE_DEBUGGING));
+  });
   connect(m_combobox_theme, &QComboBox::currentIndexChanged, &Settings::Instance(),
           &Settings::ThemeChanged);
   connect(m_combobox_userstyle, &QComboBox::currentIndexChanged, this,
@@ -263,32 +267,6 @@ void InterfacePane::ConnectLayout()
           &Settings::CursorVisibilityChanged);
   connect(m_checkbox_lock_mouse, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::LockCursorChanged);
-}
-
-void InterfacePane::UpdateShowDebuggingCheckbox()
-{
-  SignalBlocking(m_checkbox_show_debugging_ui)
-      ->setChecked(Settings::Instance().IsDebugModeEnabled());
-
-  static constexpr char TR_SHOW_DEBUGGING_UI_DESCRIPTION[] = QT_TR_NOOP(
-      "Shows Dolphin's debugging user interface. This lets you view and modify a game's code and "
-      "memory contents, set debugging breakpoints, examine network requests, and more."
-      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
-  static constexpr char TR_DISABLED_IN_HARDCORE_DESCRIPTION[] =
-      QT_TR_NOOP("<dolphin_emphasis>Disabled in Hardcore Mode.</dolphin_emphasis>");
-
-  bool hardcore = AchievementManager::GetInstance().IsHardcoreModeActive();
-  SignalBlocking(m_checkbox_show_debugging_ui)->setEnabled(!hardcore);
-  if (hardcore)
-  {
-    m_checkbox_show_debugging_ui->SetDescription(tr("%1<br><br>%2")
-                                                     .arg(tr(TR_SHOW_DEBUGGING_UI_DESCRIPTION))
-                                                     .arg(tr(TR_DISABLED_IN_HARDCORE_DESCRIPTION)));
-  }
-  else
-  {
-    m_checkbox_show_debugging_ui->SetDescription(tr(TR_SHOW_DEBUGGING_UI_DESCRIPTION));
-  }
 }
 
 void InterfacePane::LoadUserStyle()
@@ -329,6 +307,29 @@ void InterfacePane::OnEmulationStateChanged(Core::State state)
   m_checkbox_time_tracking->setEnabled(uninitialized);
 }
 
+void InterfacePane::OnHardcoreModeChanged(bool enabled)
+{
+  static constexpr char TR_DISABLED_HARDCORE_MODE[] =
+      QT_TR_NOOP("<br><br><dolphin_emphasis>Disabled in Hardcore Mode.</dolphin_emphasis>");
+
+  const QString hardcore_desc = tr(TR_DISABLED_HARDCORE_MODE);
+  QString debug_ui_desc = m_checkbox_show_debugging_ui->GetDescription();
+  const bool debug_ui_desc_contains_hardcore = debug_ui_desc.contains(hardcore_desc);
+
+  if (enabled && !debug_ui_desc_contains_hardcore)
+  {
+    debug_ui_desc += hardcore_desc;
+    m_checkbox_show_debugging_ui->SetDescription(debug_ui_desc);
+  }
+  else if (!enabled && debug_ui_desc_contains_hardcore)
+  {
+    debug_ui_desc.remove(hardcore_desc);
+    m_checkbox_show_debugging_ui->SetDescription(debug_ui_desc);
+  }
+
+  m_checkbox_show_debugging_ui->setEnabled(!enabled);
+}
+
 void InterfacePane::AddDescriptions()
 {
   static constexpr char TR_TITLE_DATABASE_DESCRIPTION[] = QT_TR_NOOP(
@@ -344,6 +345,10 @@ void InterfacePane::AddDescriptions()
       "Sets the language displayed by Dolphin's user interface."
       "<br><br>Changes to this setting only take effect once Dolphin is restarted."
       "<br><br><dolphin_emphasis>If unsure, select &lt;System Language&gt;.</dolphin_emphasis>");
+  static constexpr char TR_SHOW_DEBUGGING_UI_DESCRIPTION[] = QT_TR_NOOP(
+      "Shows Dolphin's debugging user interface. This lets you view and modify a game's code and "
+      "memory contents, set debugging breakpoints, examine network requests, and more."
+      "<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
   static constexpr char TR_FOCUSED_HOTKEYS_DESCRIPTION[] =
       QT_TR_NOOP("Requires the render window to be focused for hotkeys to take effect."
                  "<br><br><dolphin_emphasis>If unsure, leave this checked.</dolphin_emphasis>");
@@ -403,6 +408,8 @@ void InterfacePane::AddDescriptions()
 
   m_combobox_language->SetTitle(tr("Language"));
   m_combobox_language->SetDescription(tr(TR_LANGUAGE_DESCRIPTION));
+
+  m_checkbox_show_debugging_ui->SetDescription(tr(TR_SHOW_DEBUGGING_UI_DESCRIPTION));
 
   m_checkbox_focused_hotkeys->SetDescription(tr(TR_FOCUSED_HOTKEYS_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -36,6 +36,7 @@ private:
   void OnLanguageChanged();
 
   void OnEmulationStateChanged(Core::State state);
+  void OnHardcoreModeChanged(bool enabled);
 
   QVBoxLayout* m_main_layout;
   ConfigStringChoice* m_combobox_language;

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -52,7 +52,7 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
           [this] { m_refresh_action->setEnabled(true); });
 
   OnEmulationStateChanged(Core::GetState(Core::System::GetInstance()));
-  OnDebugModeToggled(Settings::Instance().IsDebugModeEnabled());
+  OnDebugModeToggled(Config::IsDebuggingEnabled());
 }
 
 void ToolBar::OnEmulationStateChanged(Core::State state)


### PR DESCRIPTION
We now just pass a signal to tell the UI that hardcore mode has been turned on/off, and we replace Settings::IsDebugModeEnabled with Config::IsDebuggingEnabled, which always returns false if hardcore is on.

This also separates the debugging ui state from the hardcore state, which means disabling hardcore mode restores the debugging ui if you had it enabled. Split off from #14276