### PR TITLE
NetPlayClient: reserve players vector in GetPlayers

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1673,6 +1673,7 @@ std::vector<const Player*> NetPlayClient::GetPlayers()
 {
   std::lock_guard lkp(m_crit.players);
   std::vector<const Player*> players;
+  players.reserve(m_players.size());
 
   for (const auto& pair : m_players)
     players.push_back(&pair.second);


### PR DESCRIPTION
GetPlayers() rebuilds the players list on every call; reserve up front for the known player count so filling it performs no reallocations.