### PR TITLE
DiscIO/VolumeWii: reserve partitions vector in GetPartitions

### DIFF
--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -250,6 +250,7 @@ bool VolumeWii::HasWiiEncryption() const
 std::vector<Partition> VolumeWii::GetPartitions() const
 {
   std::vector<Partition> partitions;
+  partitions.reserve(m_partitions.size());
   for (const auto& pair : m_partitions)
     partitions.push_back(pair.first);
   return partitions;


### PR DESCRIPTION
GetPartitions() builds the partition list from the partition map on each call; reserve for the known count so it performs no reallocations.

Found with Claude. 