### PR TITLE
VideoCommon: resolve the vertex loader once per primitive command

### DIFF
--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -129,8 +129,8 @@ public:
     // load vertices
     const u32 size = vertex_size * num_vertices;
 
-    const u32 bytes =
-        VertexLoaderManager::RunVertices<is_preprocess>(vat, primitive, num_vertices, vertex_data);
+    const u32 bytes = VertexLoaderManager::RunVertices<is_preprocess>(
+        m_current_loader, vat, primitive, num_vertices, vertex_data);
 
     ASSERT(bytes == size);
 
@@ -248,12 +248,18 @@ public:
 
   OPCODE_CALLBACK(u32 GetVertexSize(u8 vat))
   {
-    VertexLoaderBase* loader = VertexLoaderManager::RefreshLoader<is_preprocess>(vat);
-    return loader->m_vertex_size;
+    // RunCommand always calls GetVertexSize immediately before OnPrimitiveCommand for the same
+    // vat, with no CP state change in between. Resolve the loader once here and reuse it in
+    // OnPrimitiveCommand, avoiding a second RefreshLoader lookup on the hot primitive path.
+    m_current_loader = VertexLoaderManager::RefreshLoader<is_preprocess>(vat);
+    return m_current_loader->m_vertex_size;
   }
 
   u32 m_cycles = 0;
   bool m_in_display_list = false;
+  // Loader resolved by the most recent GetVertexSize call, reused by the paired OnPrimitiveCommand
+  // to avoid a redundant RefreshLoader on the hot primitive path.
+  VertexLoaderBase* m_current_loader = nullptr;
 };
 
 template <bool is_preprocess>

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -253,6 +253,13 @@ VertexLoaderBase* GetOrCreateLoader(int vtx_attr_group)
   return loader;
 }
 
+// GetOrCreateLoader is defined here but is called from RefreshLoader() (a header template) in other
+// translation units, e.g. OpcodeDecoding.cpp. These instantiations used to be pulled in implicitly
+// because RunVertices() called RefreshLoader(); RunVertices() now receives an already-resolved
+// loader, so instantiate them explicitly to keep the symbols in this object file.
+template VertexLoaderBase* GetOrCreateLoader<false>(int vtx_attr_group);
+template VertexLoaderBase* GetOrCreateLoader<true>(int vtx_attr_group);
+
 }  // namespace detail
 
 static void CheckCPConfiguration(int vtx_attr_group)

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -396,13 +396,12 @@ static bool CanSplit(OpcodeDecoder::Primitive primitive)
 }
 
 template <bool IsPreprocess>
-int RunVertices(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int count, const u8* src)
+int RunVertices(VertexLoaderBase* loader, int vtx_attr_group, OpcodeDecoder::Primitive primitive,
+                int count, const u8* src)
 {
   if (count == 0) [[unlikely]]
     return 0;
   ASSERT(count > 0);
-
-  VertexLoaderBase* loader = RefreshLoader<IsPreprocess>(vtx_attr_group);
 
   int size = count * loader->m_vertex_size;
 
@@ -478,10 +477,10 @@ int RunVertices(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int coun
   return size;
 }
 
-template int RunVertices<false>(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int count,
-                                const u8* src);
-template int RunVertices<true>(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int count,
-                               const u8* src);
+template int RunVertices<false>(VertexLoaderBase* loader, int vtx_attr_group,
+                                OpcodeDecoder::Primitive primitive, int count, const u8* src);
+template int RunVertices<true>(VertexLoaderBase* loader, int vtx_attr_group,
+                               OpcodeDecoder::Primitive primitive, int count, const u8* src);
 
 NativeVertexFormat* GetCurrentVertexFormat()
 {

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -13,6 +13,7 @@
 #include "VideoCommon/CPMemory.h"
 
 class NativeVertexFormat;
+class VertexLoaderBase;
 struct PortableVertexDeclaration;
 
 namespace OpcodeDecoder
@@ -40,9 +41,13 @@ NativeVertexFormat* GetOrCreateMatchingFormat(const PortableVertexDeclaration& d
 // offsets set to the unused attributes.
 NativeVertexFormat* GetUberVertexFormat(const PortableVertexDeclaration& decl);
 
-// Returns -1 if buf_size is insufficient, else the amount of bytes consumed
+// Returns -1 if buf_size is insufficient, else the amount of bytes consumed.
+// `loader` must be the loader previously resolved by RefreshLoader<IsPreprocess>(vtx_attr_group)
+// for this same vtx_attr_group; passing it in avoids resolving the loader a second time on the
+// hot primitive path (the decoder already resolved it in GetVertexSize).
 template <bool IsPreprocess = false>
-int RunVertices(int vtx_attr_group, OpcodeDecoder::Primitive primitive, int count, const u8* src);
+int RunVertices(VertexLoaderBase* loader, int vtx_attr_group, OpcodeDecoder::Primitive primitive,
+                int count, const u8* src);
 
 namespace detail
 {


### PR DESCRIPTION
The opcode decoder resolved the vertex loader twice for each primitive. "GetVertexSize()" resolved it to get the command size, then "RunVertices()" resolved it again. Since both calls use the same VAT, cache the loader in "GetVertexSize()" and pass it to "RunVertices()" instead. This removes one "RefreshLoader()" call, including "UpdateVertexArrayPointers()", per primitive without changing behavior.