### PR TITLE
NetPlay: Implement local device discovery

### DIFF
--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <unistd.h>
 #else
 #include <winsock2.h>
 #endif
@@ -235,6 +236,14 @@ std::optional<IPv4PortRange> StringToIPv4PortRange(std::string_view subject)
     return std::nullopt;
 
   return result;
+}
+
+std::optional<std::string> GetHostname()
+{
+  char buf[256]{};
+  if (gethostname(buf, sizeof(buf) - 1) != 0)
+    return std::nullopt;
+  return std::string(buf);
 }
 
 MACAddress GenerateMacAddress(const MACConsumer type)

--- a/Source/Core/Common/Network.h
+++ b/Source/Core/Common/Network.h
@@ -298,6 +298,8 @@ std::string IPAddressToString(IPAddress ip_address);
 // Syntax is: first_ip[-last_ip|/network_prefix_length][:first_port[-last_port]]
 std::optional<IPv4PortRange> StringToIPv4PortRange(std::string_view subject);
 
+std::optional<std::string> GetHostname();
+
 MACAddress GenerateMacAddress(MACConsumer type);
 
 std::string MacAddressToString(const MACAddress& mac);

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -504,6 +504,8 @@ add_library(core
   NetPlayClient.h
   NetPlayCommon.cpp
   NetPlayCommon.h
+  NetPlayDiscovery.cpp
+  NetPlayDiscovery.h
   NetPlayServer.cpp
   NetPlayServer.h
   NetworkCaptureLogger.cpp

--- a/Source/Core/Core/NetPlayDiscovery.cpp
+++ b/Source/Core/Core/NetPlayDiscovery.cpp
@@ -1,0 +1,270 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Core/NetPlayDiscovery.h"
+
+#include <cstring>
+
+#ifndef _WIN32
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+#define closesocket close
+#else
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <ws2tcpip.h>
+using socklen_t = int;
+#endif
+#include <SFML/Network/Packet.hpp>
+
+#include "Common/Logging/Log.h"
+#include "Common/Network.h"
+
+namespace NetPlay::Discovery
+{
+sf::Packet& operator<<(sf::Packet& packet, const Payload& payload)
+{
+  return packet << payload.server_name << payload.version << payload.game_name
+                << payload.player_count << payload.in_game << payload.port
+                << static_cast<u8>(payload.platform);
+}
+
+sf::Packet& operator>>(sf::Packet& packet, Payload& payload)
+{
+  u8 platform_raw = 0;
+  packet >> payload.server_name >> payload.version >> payload.game_name >> payload.player_count >>
+      payload.in_game >> payload.port >> platform_raw;
+  payload.platform = static_cast<Platform>(platform_raw);
+  return packet;
+}
+
+Platform GetCurrentPlatform()
+{
+#ifdef __ANDROID__
+  return Platform::Android;
+#elifdef __linux__
+  return Platform::Linux;
+#elifdef _WIN32
+  return Platform::Windows;
+#elifdef TARGET_OS_OSX
+  return Platform::macOS;
+#elifdef TARGET_OS_IOS
+  return Platform::iOS;
+#elifdef __FreeBSD__
+  return Platform::FreeBSD;
+#elifdef __OpenBSD__
+  return Platform::OpenBSD;
+#elifdef __NetBSD__
+  return Platform::NetBSD;
+#elifdef __DragonFly__
+  return Platform::DragonFlyBSD;
+#elifdef __HAIKU__
+  return Platform::Haiku;
+#else
+  return Platform::Unknown;
+#endif
+}
+
+void Server::Start()
+{
+  if (m_running.exchange(true))
+    return;
+
+  m_thread = std::thread(&Server::DiscoveryThread, this);
+}
+
+void Server::Stop()
+{
+  if (!m_running.exchange(false))
+    return;
+
+  if (m_thread.joinable())
+    m_thread.join();
+}
+
+void Server::Update(Payload payload)
+{
+  std::lock_guard lock(m_payload_mutex);
+  m_payload = payload;
+}
+
+void Server::DiscoveryThread()
+{
+  const int sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0)
+  {
+    ERROR_LOG_FMT(NETPLAY, "NetPlayDiscovery: failed to create broadcast socket.");
+    return;
+  }
+
+  constexpr int broadcast_enable = 1;
+  if (setsockopt(sock, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<const char*>(&broadcast_enable),
+                 sizeof(broadcast_enable)) < 0)
+  {
+    ERROR_LOG_FMT(COMMON, "Failed to set SO_BROADCAST on socket: {}", Common::StrNetworkError());
+  };
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(PORT);
+  addr.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+
+  INFO_LOG_FMT(NETPLAY, "Discovery broadcast started on port {}", PORT);
+  while (m_running)
+  {
+    sf::Packet packet;
+    packet.append(MAGIC.data(), sizeof(MAGIC));
+
+    {
+      std::lock_guard lg(m_payload_mutex);
+      packet << m_payload;
+    }
+
+    sendto(sock, static_cast<const char*>(packet.getData()), static_cast<int>(packet.getDataSize()),
+           0, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+
+    std::this_thread::sleep_for(SERVER_TIMEOUT / 3);
+  }
+
+  INFO_LOG_FMT(NETPLAY, "Discovery broadcast stopped");
+  closesocket(sock);
+}
+
+void Client::Start()
+{
+  if (m_running.exchange(true))
+    return;
+
+  m_thread = std::thread(&Client::ListenThread, this);
+}
+
+void Client::Stop()
+{
+  if (!m_running.exchange(false))
+    return;
+
+  if (m_thread.joinable())
+    m_thread.join();
+}
+
+std::vector<DiscoveredServer> Client::GetServers() const
+{
+  std::lock_guard lg(m_servers_mutex);
+  std::vector<DiscoveredServer> result;
+  result.reserve(m_servers.size());
+  for (const auto& [addr, server] : m_servers)
+    result.push_back(server);
+  return result;
+}
+
+void Client::ListenThread()
+{
+  const int sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0)
+  {
+    ERROR_LOG_FMT(NETPLAY, "NetPlay discovery client: failed to create socket.");
+    return;
+  }
+
+  constexpr int reuse = 1;
+  if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuse),
+                 sizeof(reuse)) < 0)
+  {
+    ERROR_LOG_FMT(COMMON, "Failed to set SO_REUSEADDR on socket: {}", Common::StrNetworkError());
+  };
+
+  // Don't block on recvfrom so we can prune stale entries
+  constexpr int timeout_ms = 500;
+#if defined(_WIN32)
+  DWORD timeout = timeout_ms;
+  if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout),
+                 sizeof(timeout)) < 0)
+#else
+  timeval timeout{.tv_sec = 0, .tv_usec = timeout_ms * 1000};
+  if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0)
+#endif
+  {
+    ERROR_LOG_FMT(COMMON, "Failed to set SO_RCVTIMEO on socket: {}", Common::StrNetworkError());
+  };
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(PORT);
+  addr.sin_addr.s_addr = INADDR_ANY;
+
+  if (bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+  {
+    ERROR_LOG_FMT(NETPLAY, "NetPlay discovery client: failed to bind to port {}.", PORT);
+    closesocket(sock);
+    return;
+  }
+
+  std::vector<u8> buf(512);
+
+  while (m_running)
+  {
+    sockaddr_in from{};
+    socklen_t from_len = sizeof(from);
+
+    const int received =
+        recvfrom(sock, reinterpret_cast<char*>(buf.data()), static_cast<int>(buf.size()), 0,
+                 reinterpret_cast<sockaddr*>(&from), &from_len);
+
+    if (received <= 0)
+    {
+      PruneStaleServers();
+      continue;
+    }
+
+    if (static_cast<size_t>(received) < MAGIC.size() ||
+        std::memcmp(buf.data(), MAGIC.data(), MAGIC.size()) != 0)
+    {
+      PruneStaleServers();
+      continue;
+    }
+
+    sf::Packet packet;
+    packet.append(buf.data() + MAGIC.size(), received - MAGIC.size());
+
+    Payload payload;
+    packet >> payload;
+
+    if (!packet)
+      continue;
+
+    char addr_str[INET_ADDRSTRLEN] = {};
+    inet_ntop(AF_INET, &from.sin_addr, addr_str, sizeof(addr_str));
+
+    DiscoveredServer discovered;
+    discovered.payload = std::move(payload);
+    discovered.address = addr_str;
+    discovered.last_seen = std::chrono::steady_clock::now();
+
+    {
+      std::lock_guard lg(m_servers_mutex);
+      m_servers[discovered.address] = std::move(discovered);
+    }
+  }
+
+  closesocket(sock);
+
+  {
+    std::lock_guard lg(m_servers_mutex);
+    m_servers.clear();
+  }
+}
+
+void Client::PruneStaleServers()
+{
+  const auto now = std::chrono::steady_clock::now();
+  std::lock_guard lg(m_servers_mutex);
+  std::erase_if(m_servers, [&](const auto& entry) {
+    return now - entry.second.last_seen > SERVER_TIMEOUT || entry.second.payload.player_count == 0;
+  });
+}
+}  // namespace NetPlay::Discovery

--- a/Source/Core/Core/NetPlayDiscovery.h
+++ b/Source/Core/Core/NetPlayDiscovery.h
@@ -1,0 +1,103 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+namespace sf
+{
+class Packet;
+}
+
+namespace NetPlay
+{
+namespace Discovery
+{
+enum class Platform : u8
+{
+  Unknown = 0,
+  Linux = 1,
+  Windows = 2,
+  macOS = 3,
+  Android = 4,
+  iOS = 5,
+  FreeBSD = 6,
+  OpenBSD = 7,
+  NetBSD = 8,
+  DragonFlyBSD = 9,
+  Haiku = 10
+};
+
+struct Payload
+{
+  std::string server_name;
+  std::string version;
+  std::string game_name;
+  u8 player_count = 0;
+  bool in_game = false;
+  u16 port = 0;
+  Platform platform = Platform::Unknown;
+};
+
+struct DiscoveredServer
+{
+  Payload payload;
+  std::string address;
+  std::chrono::steady_clock::time_point last_seen;
+};
+
+sf::Packet& operator<<(sf::Packet& packet, const Payload& payload);
+sf::Packet& operator>>(sf::Packet& packet, Payload& payload);
+
+static constexpr u16 PORT = 2662;
+static constexpr u8 PROTOCOL_VERSION = 1;  // Increase this if the payload definition changes
+static constexpr std::array<u8, 8> MAGIC{'D', 'O', 'L', 'P', 'H', 'I', 'N', PROTOCOL_VERSION};
+static constexpr std::chrono::seconds SERVER_TIMEOUT{5};
+
+Platform GetCurrentPlatform();
+
+class Server
+{
+public:
+  void Start();
+  void Stop();
+  void Update(Payload payload);
+
+private:
+  void DiscoveryThread();
+
+  std::thread m_thread;
+  std::atomic<bool> m_running{false};
+  std::mutex m_payload_mutex;
+  Payload m_payload;
+};
+
+class Client
+{
+public:
+  void Start();
+  void Stop();
+
+  std::vector<DiscoveredServer> GetServers() const;
+
+private:
+  void ListenThread();
+  void PruneStaleServers();
+
+  std::thread m_thread;
+  std::atomic<bool> m_running{false};
+  mutable std::mutex m_servers_mutex;
+  std::unordered_map<std::string, DiscoveredServer> m_servers;
+};
+}  // namespace Discovery
+}  // namespace NetPlay

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -26,6 +26,7 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+#include "Common/Network.h"
 #include "Common/SFMLHelper.h"
 #include "Common/StringUtil.h"
 #include "Common/UPnP.h"
@@ -114,6 +115,7 @@ NetPlayServer::~NetPlayServer()
 #ifdef USE_UPNP
   Common::UPnP::StopPortmapping();
 #endif
+  m_discovery_server.Stop();
 }
 
 // called from ---GUI--- thread
@@ -174,6 +176,9 @@ NetPlayServer::NetPlayServer(const u16 port, const bool forward_port, NetPlayUI*
     if (forward_port && !traversal_config.use_traversal)
       Common::UPnP::TryPortmapping(port);
 #endif
+
+    m_discovery_server.Start();
+    UpdateDiscoveryPayload();
   }
 }
 
@@ -265,6 +270,7 @@ void NetPlayServer::ThreadFunc()
       m_index.SetPlayerCount(static_cast<int>(m_players.size()));
       m_index.SetGame(m_selected_game_name);
       m_index.SetInGame(m_is_running);
+      UpdateDiscoveryPayload();
 
       m_update_pings = false;
     }
@@ -1023,6 +1029,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
       break;
 
     m_is_running = false;
+    UpdateDiscoveryPayload();
 
     // tell clients to stop game
     sf::Packet spac;
@@ -1318,6 +1325,7 @@ bool NetPlayServer::ChangeGame(const SyncIdentifier& sync_identifier,
 
   m_selected_game_identifier = sync_identifier;
   m_selected_game_name = netplay_name;
+  UpdateDiscoveryPayload();
 
   // send changed game to clients
   sf::Packet spac;
@@ -1694,6 +1702,7 @@ bool NetPlayServer::StartGame()
 
   m_start_pending = false;
   m_is_running = true;
+  UpdateDiscoveryPayload();
 
   return true;
 }
@@ -2558,4 +2567,18 @@ void NetPlayServer::ChunkedDataAbort()
   m_chunked_data_event.Set();
   m_chunked_data_complete_event.Set();
 }
+
+void NetPlayServer::UpdateDiscoveryPayload()
+{
+  m_discovery_server.Update(NetPlay::Discovery::Payload{
+      .server_name = Common::GetHostname().value_or(Common::GetScmRevStr()),
+      .version = Common::GetScmDescStr(),
+      .game_name = m_selected_game_name,
+      .player_count = static_cast<u8>(m_players.size()),
+      .in_game = m_is_running,
+      .port = GetPort(),
+      .platform = NetPlay::Discovery::GetCurrentPlatform(),
+  });
+}
+
 }  // namespace NetPlay

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -18,6 +18,7 @@
 #include "Common/SPSCQueue.h"
 #include "Common/Timer.h"
 #include "Common/TraversalClient.h"
+#include "Core/NetPlayDiscovery.h"
 #include "Core/NetPlayProto.h"
 #include "Core/SyncIdentifier.h"
 #include "UICommon/NetPlayIndex.h"
@@ -71,6 +72,8 @@ public:
 
   std::unordered_set<std::string> GetInterfaceSet() const;
   std::string GetInterfaceHost(const std::string& inter) const;
+
+  void UpdateDiscoveryPayload();
 
   bool is_connected = false;
 
@@ -210,5 +213,7 @@ private:
   Common::TraversalClient* m_traversal_client = nullptr;
   NetPlayUI* m_dialog = nullptr;
   NetPlayIndex m_index;
+
+  NetPlay::Discovery::Server m_discovery_server{};
 };
 }  // namespace NetPlay

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -296,6 +296,8 @@ add_executable(dolphin-emu
   MenuBar.h
   NetPlay/ChunkedProgressDialog.cpp
   NetPlay/ChunkedProgressDialog.h
+  NetPlay/DiscoveryWidget.cpp
+  NetPlay/DiscoveryWidget.h
   NetPlay/GameDigestDialog.cpp
   NetPlay/GameDigestDialog.h
   NetPlay/GameListDialog.cpp

--- a/Source/Core/DolphinQt/NetPlay/DiscoveryWidget.cpp
+++ b/Source/Core/DolphinQt/NetPlay/DiscoveryWidget.cpp
@@ -1,0 +1,145 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/NetPlay/DiscoveryWidget.h"
+
+#include <QHeaderView>
+#include <QTableWidget>
+#include <QTimer>
+
+static QString GetPlatformName(NetPlay::Discovery::Platform platform)
+{
+  switch (platform)
+  {
+  case NetPlay::Discovery::Platform::Linux:
+    return QStringLiteral("Linux");
+  case NetPlay::Discovery::Platform::Windows:
+    return QStringLiteral("Windows");
+  case NetPlay::Discovery::Platform::macOS:
+    return QStringLiteral("macOS");
+  case NetPlay::Discovery::Platform::Android:
+    return QStringLiteral("Android");
+  case NetPlay::Discovery::Platform::iOS:
+    return QStringLiteral("iOS");
+  case NetPlay::Discovery::Platform::FreeBSD:
+    return QStringLiteral("FreeBSD");
+  case NetPlay::Discovery::Platform::OpenBSD:
+    return QStringLiteral("OpenBSD");
+  case NetPlay::Discovery::Platform::NetBSD:
+    return QStringLiteral("NetBSD");
+  case NetPlay::Discovery::Platform::DragonFlyBSD:
+    return QStringLiteral("DragonFly BSD");
+  case NetPlay::Discovery::Platform::Haiku:
+    return QStringLiteral("Haiku");
+  default:
+    return QStringLiteral("Unknown");
+  }
+}
+
+DiscoveryWidget::DiscoveryWidget(QWidget* parent) : QTableWidget(0, 5, parent)
+{
+  setHorizontalHeaderLabels({tr("Platform"), tr("Host"), tr("Game"), tr("Players"), tr("Version")});
+  verticalHeader()->setVisible(false);
+  setSelectionBehavior(QAbstractItemView::SelectRows);
+  setSelectionMode(QAbstractItemView::SingleSelection);
+  setEditTriggers(QAbstractItemView::NoEditTriggers);
+  horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+  horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+  horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+  horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+  horizontalHeader()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
+
+  connect(this, &QTableWidget::cellDoubleClicked, this, &DiscoveryWidget::OnCellDoubleClicked);
+  connect(this, &QTableWidget::itemSelectionChanged, this, &DiscoveryWidget::OnSelectionChanged);
+
+  m_timer = new QTimer(this);
+  connect(m_timer, &QTimer::timeout, this, &DiscoveryWidget::RefreshServers);
+}
+
+DiscoveryWidget::~DiscoveryWidget()
+{
+  if (m_timer->isActive())
+    m_timer->stop();
+  m_client.Stop();
+}
+
+void DiscoveryWidget::showEvent(QShowEvent* event)
+{
+  QTableWidget::showEvent(event);
+
+  if (!m_timer->isActive())
+  {
+    m_client.Start();
+    RefreshServers();
+    m_timer->start(1000);
+  }
+}
+
+void DiscoveryWidget::hideEvent(QHideEvent* event)
+{
+  QTableWidget::hideEvent(event);
+
+  if (m_timer->isActive())
+  {
+    m_timer->stop();
+    m_client.Stop();
+    clearContents();
+  }
+}
+
+void DiscoveryWidget::RefreshServers()
+{
+  using NetPlay::Discovery::DiscoveredServer;
+  const std::vector<DiscoveredServer> servers = m_client.GetServers();
+
+  {
+    const QSignalBlocker blocker(this);
+    setRowCount(static_cast<int>(servers.size()));
+
+    for (int row = 0; row < static_cast<int>(servers.size()); ++row)
+    {
+      const DiscoveredServer& server = servers[row];
+
+      auto* platform_item = new QTableWidgetItem(GetPlatformName(server.payload.platform));
+      platform_item->setData(Qt::UserRole, QVariant::fromValue(server));
+
+      auto* host_item = new QTableWidgetItem(QString::fromStdString(server.payload.server_name));
+      auto* game_item = new QTableWidgetItem(server.payload.game_name.empty() ?
+                                                 tr("No game selected") :
+                                                 QString::fromStdString(server.payload.game_name));
+      auto* players_item = new QTableWidgetItem(QString::number(server.payload.player_count));
+      players_item->setTextAlignment(Qt::AlignCenter);
+      auto* version_item = new QTableWidgetItem(QString::fromStdString(server.payload.version));
+
+      setItem(row, 0, platform_item);
+      setItem(row, 1, host_item);
+      setItem(row, 2, game_item);
+      setItem(row, 3, players_item);
+      setItem(row, 4, version_item);
+    }
+  }
+}
+
+void DiscoveryWidget::OnSelectionChanged()
+{
+  const auto selected = selectionModel()->selectedRows();
+  if (selected.isEmpty())
+    return;
+
+  auto* platform_item = item(selected.first().row(), 0);
+  if (!platform_item)
+    return;
+
+  emit ServerSelected(
+      platform_item->data(Qt::UserRole).value<NetPlay::Discovery::DiscoveredServer>());
+}
+
+void DiscoveryWidget::OnCellDoubleClicked(int row, int column)
+{
+  auto* platform_item = item(row, 0);
+  if (!platform_item)
+    return;
+
+  emit ServerActivated(
+      platform_item->data(Qt::UserRole).value<NetPlay::Discovery::DiscoveredServer>());
+}

--- a/Source/Core/DolphinQt/NetPlay/DiscoveryWidget.h
+++ b/Source/Core/DolphinQt/NetPlay/DiscoveryWidget.h
@@ -1,0 +1,36 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QTableWidget>
+
+#include "Core/NetPlayDiscovery.h"
+
+class QTimer;
+
+class DiscoveryWidget : public QTableWidget
+{
+  Q_OBJECT
+public:
+  explicit DiscoveryWidget(QWidget* parent = nullptr);
+  ~DiscoveryWidget();
+
+signals:
+  void ServerSelected(const NetPlay::Discovery::DiscoveredServer& server);
+  void ServerActivated(const NetPlay::Discovery::DiscoveredServer& server);
+
+protected:
+  void showEvent(QShowEvent* event) override;
+  void hideEvent(QHideEvent* event) override;
+
+private:
+  void RefreshServers();
+
+  void OnCellDoubleClicked(int row, int column);
+  void OnSelectionChanged();
+
+  NetPlay::Discovery::Client m_client{};
+
+  QTimer* m_timer;
+};

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -9,6 +9,7 @@
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QGridLayout>
+#include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
 #include <QListWidget>
@@ -16,10 +17,12 @@
 #include <QSignalBlocker>
 #include <QSpinBox>
 #include <QTabWidget>
+#include <QVBoxLayout>
 
 #include "Core/Config/NetplaySettings.h"
 #include "Core/NetPlayProto.h"
 
+#include "DolphinQt/NetPlay/DiscoveryWidget.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/QtUtils/UTF8CodePointCountValidator.h"
@@ -109,6 +112,7 @@ void NetPlaySetupDialog::CreateMainLayout()
   connection_layout->addWidget(m_ip_edit, 0, 1);
   connection_layout->addWidget(m_connect_port_label, 0, 2);
   connection_layout->addWidget(m_connect_port_box, 0, 3);
+  connection_layout->addWidget(m_connect_button, 0, 4);
   auto* const alert_label = new QLabel(
       tr("ALERT:\n\n"
          "All players must use the same Dolphin version.\n"
@@ -125,8 +129,14 @@ void NetPlaySetupDialog::CreateMainLayout()
   alert_label->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
 
   connection_layout->addWidget(alert_label, 1, 0, 1, -1);
-  connection_layout->addItem(new QSpacerItem(1, 1), 2, 0, -1, -1);
-  connection_layout->addWidget(m_connect_button, 3, 3, Qt::AlignRight);
+
+  QGroupBox* discovery_group = new QGroupBox(tr("Local Network"));
+  QVBoxLayout* discovery_group_layout = new QVBoxLayout;
+  m_discovery_widget = new DiscoveryWidget;
+  discovery_group_layout->addWidget(m_discovery_widget);
+  discovery_group->setLayout(discovery_group_layout);
+
+  connection_layout->addWidget(discovery_group, 2, 0, 1, -1);
 
   connection_widget->setLayout(connection_layout);
 
@@ -216,6 +226,13 @@ void NetPlaySetupDialog::ConnectWidgets()
   // Connect widget
   connect(m_ip_edit, &QLineEdit::textChanged, this, &NetPlaySetupDialog::SaveSettings);
   connect(m_connect_port_box, &QSpinBox::valueChanged, this, &NetPlaySetupDialog::SaveSettings);
+  connect(m_discovery_widget, &DiscoveryWidget::ServerSelected, this,
+          &NetPlaySetupDialog::OnServerSelected);
+  connect(m_discovery_widget, &DiscoveryWidget::ServerActivated, this,
+          [this](const NetPlay::Discovery::DiscoveredServer& server) {
+            OnServerSelected(server);
+            accept();
+          });
   // Host widget
   connect(m_host_port_box, &QSpinBox::valueChanged, this, &NetPlaySetupDialog::SaveSettings);
   connect(m_host_games, &QListWidget::currentRowChanged, [this](int index) {
@@ -316,6 +333,12 @@ void NetPlaySetupDialog::OnConnectionTypeChanged(int index)
 
   Config::SetBaseOrCurrent(Config::NETPLAY_TRAVERSAL_CHOICE,
                            std::string(index == 0 ? "direct" : "traversal"));
+}
+
+void NetPlaySetupDialog::OnServerSelected(const NetPlay::Discovery::DiscoveredServer& server)
+{
+  m_ip_edit->setText(QString::fromStdString(server.address));
+  m_connect_port_box->setValue(server.payload.port);
 }
 
 void NetPlaySetupDialog::show()

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.h
@@ -17,6 +17,15 @@ class QGridLayout;
 class QPushButton;
 class QSpinBox;
 class QTabWidget;
+class DiscoveryWidget;
+
+namespace NetPlay
+{
+namespace Discovery
+{
+struct DiscoveredServer;
+}
+}  // namespace NetPlay
 
 namespace UICommon
 {
@@ -46,6 +55,8 @@ private:
 
   void OnConnectionTypeChanged(int index);
 
+  void OnServerSelected(const NetPlay::Discovery::DiscoveredServer& server);
+
   // Main Widget
   QDialogButtonBox* m_button_box;
   QComboBox* m_connection_type;
@@ -60,6 +71,7 @@ private:
   QLabel* m_connect_port_label;
   QSpinBox* m_connect_port_box;
   QPushButton* m_connect_button;
+  DiscoveryWidget* m_discovery_widget;
 
   // Host Widget
   QLabel* m_host_port_label;


### PR DESCRIPTION
This PR allows device on the same network to discover each-other.

<img width="721" height="706" alt="image" src="https://github.com/user-attachments/assets/f104c0cd-7271-4998-83d0-7469e158757a" />

On the UI side, clicking one of the entries automatically fills the "IP Address" and "Port" fields. Double-clicking joins the NetPlay session.

This PR doesn't attempt to implement this feature on Android, on which I couldn't figure out how to allow broadcasting to happen.