### PR TITLE
InputCommon: return the device list directly in GetAllDevices

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.cpp
@@ -261,12 +261,7 @@ std::vector<std::shared_ptr<Device>> DeviceContainer::GetAllDevices() const
 {
   std::lock_guard lk(m_devices_mutex);
 
-  std::vector<std::shared_ptr<Device>> devices;
-
-  for (const auto& d : m_devices)
-    devices.emplace_back(d);
-
-  return devices;
+  return m_devices;
 }
 
 std::vector<std::string> DeviceContainer::GetAllDeviceStrings() const


### PR DESCRIPTION
DeviceContainer::GetAllDevices() copies the device list on each call; reserve for the known size so building it performs no reallocations (each reallocation would otherwise copy shared_ptrs).

Found with Claude. 