### PR TITLE
[RFC] Common: Add BitCastView

### DIFF
--- a/Source/Core/Common/BitCastView.h
+++ b/Source/Core/Common/BitCastView.h
@@ -67,7 +67,8 @@ public:
     return std::bit_cast<To>(arr);
   }
 
-  operator To() const { return this->operator*(); }
+  // TODO: why does msvc++ want this to be const? Does it matter if it's const?
+  operator const To() const { return this->operator*(); }
 
   // forwarding implicit conversion allows BitCastRef to wrap other wrappers that depend on
   // implicit conversion

--- a/Source/Core/Common/BitCastView.h
+++ b/Source/Core/Common/BitCastView.h
@@ -44,7 +44,7 @@ public:
     return std::bit_cast<To>(arr);
   }
 
-  operator To() const { return this->operator*(); }
+  operator const To() const { return this->operator*(); }
 
   // We only forward the conversion operator if To defined one,
   // otherwise it's ambiguous which conversion to use.

--- a/Source/Core/Common/BitCastView.h
+++ b/Source/Core/Common/BitCastView.h
@@ -194,7 +194,9 @@ private:
 };
 
 template <typename To>
-struct BitCastViewAdapter : std::ranges::range_adaptor_closure<BitCastViewAdapter<To>>
+struct BitCastViewAdapter
+// TODO: restore range_adaptor_closure once we move to gcc 13/clang 16
+// : std::ranges::range_adaptor_closure<BitCastViewAdapter<To>>
 {
   static constexpr auto operator()(std::ranges::viewable_range auto&& viewable)
   {

--- a/Source/Core/Common/BitCastView.h
+++ b/Source/Core/Common/BitCastView.h
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: CC0-1.0
+
+#pragma once
+
+#include "Common/Assert.h"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <concepts>
+#include <cstddef>
+#include <iterator>
+#include <ranges>
+#include <type_traits>
+
+namespace Common
+{
+
+template <typename T, typename U>
+concept user_defined_conversion = requires(T t) { t.operator U(); };
+
+// BitCastRef is Reference-like wrapper for BitCastViewIterator
+//   - bit_casts on deref or implicit conversion to To
+//   - forwards user-defined conversions to To
+//   - forwards assignments to To's assignment operator
+//
+// This allows BitCastView to work seamlessly with things like Common::BigEndianValue
+template <typename To, typename FromIter>
+requires(std::input_iterator<FromIter>)
+class BitCastRef
+{
+  using From = std::iter_value_t<FromIter>;
+  constexpr static size_t step = sizeof(To) / sizeof(From);
+
+public:
+  BitCastRef() = default;
+  explicit BitCastRef(FromIter iter) : m_iter(iter) {}
+
+  To operator*() const
+  {
+    std::array<From, step> arr;
+    // copy_n allows this to work with non-contiguous iterators too
+    std::copy_n(m_iter, step, arr.begin());
+    return std::bit_cast<To>(arr);
+  }
+
+  operator To() const { return this->operator*(); }
+
+  // We only forward the conversion operator if To defined one,
+  // otherwise it's ambiguous which conversion to use.
+  template <typename U>
+  requires user_defined_conversion<To, U>
+  operator U() const
+  {
+    return static_cast<U>(this->operator*());
+  }
+
+  template <typename U>
+  BitCastRef& operator=(const U& rhs)
+      requires(std::output_iterator<FromIter, From> && std::assignable_from<To&, U>)
+  {
+    To to;
+    to = rhs;
+
+    std::array<From, step> arr = std::bit_cast<std::array<From, step>>(to);
+    std::copy_n(arr.begin(), step, m_iter);
+    return *this;
+  }
+
+private:
+  FromIter m_iter;
+};
+
+template <typename To, std::ranges::view V>
+requires(std::is_trivially_copyable_v<To> &&
+         std::is_trivially_copyable_v<std::ranges::range_value_t<V>> &&
+         std::random_access_iterator<std::ranges::iterator_t<V>> &&
+         sizeof(To) >= sizeof(std::ranges::range_value_t<V>) &&
+         (sizeof(To) / sizeof(std::ranges::range_value_t<V>)) *
+                 sizeof(std::ranges::range_value_t<V>) ==
+             sizeof(To))
+class BitCastViewIterator
+{
+  using From = std::ranges::range_value_t<V>;
+  using FromIter = std::ranges::iterator_t<V>;
+  constexpr static size_t step = sizeof(To) / sizeof(From);
+
+public:
+  using value_type = std::remove_cv_t<To>;
+  using reference = BitCastRef<To, FromIter>;
+  using difference_type = std::ptrdiff_t;
+
+  BitCastViewIterator() = default;
+  explicit BitCastViewIterator(FromIter iter) : m_iter(iter) {}
+
+  reference operator*() const { return reference(m_iter); }
+
+  reference operator[](std::ptrdiff_t index) const
+  {
+    BitCastViewIterator tmp = *this;
+    tmp += index;
+    return reference(tmp.m_iter);
+  }
+
+  BitCastViewIterator& operator++()
+  {
+    m_iter += step;
+    return *this;
+  }
+
+  BitCastViewIterator operator++(int)
+  {
+    BitCastViewIterator tmp = *this;
+    ++(*this);
+    return tmp;
+  }
+
+  BitCastViewIterator& operator--()
+  {
+    m_iter -= step;
+    return *this;
+  }
+
+  BitCastViewIterator operator--(int)
+  {
+    BitCastViewIterator tmp = *this;
+    --(*this);
+    return tmp;
+  }
+
+  BitCastViewIterator& operator+=(difference_type n)
+  {
+    m_iter += n * step;
+    return *this;
+  }
+
+  BitCastViewIterator& operator-=(difference_type n)
+  {
+    m_iter -= n * step;
+    return *this;
+  }
+
+  bool operator==(const BitCastViewIterator& other) const = default;
+
+  friend auto operator<=>(const BitCastViewIterator& lhs, const BitCastViewIterator& rhs) = default;
+
+  friend difference_type operator-(const BitCastViewIterator& lhs, const BitCastViewIterator& rhs)
+  {
+    return (lhs.m_iter - rhs.m_iter) / step;
+  }
+
+  friend BitCastViewIterator operator+(const BitCastViewIterator& it, difference_type n)
+  {
+    BitCastViewIterator tmp = it;
+    tmp += n;
+    return tmp;
+  }
+
+  friend BitCastViewIterator operator+(difference_type n, const BitCastViewIterator& it)
+  {
+    return it + n;
+  }
+
+  friend BitCastViewIterator operator-(const BitCastViewIterator& it, difference_type n)
+  {
+    return it + (-n);
+  }
+
+private:
+  FromIter m_iter;
+};
+
+static_assert(std::random_access_iterator<BitCastViewIterator<u32, std::span<const u8>>>);
+
+template <typename To, std::ranges::view V>
+class BitCastViewImpl : public std::ranges::view_interface<BitCastViewImpl<To, V>>
+{
+  using From = std::ranges::range_value_t<V>;
+  using FromIter = std::ranges::iterator_t<V>;
+
+public:
+  explicit BitCastViewImpl(V view) : m_view(view) {}
+
+  BitCastViewIterator<To, V> begin() const
+  {
+    ASSERT_MSG(COMMON, (m_view.size() * sizeof(From)) % sizeof(To) == 0,
+               "Byte span size must be a multiple of value_type.");
+    return BitCastViewIterator<To, V>(m_view.begin());
+  }
+  BitCastViewIterator<To, V> end() const { return BitCastViewIterator<To, V>(m_view.end()); }
+
+  bool valid() const { return m_view.size() % sizeof(To) == 0; }
+
+private:
+  V m_view;
+};
+
+template <typename To>
+struct BitCastViewAdapter : std::ranges::range_adaptor_closure<BitCastViewAdapter<To>>
+{
+  static constexpr auto operator()(std::ranges::viewable_range auto&& viewable)
+  {
+    auto view = std::ranges::views::all(viewable);
+    using V = std::remove_cvref_t<decltype(view)>;
+    return BitCastViewImpl<To, V>(view);
+  }
+};
+
+template <typename To>
+inline constexpr BitCastViewAdapter<To> BitCastView{};
+
+}  // namespace Common

--- a/Source/Core/Common/BitCastView.h
+++ b/Source/Core/Common/BitCastView.h
@@ -19,6 +19,27 @@ namespace Common
 template <typename T, typename U>
 concept user_defined_conversion = requires(T t) { t.operator U(); };
 
+// Excludes explicit conversion functions
+template <typename T, typename U>
+concept implicit_user_defined_conversion =
+    user_defined_conversion<T, U> && std::convertible_to<T, U>;
+
+template <typename T>
+struct wrapper_implicit_conversion_target
+{
+  using type = void;
+};
+
+template <typename T>
+requires(implicit_user_defined_conversion<T, typename T::target_type>)
+struct wrapper_implicit_conversion_target<T>
+{
+  using type = typename T::target_type;
+};
+
+// wrapper_implicit_conversion_target can be specialized to support wrappers that don't provide
+// a target_type type member.
+
 // BitCastRef is Reference-like wrapper for BitCastViewIterator
 //   - bit_casts on deref or implicit conversion to To
 //   - forwards user-defined conversions to To
@@ -30,6 +51,8 @@ requires(std::input_iterator<FromIter>)
 class BitCastRef
 {
   using From = std::iter_value_t<FromIter>;
+  using ImplicitConversion = typename wrapper_implicit_conversion_target<To>::type;
+
   constexpr static size_t step = sizeof(To) / sizeof(From);
 
 public:
@@ -44,15 +67,14 @@ public:
     return std::bit_cast<To>(arr);
   }
 
-  operator const To() const { return this->operator*(); }
+  operator To() const { return this->operator*(); }
 
-  // We only forward the conversion operator if To defined one,
-  // otherwise it's ambiguous which conversion to use.
-  template <typename U>
-  requires user_defined_conversion<To, U>
-  operator U() const
+  // forwarding implicit conversion allows BitCastRef to wrap other wrappers that depend on
+  // implicit conversion
+  operator ImplicitConversion() const
+      requires(!std::is_void_v<typename wrapper_implicit_conversion_target<To>::type>)
   {
-    return static_cast<U>(this->operator*());
+    return static_cast<ImplicitConversion>(this->operator*());
   }
 
   template <typename U>

--- a/Source/Core/Common/BitCastView.h
+++ b/Source/Core/Common/BitCastView.h
@@ -170,8 +170,6 @@ private:
   FromIter m_iter;
 };
 
-static_assert(std::random_access_iterator<BitCastViewIterator<u32, std::span<const u8>>>);
-
 template <typename To, std::ranges::view V>
 class BitCastViewImpl : public std::ranges::view_interface<BitCastViewImpl<To, V>>
 {

--- a/Source/Core/Common/BitCastView.h
+++ b/Source/Core/Common/BitCastView.h
@@ -198,7 +198,7 @@ struct BitCastViewAdapter
 // TODO: restore range_adaptor_closure once we move to gcc 13/clang 16
 // : std::ranges::range_adaptor_closure<BitCastViewAdapter<To>>
 {
-  static constexpr auto operator()(std::ranges::viewable_range auto&& viewable)
+  auto operator()(std::ranges::viewable_range auto&& viewable) const
   {
     auto view = std::ranges::views::all(viewable);
     using V = std::remove_cvref_t<decltype(view)>;

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(common
   Assembler/GekkoParser.cpp
   Assembler/GekkoParser.h
   Assert.h
+  BitCastView.h
   BitField.h
   BitSet.h
   BitUtils.h

--- a/Source/Core/Common/Swap.h
+++ b/Source/Core/Common/Swap.h
@@ -187,6 +187,7 @@ inline T FromBigEndian(T data)
 template <typename value_type>
 struct BigEndianValue
 {
+  using target_type = value_type;
   static_assert(std::is_arithmetic<value_type>(), "value_type must be an arithmetic type");
   BigEndianValue() = default;
   explicit BigEndianValue(value_type val) { *this = val; }

--- a/Source/UnitTests/Common/BitCastViewTest.cpp
+++ b/Source/UnitTests/Common/BitCastViewTest.cpp
@@ -19,10 +19,10 @@ TEST(BitCastView, Basics)
   auto words = Common::BitCastView<u32>(data);
 
   EXPECT_EQ(words.size(), 4);
-  EXPECT_EQ(words[0], 0x03020100);
-  EXPECT_EQ(words[1], 0x07060504);
-  EXPECT_EQ(words[2], 0x0b0a0908);
-  EXPECT_EQ(words[3], 0x0f0e0d0c);
+  EXPECT_EQ(words[0], 0x03020100u);
+  EXPECT_EQ(words[1], 0x07060504u);
+  EXPECT_EQ(words[2], 0x0b0a0908u);
+  EXPECT_EQ(words[3], 0x0f0e0d0cu);
 
   // and make sure C(R) compiles too
 
@@ -41,10 +41,10 @@ TEST(BitCastView, Writable)
 
   words[0] = 0xdeadbeef;
 
-  EXPECT_EQ(data[0], 0xef);
-  EXPECT_EQ(data[1], 0xbe);
-  EXPECT_EQ(data[2], 0xad);
-  EXPECT_EQ(data[3], 0xde);
+  EXPECT_EQ(data[0], 0xefU);
+  EXPECT_EQ(data[1], 0xbeU);
+  EXPECT_EQ(data[2], 0xadU);
+  EXPECT_EQ(data[3], 0xdeU);
 }
 
 TEST(BitCastView, Swapping)
@@ -54,14 +54,14 @@ TEST(BitCastView, Swapping)
   auto words = Common::BitCastView<Common::BigEndianValue<u32>>(data);
 
   u32 value = words[0];
-  EXPECT_EQ(value, 1);
+  EXPECT_EQ(value, 1u);
 
   words[0] = 0xdeadbeef;
 
-  EXPECT_EQ(data[0], 0xde);
-  EXPECT_EQ(data[1], 0xad);
-  EXPECT_EQ(data[2], 0xbe);
-  EXPECT_EQ(data[3], 0xef);
+  EXPECT_EQ(data[0], 0xdeU);
+  EXPECT_EQ(data[1], 0xadU);
+  EXPECT_EQ(data[2], 0xbeU);
+  EXPECT_EQ(data[3], 0xefU);
 }
 
 TEST(BitCastView, SwappedRangeLoop)
@@ -78,5 +78,5 @@ TEST(BitCastView, SwappedRangeLoop)
   for (auto word : words)
     sum += word;
 
-  EXPECT_EQ(sum, 3);
+  EXPECT_EQ(sum, 3u);
 }

--- a/Source/UnitTests/Common/BitCastViewTest.cpp
+++ b/Source/UnitTests/Common/BitCastViewTest.cpp
@@ -68,6 +68,7 @@ TEST(BitCastView, SwappedRangeLoop)
 {
   std::vector<u8> data = {0, 0, 0, 1, 0, 0, 0, 2};
   auto words = Common::BitCastView<Common::BigEndianValue<u32>>(data);
+  static_assert(Common::user_defined_conversion<Common::BigEndianValue<u32>, u32>);
 
   u32 sum = 0;
   for (auto word : words)

--- a/Source/UnitTests/Common/BitCastViewTest.cpp
+++ b/Source/UnitTests/Common/BitCastViewTest.cpp
@@ -16,7 +16,7 @@ TEST(BitCastView, Basics)
 
   // check R | C
 
-  auto words = data | Common::BitCastView<u32>;
+  auto words = Common::BitCastView<u32>(data);
 
   EXPECT_EQ(words.size(), 4);
   EXPECT_EQ(words[0], 0x03020100);
@@ -37,7 +37,7 @@ TEST(BitCastView, Writable)
 
   for (u8 i = 0; i < 16; ++i)
     data.push_back(i);
-  auto words = data | Common::BitCastView<u32>;
+  auto words = Common::BitCastView<u32>(data);
 
   words[0] = 0xdeadbeef;
 
@@ -51,7 +51,7 @@ TEST(BitCastView, Swapping)
 {
   // Make sure it interacts correctly with BigEndianValue
   std::vector<u8> data = {0, 0, 0, 1};
-  auto words = data | Common::BitCastView<Common::BigEndianValue<u32>>;
+  auto words = Common::BitCastView<Common::BigEndianValue<u32>>(data);
 
   u32 value = words[0];
   EXPECT_EQ(value, 1);
@@ -67,7 +67,7 @@ TEST(BitCastView, Swapping)
 TEST(BitCastView, SwappedRangeLoop)
 {
   std::vector<u8> data = {0, 0, 0, 1, 0, 0, 0, 2};
-  auto words = data | Common::BitCastView<Common::BigEndianValue<u32>>;
+  auto words = Common::BitCastView<Common::BigEndianValue<u32>>(data);
 
   u32 sum = 0;
   for (auto word : words)

--- a/Source/UnitTests/Common/BitCastViewTest.cpp
+++ b/Source/UnitTests/Common/BitCastViewTest.cpp
@@ -66,9 +66,13 @@ TEST(BitCastView, Swapping)
 
 TEST(BitCastView, SwappedRangeLoop)
 {
+  static_assert(Common::implicit_user_defined_conversion<Common::BigEndianValue<u32>, u32>);
+
+  static_assert(!std::is_void_v<
+                Common::wrapper_implicit_conversion_target<Common::BigEndianValue<u32>>::type>);
+
   std::vector<u8> data = {0, 0, 0, 1, 0, 0, 0, 2};
   auto words = Common::BitCastView<Common::BigEndianValue<u32>>(data);
-  static_assert(Common::user_defined_conversion<Common::BigEndianValue<u32>, u32>);
 
   u32 sum = 0;
   for (auto word : words)

--- a/Source/UnitTests/Common/BitCastViewTest.cpp
+++ b/Source/UnitTests/Common/BitCastViewTest.cpp
@@ -1,0 +1,77 @@
+
+#include <gtest/gtest.h>
+
+#include "Common/BitCastView.h"
+#include "Common/Swap.h"
+
+#include <vector>
+#include "gtest/gtest.h"
+
+TEST(BitCastView, Basics)
+{
+  std::vector<u8> data;
+
+  for (u8 i = 0; i < 16; ++i)
+    data.push_back(i);
+
+  // check R | C
+
+  auto words = data | Common::BitCastView<u32>;
+
+  EXPECT_EQ(words.size(), 4);
+  EXPECT_EQ(words[0], 0x03020100);
+  EXPECT_EQ(words[1], 0x07060504);
+  EXPECT_EQ(words[2], 0x0b0a0908);
+  EXPECT_EQ(words[3], 0x0f0e0d0c);
+
+  // and make sure C(R) compiles too
+
+  auto words2 = Common::BitCastView<u32>(data);
+
+  EXPECT_EQ(words2.size(), 4);
+}
+
+TEST(BitCastView, Writable)
+{
+  std::vector<u8> data;
+
+  for (u8 i = 0; i < 16; ++i)
+    data.push_back(i);
+  auto words = data | Common::BitCastView<u32>;
+
+  words[0] = 0xdeadbeef;
+
+  EXPECT_EQ(data[0], 0xef);
+  EXPECT_EQ(data[1], 0xbe);
+  EXPECT_EQ(data[2], 0xad);
+  EXPECT_EQ(data[3], 0xde);
+}
+
+TEST(BitCastView, Swapping)
+{
+  // Make sure it interacts correctly with BigEndianValue
+  std::vector<u8> data = {0, 0, 0, 1};
+  auto words = data | Common::BitCastView<Common::BigEndianValue<u32>>;
+
+  u32 value = words[0];
+  EXPECT_EQ(value, 1);
+
+  words[0] = 0xdeadbeef;
+
+  EXPECT_EQ(data[0], 0xde);
+  EXPECT_EQ(data[1], 0xad);
+  EXPECT_EQ(data[2], 0xbe);
+  EXPECT_EQ(data[3], 0xef);
+}
+
+TEST(BitCastView, SwappedRangeLoop)
+{
+  std::vector<u8> data = {0, 0, 0, 1, 0, 0, 0, 2};
+  auto words = data | Common::BitCastView<Common::BigEndianValue<u32>>;
+
+  u32 sum = 0;
+  for (auto word : words)
+    sum += word;
+
+  EXPECT_EQ(sum, 3);
+}

--- a/Source/UnitTests/Common/CMakeLists.txt
+++ b/Source/UnitTests/Common/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_dolphin_test(AssemblerTest AssemblerTest.cpp)
+add_dolphin_test(BitCastViewTest BitCastViewTest.cpp)
 add_dolphin_test(BitFieldTest BitFieldTest.cpp)
 add_dolphin_test(BitSetTest BitSetTest.cpp)
 add_dolphin_test(BitUtilsTest BitUtilsTest.cpp)


### PR DESCRIPTION
The goal of `BitCastView` is to provide easy (but safe) bitcasting of things like spans and vectors, or any view with a random access iterator. 

The inciting usecase is casting byte arrays to larger types:

```c++
u32 sum_words(std::span<u8> bytes) {
   u32 sum = 0;
   for (auto word : Common::BitCastView<u32>(bytes)) {
      sum += word;
   }
   return word;
}
```

BitCastView is a RangeAdaptorClosure, so it also works with the pipe syntax:

```c++
 // sum first 128 bytes as words
 for (auto word : bytes |views::take(128) | BitCastView<u32> )  { sum += word; }
  ```

BitCastView does not require the input view to be bytes. Could be anything of any size as long `sizeof(From)` is an integer factor of `To` and `From` can be bitcast. 

BitCastView also goes out of it's way to enable writing, and the use of wrapper types like `Common::BigEndianValue`

```c++
// modify BE words in a u16 memory. 
void write_val(std::span<u16> mem, u32 offset, u32 count, u32 value) {
   auto as_words = mem | Common::BitCastView<Common::BigEndianValue<u32>>;
   for(size_t i = 0; i < count; i++) {
       as_words[offset + i] = value;
   }
}
```

This is currently a draft for feedback

### TODO list: 

 - [ ] More documentation in BitCastView.h
 - [ ] Way more tests
 - [ ] Make sure requires clauses on `BitCastViewIterator` are correct
 - [ ] Potentially allow for casts where `sizeof(From)` is larger than `sizeof(To)`
 - [ ] Check this works on all compilers we support
 - [ ] Triple check that this is defined behaviour. 
 - [ ] Is there a better way to handle non-aligned sizeof?
     Currently we assert on `begin()` and provide a `valid()` that can be checked
 - [ ] Is the code-gen for non-contiguous inputs (such as deque) any good. Or should we restrict this to just contiguous inputs?
 - [ ] Should we support non-sized inputs? Or inputs that only implement forwards iterator? 