### PR TITLE
DolphinQt/AudioPane: avoid per-device std::string copy in WASAPI loop

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -134,7 +134,7 @@ void AudioPane::CreateWidgets()
       QString::fromStdString(Config::MAIN_WASAPI_DEVICE.GetDefaultValue());
   wasapi_options.emplace_back(tr("Default Device"), default_device_config_value);
 
-  for (auto string : WASAPIStream::GetAvailableDevices())
+  for (const auto& string : WASAPIStream::GetAvailableDevices())
   {
     wasapi_options.push_back(std::pair<QString, QString>{QString::fromStdString(string),
                                                          QString::fromStdString(string)});


### PR DESCRIPTION
This change avoids an unnecessary copy of each device name while populating the WASAPI device list. `WASAPIStream::GetAvailableDevices()` returns a `std::vector<std::string>` by value, and the loop only reads each element to construct the corresponding `QString` entries. Iterating with `auto` copied every `std::string` into the loop variable, incurring avoidable allocations and character copies for each device. Switching the loop variable to `const auto&` iterates over the existing strings in the returned vector without copying them. Since the elements are never modified and the temporary vector remains alive for the duration of the range-based `for` loop, this change is both safe and more efficient while preserving the existing behavior.

Claude AI is used to find this.