### PR TITLE
DolphinQt/AudioPane: convert each WASAPI device name only once

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -136,8 +136,8 @@ void AudioPane::CreateWidgets()
 
   for (auto string : WASAPIStream::GetAvailableDevices())
   {
-    wasapi_options.push_back(std::pair<QString, QString>{QString::fromStdString(string),
-                                                         QString::fromStdString(string)});
+    const QString device = QString::fromStdString(string);
+    wasapi_options.emplace_back(device, device);
   }
 
   m_wasapi_device_label = new QLabel(tr("Output Device:"));


### PR DESCRIPTION
The WASAPI device loop built the same QString from each device name twice via two QString::fromStdString calls. Convert once and reuse it, matching the idiomatic backend-list construction a few lines above.

Found with Claude.