### PR TITLE
Refactor the GameCube microphone code

### DIFF
--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(audiocommon
   AudioCommon.h
   CubebStream.h
   Enums.h
+  Microphone.cpp
+  Microphone.h
   Mixer.cpp
   Mixer.h
   SurroundDecoder.cpp

--- a/Source/Core/AudioCommon/Microphone.cpp
+++ b/Source/Core/AudioCommon/Microphone.cpp
@@ -142,6 +142,7 @@ void Microphone::StreamStart(u32 sampling_rate)
     }
 
     m_stream_buffer.resize(GetStreamSize());
+    m_stream_rpos = 0;
     m_stream_wpos = 0;
     INFO_LOG_FMT(AUDIO, "started cubeb stream");
   });
@@ -177,6 +178,11 @@ long Microphone::CubebDataCallback(cubeb_stream* stream, void* user_data, const 
   return mic->DataCallback(static_cast<const SampleType*>(input_buffer), nframes);
 }
 
+void Microphone::OnOverflow()
+{
+  m_samples_avail = GetStreamSize();
+}
+
 long Microphone::DataCallback(const SampleType* input_buffer, long nframes)
 {
   std::lock_guard lock(m_ring_lock);
@@ -204,7 +210,7 @@ long Microphone::DataCallback(const SampleType* input_buffer, long nframes)
   m_samples_avail += nframes;
   if (m_samples_avail > stream_size)
   {
-    m_samples_avail = stream_size;
+    OnOverflow();
   }
 
   return nframes;
@@ -213,22 +219,23 @@ long Microphone::DataCallback(const SampleType* input_buffer, long nframes)
 
 u16 Microphone::ReadIntoBuffer(u8* ptr, u32 size)
 {
-  static constexpr u32 SINGLE_READ_SIZE = BUFF_SIZE_SAMPLES * sizeof(SampleType);
+  const u32 samples_per_read = GetBufferSizeSamples();
+  const u32 bytes_per_read = samples_per_read * sizeof(SampleType);
 
   std::lock_guard lock(m_ring_lock);
 
   const u32 stream_size = GetStreamSize();
-  u8* begin = ptr;
-  for (u8* end = begin + size; ptr < end; ptr += SINGLE_READ_SIZE, size -= SINGLE_READ_SIZE)
+  u8* const begin = ptr;
+  for (u8* const end = begin + size; ptr < end; ptr += bytes_per_read, size -= bytes_per_read)
   {
-    if (size < SINGLE_READ_SIZE || m_samples_avail < BUFF_SIZE_SAMPLES)
+    if (size < bytes_per_read || m_samples_avail < samples_per_read)
       break;
 
     SampleType* last_buffer = &m_stream_buffer[m_stream_rpos];
-    std::memcpy(ptr, last_buffer, SINGLE_READ_SIZE);
+    std::memcpy(ptr, last_buffer, bytes_per_read);
 
-    m_samples_avail -= BUFF_SIZE_SAMPLES;
-    m_stream_rpos += BUFF_SIZE_SAMPLES;
+    m_samples_avail -= samples_per_read;
+    m_stream_rpos += samples_per_read;
     m_stream_rpos %= stream_size;
   }
   return static_cast<u16>(ptr - begin);
@@ -266,7 +273,7 @@ void Microphone::UpdateLoudness(const SampleType sample)
   }
 }
 
-bool Microphone::HasData(u32 sample_count = BUFF_SIZE_SAMPLES) const
+bool Microphone::HasData(u32 sample_count) const
 {
   std::lock_guard lock(m_ring_lock);
   return m_samples_avail >= sample_count;
@@ -281,6 +288,11 @@ void Microphone::SetSamplingRate(u32 sampling_rate)
 {
   StreamStop();
   StreamStart(sampling_rate);
+}
+
+u32 Microphone::GetBufferSizeSamples() const
+{
+  return BUFF_SIZE_SAMPLES;
 }
 
 const Microphone::FloatType Microphone::Loudness::DB_MIN =

--- a/Source/Core/AudioCommon/Microphone.cpp
+++ b/Source/Core/AudioCommon/Microphone.cpp
@@ -1,7 +1,7 @@
 // Copyright 2025 Dolphin Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "Core/IOS/USB/Emulated/Microphone.h"
+#include "AudioCommon/Microphone.h"
 
 #include <algorithm>
 #include <cmath>
@@ -28,7 +28,7 @@
 #include "jni/AndroidCommon/IDCache.h"
 #endif
 
-namespace IOS::HLE::USB
+namespace AudioCommon
 {
 #ifdef HAVE_CUBEB
 Microphone::Microphone(const MicrophoneState& sampler, std::string worker_name)
@@ -72,7 +72,7 @@ void Microphone::StreamInit()
 {
   if (!m_worker.Execute([this] { m_cubeb_ctx = CubebUtils::GetContext(); }))
   {
-    ERROR_LOG_FMT(IOS_USB, "Failed to init microphone stream");
+    ERROR_LOG_FMT(AUDIO, "Failed to init microphone stream");
     return;
   }
 
@@ -121,7 +121,7 @@ void Microphone::StreamStart(u32 sampling_rate)
     u32 minimum_latency;
     if (cubeb_get_min_latency(m_cubeb_ctx.get(), &params, &minimum_latency) != CUBEB_OK)
     {
-      WARN_LOG_FMT(IOS_USB, "Error getting minimum latency");
+      WARN_LOG_FMT(AUDIO, "Error getting minimum latency");
       minimum_latency = 16;
     }
 
@@ -131,19 +131,19 @@ void Microphone::StreamStart(u32 sampling_rate)
                           std::max<u32>(16, minimum_latency), CubebDataCallback, StateCallback,
                           this) != CUBEB_OK)
     {
-      ERROR_LOG_FMT(IOS_USB, "Error initializing cubeb stream");
+      ERROR_LOG_FMT(AUDIO, "Error initializing cubeb stream");
       return;
     }
 
     if (cubeb_stream_start(m_cubeb_stream) != CUBEB_OK)
     {
-      ERROR_LOG_FMT(IOS_USB, "Error starting cubeb stream");
+      ERROR_LOG_FMT(AUDIO, "Error starting cubeb stream");
       return;
     }
 
     m_stream_buffer.resize(GetStreamSize());
     m_stream_wpos = 0;
-    INFO_LOG_FMT(IOS_USB, "started cubeb stream");
+    INFO_LOG_FMT(AUDIO, "started cubeb stream");
   });
 }
 
@@ -154,7 +154,7 @@ void Microphone::StreamStop()
 
   m_worker.Execute([this] {
     if (cubeb_stream_stop(m_cubeb_stream) != CUBEB_OK)
-      ERROR_LOG_FMT(IOS_USB, "Error stopping cubeb stream");
+      ERROR_LOG_FMT(AUDIO, "Error stopping cubeb stream");
     cubeb_stream_destroy(m_cubeb_stream);
     m_cubeb_stream = nullptr;
   });
@@ -375,7 +375,7 @@ void Microphone::Loudness::LogStats()
   const auto crest_factor = GetCrestFactor();
   const auto crest_factor_db = GetDecibel(crest_factor);
 
-  INFO_LOG_FMT(IOS_USB,
+  INFO_LOG_FMT(AUDIO,
                "Microphone loudness stats (sample count: {}/{}):\n"
                " - min={} max={} amplitude={} ({} dB)\n"
                " - rms={} ({} dB) \n"
@@ -384,4 +384,4 @@ void Microphone::Loudness::LogStats()
                samples_count, SAMPLES_NEEDED, peak_min, peak_max, amplitude, amplitude_db, rms,
                rms_db, abs_mean, abs_mean_db, crest_factor, crest_factor_db);
 }
-}  // namespace IOS::HLE::USB
+}  // namespace AudioCommon

--- a/Source/Core/AudioCommon/Microphone.h
+++ b/Source/Core/AudioCommon/Microphone.h
@@ -49,7 +49,9 @@ public:
   void SetSamplingRate(u32 sampling_rate);
 
 protected:
+  // sic. can be 16, 32 or 64 on GameCube
   static constexpr u32 BUFF_SIZE_SAMPLES = 32;
+  u32 m_samples_avail = 0;
 
 private:
 #ifdef HAVE_CUBEB
@@ -59,6 +61,7 @@ private:
   virtual std::string GetCubebStreamName() const = 0;
   virtual s16 GetVolumeModifier() const = 0;
   virtual bool AreSamplesByteSwapped() const = 0;
+  virtual void OnOverflow();
 #endif
 
   long DataCallback(const SampleType* input_buffer, long nframes);
@@ -70,11 +73,11 @@ private:
   void StreamStart(u32 sampling_rate);
   void StreamStop();
 
+  virtual u32 GetBufferSizeSamples() const;
   virtual u32 GetStreamSize() const = 0;
   std::vector<SampleType> m_stream_buffer{};
   u32 m_stream_wpos = 0;
   u32 m_stream_rpos = 0;
-  u32 m_samples_avail = 0;
 
   // TODO: Find how this level is calculated on real hardware
   std::atomic<u16> m_loudness_level = 0;

--- a/Source/Core/AudioCommon/Microphone.h
+++ b/Source/Core/AudioCommon/Microphone.h
@@ -19,7 +19,7 @@ struct cubeb;
 struct cubeb_stream;
 #endif
 
-namespace IOS::HLE::USB
+namespace AudioCommon
 {
 class MicrophoneState
 {
@@ -124,4 +124,4 @@ private:
   CubebUtils::CoInitSyncWorker m_worker;
 #endif
 };
-}  // namespace IOS::HLE::USB
+}  // namespace AudioCommon

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -455,8 +455,6 @@ add_library(core
   IOS/USB/Common.h
   IOS/USB/Emulated/Infinity.cpp
   IOS/USB/Emulated/Infinity.h
-  IOS/USB/Emulated/Microphone.cpp
-  IOS/USB/Emulated/Microphone.h
   IOS/USB/Emulated/Skylanders/Skylander.cpp
   IOS/USB/Emulated/Skylanders/Skylander.h
   IOS/USB/Emulated/Skylanders/SkylanderCrypto.cpp

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -28,8 +28,10 @@ namespace ExpansionInterface
 {
 void CEXIMic::StreamInit()
 {
-  stream_buffer = nullptr;
-  samples_avail = stream_wpos = stream_rpos = 0;
+  m_stream_buffer = nullptr;
+  m_samples_avail = 0;
+  m_stream_wpos = 0;
+  m_stream_rpos = 0;
 
 #ifdef _WIN32
   if (!m_coinit_success)
@@ -69,20 +71,20 @@ long CEXIMic::DataCallback(cubeb_stream* stream, void* user_data, const void* in
 {
   CEXIMic* mic = static_cast<CEXIMic*>(user_data);
 
-  std::lock_guard lk(mic->ring_lock);
+  std::lock_guard lk(mic->m_ring_lock);
 
   const s16* buff_in = static_cast<const s16*>(input_buffer);
   for (long i = 0; i < nframes; i++)
   {
-    mic->stream_buffer[mic->stream_wpos] = buff_in[i];
-    mic->stream_wpos = (mic->stream_wpos + 1) % mic->stream_size;
+    mic->m_stream_buffer[mic->m_stream_wpos] = buff_in[i];
+    mic->m_stream_wpos = (mic->m_stream_wpos + 1) % mic->m_stream_size;
   }
 
-  mic->samples_avail += nframes;
-  if (mic->samples_avail > mic->stream_size)
+  mic->m_samples_avail += nframes;
+  if (mic->m_samples_avail > mic->m_stream_size)
   {
-    mic->samples_avail = 0;
-    mic->status.buff_ovrflw = 1;
+    mic->m_samples_avail = 0;
+    mic->m_status.buff_ovrflw = 1;
   }
 
   return nframes;
@@ -99,12 +101,12 @@ void CEXIMic::StreamStart()
   m_work_queue.PushBlocking([this] {
 #endif
     // Open stream with current parameters
-    stream_size = buff_size_samples * 500;
-    stream_buffer = new s16[stream_size];
+    m_stream_size = m_buff_size_samples * 500;
+    m_stream_buffer = new s16[m_stream_size];
 
     cubeb_stream_params params{};
     params.format = CUBEB_SAMPLE_S16LE;
-    params.rate = sample_rate;
+    params.rate = m_sample_rate;
     params.channels = 1;
     params.layout = CUBEB_LAYOUT_MONO;
 
@@ -116,8 +118,8 @@ void CEXIMic::StreamStart()
 
     if (cubeb_stream_init(m_cubeb_ctx.get(), &m_cubeb_stream,
                           "Dolphin Emulated GameCube Microphone", nullptr, &params, nullptr,
-                          nullptr, std::max<u32>(buff_size_samples, minimum_latency), DataCallback,
-                          state_callback, this) != CUBEB_OK)
+                          nullptr, std::max<u32>(m_buff_size_samples, minimum_latency),
+                          DataCallback, state_callback, this) != CUBEB_OK)
     {
       ERROR_LOG_FMT(EXPANSIONINTERFACE, "Error initializing cubeb stream");
       return;
@@ -151,25 +153,27 @@ void CEXIMic::StreamStop()
 #endif
   }
 
-  samples_avail = stream_wpos = stream_rpos = 0;
+  m_samples_avail = 0;
+  m_stream_wpos = 0;
+  m_stream_rpos = 0;
 
-  delete[] stream_buffer;
-  stream_buffer = nullptr;
+  delete[] m_stream_buffer;
+  m_stream_buffer = nullptr;
 }
 
 void CEXIMic::StreamReadOne()
 {
-  std::lock_guard lk(ring_lock);
+  std::lock_guard lk(m_ring_lock);
 
-  if (samples_avail >= buff_size_samples)
+  if (m_samples_avail >= m_buff_size_samples)
   {
-    s16* last_buffer = &stream_buffer[stream_rpos];
-    std::memcpy(ring_buffer.data(), last_buffer, buff_size);
+    s16* last_buffer = &m_stream_buffer[m_stream_rpos];
+    std::memcpy(m_ring_buffer.data(), last_buffer, m_buff_size);
 
-    samples_avail -= buff_size_samples;
+    m_samples_avail -= m_buff_size_samples;
 
-    stream_rpos += buff_size_samples;
-    stream_rpos %= stream_size;
+    m_stream_rpos += m_buff_size_samples;
+    m_stream_rpos %= m_stream_size;
   }
 }
 
@@ -180,7 +184,7 @@ void CEXIMic::StreamReadOne()
 // cmdGetBuffer, which is when we actually read data from a buffer filled
 // in the background.
 CEXIMic::CEXIMic(Core::System& system, int index)
-    : IEXIDevice(system), slot(index)
+    : IEXIDevice(system), m_slot(index)
 #ifdef _WIN32
       ,
       m_work_queue("Mic Worker")
@@ -228,19 +232,19 @@ void CEXIMic::SetCS(int cs)
 
 void CEXIMic::UpdateNextInterruptTicks()
 {
-  int diff = (m_system.GetSystemTimers().GetTicksPerSecond() / sample_rate) * buff_size_samples;
-  next_int_ticks = m_system.GetCoreTiming().GetTicks() + diff;
+  int diff = (m_system.GetSystemTimers().GetTicksPerSecond() / m_sample_rate) * m_buff_size_samples;
+  m_next_int_ticks = m_system.GetCoreTiming().GetTicks() + diff;
   m_system.GetExpansionInterface().ScheduleUpdateInterrupts(CoreTiming::FromThread::CPU, diff);
 }
 
 bool CEXIMic::IsInterruptSet()
 {
-  if (next_int_ticks && m_system.GetCoreTiming().GetTicks() >= next_int_ticks)
+  if (m_next_int_ticks && m_system.GetCoreTiming().GetTicks() >= m_next_int_ticks)
   {
-    if (status.is_active)
+    if (m_status.is_active)
       UpdateNextInterruptTicks();
     else
-      next_int_ticks = 0;
+      m_next_int_ticks = 0;
 
     return true;
   }
@@ -254,15 +258,15 @@ void CEXIMic::TransferByte(u8& byte)
 {
   if (m_position == 0)
   {
-    command = byte;  // first byte is command
-    byte = 0xFF;     // would be tristate, but we don't care.
+    m_command = byte;  // first byte is command
+    byte = 0xFF;       // would be tristate, but we don't care.
     m_position++;
     return;
   }
 
   int pos = m_position - 1;
 
-  switch (command)
+  switch (m_command)
   {
   case cmdID:
     byte = EXI_ID[pos];
@@ -270,31 +274,31 @@ void CEXIMic::TransferByte(u8& byte)
 
   case cmdGetStatus:
     if (pos == 0)
-      status.button = Pad::GetMicButton(slot);
+      m_status.button = Pad::GetMicButton(m_slot);
 
-    byte = Common::BitCastPtr<u8>(&status)[pos ^ 1];
+    byte = Common::BitCastPtr<u8>(&m_status)[pos ^ 1];
 
     if (pos == 1)
-      status.buff_ovrflw = 0;
+      m_status.buff_ovrflw = 0;
     break;
 
   case cmdSetStatus:
   {
-    bool wasactive = status.is_active;
-    Common::BitCastPtr<u8>(&status)[pos ^ 1] = byte;
+    bool wasactive = m_status.is_active;
+    Common::BitCastPtr<u8>(&m_status)[pos ^ 1] = byte;
 
     // safe to do since these can only be entered if both bytes of status have been written
-    if (!wasactive && status.is_active)
+    if (!wasactive && m_status.is_active)
     {
-      sample_rate = RATE_BASE << status.sample_rate;
-      buff_size = RING_BASE << status.buff_size;
-      buff_size_samples = buff_size / SAMPLE_SIZE;
+      m_sample_rate = RATE_BASE << m_status.sample_rate;
+      m_buff_size = RING_BASE << m_status.buff_size;
+      m_buff_size_samples = m_buff_size / SAMPLE_SIZE;
 
       UpdateNextInterruptTicks();
 
       StreamStart();
     }
-    else if (wasactive && !status.is_active)
+    else if (wasactive && !m_status.is_active)
     {
       StreamStop();
     }
@@ -303,16 +307,16 @@ void CEXIMic::TransferByte(u8& byte)
 
   case cmdGetBuffer:
   {
-    if (ring_pos == 0)
+    if (m_ring_pos == 0)
       StreamReadOne();
 
-    byte = ring_buffer[ring_pos ^ 1];
-    ring_pos = (ring_pos + 1) % buff_size;
+    byte = m_ring_buffer[m_ring_pos ^ 1];
+    m_ring_pos = (m_ring_pos + 1) % m_buff_size;
   }
   break;
 
   default:
-    ERROR_LOG_FMT(EXPANSIONINTERFACE, "EXI MIC: unknown command byte {:02x}", command);
+    ERROR_LOG_FMT(EXPANSIONINTERFACE, "EXI MIC: unknown command byte {:02x}", m_command);
     break;
   }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstring>
 #include <mutex>
+#include <utility>
 
 #include <cubeb/cubeb.h>
 
@@ -26,155 +27,71 @@
 
 namespace ExpansionInterface
 {
-void CEXIMic::StreamInit()
+bool GameCubeMicState::IsSampleOn() const
 {
-  m_stream_buffer.clear();
-  m_samples_avail = 0;
-  m_stream_wpos = 0;
-  m_stream_rpos = 0;
-
-#ifdef _WIN32
-  if (!m_coinit_success)
-    return;
-  m_work_queue.PushBlocking([this] {
-#endif
-    m_cubeb_ctx = CubebUtils::GetContext();
-#ifdef _WIN32
-  });
-#endif
+  return status.is_active;
 }
 
-void CEXIMic::StreamTerminate()
+bool GameCubeMicState::IsMuted() const
 {
-  StreamStop();
+  return false;  // Not applicable
+}
 
-  if (m_cubeb_ctx)
+u32 GameCubeMicState::GetDefaultSamplingRate() const
+{
+  return DEFAULT_SAMPLING_RATE << status.sample_rate;
+}
+
+u32 GameCubeMicState::GetSampleRate() const
+{
+  return DEFAULT_SAMPLING_RATE << status.sample_rate;
+}
+
+u32 GameCubeMicState::GetBufferSize() const
+{
+  return RING_BASE << status.buff_size;
+}
+
+u32 GameCubeMicState::GetBufferSizeSamples() const
+{
+  return GetBufferSize() / SAMPLE_SIZE;
+}
+
+namespace
+{
+class MicrophoneGameCube : public AudioCommon::Microphone
+{
+public:
+  explicit MicrophoneGameCube(const GameCubeMicState& sampler)
+      : Microphone(sampler, "GameCube Microphone"), m_sampler(sampler),
+        m_buff_size_samples(sampler.GetBufferSizeSamples())
   {
-#ifdef _WIN32
-    if (!m_coinit_success)
-      return;
-    m_work_queue.PushBlocking([this] {
-#endif
-      m_cubeb_ctx.reset();
-#ifdef _WIN32
-    });
-#endif
-  }
-}
-
-static void state_callback(cubeb_stream* stream, void* user_data, cubeb_state state)
-{
-}
-
-long CEXIMic::DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
-                           void* /*output_buffer*/, long nframes)
-{
-  CEXIMic* mic = static_cast<CEXIMic*>(user_data);
-
-  std::lock_guard lk(mic->m_ring_lock);
-
-  const s16* buff_in = static_cast<const s16*>(input_buffer);
-  for (long i = 0; i < nframes; i++)
-  {
-    mic->m_stream_buffer[mic->m_stream_wpos] = buff_in[i];
-    mic->m_stream_wpos = (mic->m_stream_wpos + 1) % mic->m_stream_size;
   }
 
-  mic->m_samples_avail += nframes;
-  if (mic->m_samples_avail > mic->m_stream_size)
+  bool GetOverflowBit() { return std::exchange(m_overflow_bit_set, false); }
+
+private:
+#ifdef HAVE_CUBEB
+  std::string GetInputDeviceId() const override { return {}; }
+  std::string GetCubebStreamName() const override { return "Dolphin Emulated GameCube Microphone"; }
+  s16 GetVolumeModifier() const override { return 0; }
+  bool AreSamplesByteSwapped() const override { return true; }
+  void OnOverflow() override
   {
-    mic->m_samples_avail = 0;
-    mic->m_status.buff_ovrflw = 1;
+    m_samples_avail = 0;
+    m_overflow_bit_set = true;
   }
-
-  return nframes;
-}
-
-void CEXIMic::StreamStart()
-{
-  if (!m_cubeb_ctx)
-    return;
-
-#ifdef _WIN32
-  if (!m_coinit_success)
-    return;
-  m_work_queue.PushBlocking([this] {
 #endif
-    // Open stream with current parameters
-    m_stream_size = m_buff_size_samples * 500;
-    m_stream_buffer.reset(m_stream_size);
 
-    cubeb_stream_params params{};
-    params.format = CUBEB_SAMPLE_S16LE;
-    params.rate = m_sample_rate;
-    params.channels = 1;
-    params.layout = CUBEB_LAYOUT_MONO;
+  bool IsMicrophoneMuted() const override { return false; }
+  u32 GetBufferSizeSamples() const override { return m_buff_size_samples; }
+  u32 GetStreamSize() const override { return m_buff_size_samples * 500; }
 
-    u32 minimum_latency;
-    if (cubeb_get_min_latency(m_cubeb_ctx.get(), &params, &minimum_latency) != CUBEB_OK)
-    {
-      WARN_LOG_FMT(EXPANSIONINTERFACE, "Error getting minimum latency");
-    }
-
-    if (cubeb_stream_init(m_cubeb_ctx.get(), &m_cubeb_stream,
-                          "Dolphin Emulated GameCube Microphone", nullptr, &params, nullptr,
-                          nullptr, std::max<u32>(m_buff_size_samples, minimum_latency),
-                          DataCallback, state_callback, this) != CUBEB_OK)
-    {
-      ERROR_LOG_FMT(EXPANSIONINTERFACE, "Error initializing cubeb stream");
-      return;
-    }
-
-    if (cubeb_stream_start(m_cubeb_stream) != CUBEB_OK)
-    {
-      ERROR_LOG_FMT(EXPANSIONINTERFACE, "Error starting cubeb stream");
-      return;
-    }
-
-    INFO_LOG_FMT(EXPANSIONINTERFACE, "started cubeb stream");
-#ifdef _WIN32
-  });
-#endif
-}
-
-void CEXIMic::StreamStop()
-{
-  if (m_cubeb_stream)
-  {
-#ifdef _WIN32
-    m_work_queue.PushBlocking([this] {
-#endif
-      if (cubeb_stream_stop(m_cubeb_stream) != CUBEB_OK)
-        ERROR_LOG_FMT(EXPANSIONINTERFACE, "Error stopping cubeb stream");
-      cubeb_stream_destroy(m_cubeb_stream);
-      m_cubeb_stream = nullptr;
-#ifdef _WIN32
-    });
-#endif
-  }
-
-  m_samples_avail = 0;
-  m_stream_wpos = 0;
-  m_stream_rpos = 0;
-
-  m_stream_buffer.clear();
-}
-
-void CEXIMic::StreamReadOne()
-{
-  std::lock_guard lk(m_ring_lock);
-
-  if (m_samples_avail >= m_buff_size_samples)
-  {
-    s16* last_buffer = &m_stream_buffer[m_stream_rpos];
-    std::memcpy(m_ring_buffer.data(), last_buffer, m_buff_size);
-
-    m_samples_avail -= m_buff_size_samples;
-
-    m_stream_rpos += m_buff_size_samples;
-    m_stream_rpos %= m_stream_size;
-  }
-}
+  const GameCubeMicState& m_sampler;
+  const u32 m_buff_size_samples;
+  bool m_overflow_bit_set = false;
+};
+}  // namespace
 
 // EXI Mic Device
 // This works by opening and starting an input stream when the is_active
@@ -182,39 +99,13 @@ void CEXIMic::StreamReadOne()
 // buffer size settings. When the console handles the interrupt, it will send
 // cmdGetBuffer, which is when we actually read data from a buffer filled
 // in the background.
-CEXIMic::CEXIMic(Core::System& system, int index)
-    : IEXIDevice(system), m_slot(index)
-#ifdef _WIN32
-      ,
-      m_work_queue("Mic Worker")
-#endif
+CEXIMic::CEXIMic(Core::System& system, int index) : IEXIDevice(system), m_slot(index)
 {
-#ifdef _WIN32
-  m_work_queue.PushBlocking([this] {
-    auto result = ::CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
-    m_coinit_success = result == S_OK;
-    m_should_couninit = result == S_OK || result == S_FALSE;
-  });
-#endif
-
-  StreamInit();
+  m_microphone = std::make_unique<MicrophoneGameCube>(m_sampler);
+  m_microphone->Initialize();
 }
 
-CEXIMic::~CEXIMic()
-{
-  StreamTerminate();
-
-#ifdef _WIN32
-  if (m_should_couninit)
-  {
-    m_work_queue.PushBlocking([this] {
-      m_should_couninit = false;
-      CoUninitialize();
-    });
-  }
-  m_coinit_success = false;
-#endif
-}
+CEXIMic::~CEXIMic() = default;
 
 bool CEXIMic::IsPresent() const
 {
@@ -242,7 +133,7 @@ bool CEXIMic::IsInterruptSet()
   if (m_next_int_ticks == 0 || m_system.GetCoreTiming().GetTicks() < m_next_int_ticks)
     return false;
 
-  if (m_status.is_active)
+  if (m_sampler.IsSampleOn())
     UpdateNextInterruptTicks();
   else
     m_next_int_ticks = 0;
@@ -274,54 +165,66 @@ void CEXIMic::TransferByte(u8& byte)
     break;
 
   case cmdGetStatus:
-    if (pos >= sizeof(m_status))
+    if (pos >= sizeof(m_sampler.status))
     {
       ERROR_LOG_FMT(EXPANSIONINTERFACE, "GetStatus command will overflow, pos={}", pos);
       break;
     }
     if (pos == 0)
-      m_status.button = Pad::GetMicButton(m_slot);
+    {
+      m_sampler.status.button = Pad::GetMicButton(m_slot);
+      if (m_microphone && static_cast<MicrophoneGameCube*>(m_microphone.get())->GetOverflowBit())
+      {
+        m_sampler.status.buff_ovrflw = 1;
+      }
+    }
 
-    byte = Common::BitCastPtr<u8>(&m_status)[pos ^ 1];
+    byte = Common::BitCastPtr<u8>(&m_sampler.status)[pos ^ 1];
 
     if (pos == 1)
-      m_status.buff_ovrflw = 0;
+      m_sampler.status.buff_ovrflw = 0;
     break;
 
   case cmdSetStatus:
   {
-    if (pos >= sizeof(m_status))
+    if (pos >= sizeof(m_sampler.status))
     {
       ERROR_LOG_FMT(EXPANSIONINTERFACE, "SetStatus command will overflow, pos={}", pos);
       break;
     }
-    const bool was_active = m_status.is_active;
-    Common::BitCastPtr<u8>(&m_status)[pos ^ 1] = byte;
+    const bool was_active = m_sampler.IsSampleOn();
+    Common::BitCastPtr<u8>(&m_sampler.status)[pos ^ 1] = byte;
 
     // safe to do since these can only be entered if both bytes of status have been written
-    if (!was_active && m_status.is_active)
+    if (!was_active && m_sampler.IsSampleOn())
     {
-      m_sample_rate = RATE_BASE << m_status.sample_rate;
-      m_buff_size = RING_BASE << m_status.buff_size;
-      m_buff_size_samples = m_buff_size / SAMPLE_SIZE;
+      m_sample_rate = m_sampler.GetSampleRate();
+      m_buff_size = m_sampler.GetBufferSize();
+      m_buff_size_samples = m_sampler.GetBufferSizeSamples();
 
       UpdateNextInterruptTicks();
 
-      StreamStart();
+      INFO_LOG_FMT(EXPANSIONINTERFACE, "Microphone sampling on (rate={}, samples={})",
+                   m_sample_rate, m_buff_size_samples);
+      m_microphone = std::make_unique<MicrophoneGameCube>(m_sampler);
+      m_microphone->Initialize();
     }
-    else if (was_active && !m_status.is_active)
+    else if (was_active && !m_sampler.IsSampleOn())
     {
-      StreamStop();
+      // If IsSampleOn() is false the DataCallback will skip frames.
+      //
+      // TODO: Is it worth to stop and destroy the stream each time?
+      m_microphone.reset();
     }
   }
   break;
 
   case cmdGetBuffer:
   {
-    if (m_ring_pos == 0)
-      StreamReadOne();
+    if (m_ring_pos == 0 && m_microphone)
+      m_microphone->ReadIntoBuffer(m_ring_buffer.data(), m_buff_size);
 
-    byte = m_ring_buffer[m_ring_pos ^ 1];
+    byte = m_ring_buffer[m_ring_pos];
     m_ring_pos = (m_ring_pos + 1) % m_buff_size;
   }
   break;

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -186,17 +186,6 @@ CEXIMic::CEXIMic(Core::System& system, int index)
       m_work_queue("Mic Worker")
 #endif
 {
-  m_position = 0;
-  command = 0;
-
-  sample_rate = RATE_BASE;
-  buff_size = RING_BASE;
-  buff_size_samples = buff_size / SAMPLE_SIZE;
-
-  ring_pos = 0;
-
-  next_int_ticks = 0;
-
 #ifdef _WIN32
   m_work_queue.PushBlocking([this] {
     auto result = ::CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -232,7 +232,8 @@ void CEXIMic::SetCS(int cs)
 
 void CEXIMic::UpdateNextInterruptTicks()
 {
-  int diff = (m_system.GetSystemTimers().GetTicksPerSecond() / m_sample_rate) * m_buff_size_samples;
+  const int diff =
+      (m_system.GetSystemTimers().GetTicksPerSecond() / m_sample_rate) * m_buff_size_samples;
   m_next_int_ticks = m_system.GetCoreTiming().GetTicks() + diff;
   m_system.GetExpansionInterface().ScheduleUpdateInterrupts(CoreTiming::FromThread::CPU, diff);
 }
@@ -264,7 +265,7 @@ void CEXIMic::TransferByte(u8& byte)
     return;
   }
 
-  int pos = m_position - 1;
+  const int pos = m_position - 1;
 
   switch (m_command)
   {
@@ -284,11 +285,11 @@ void CEXIMic::TransferByte(u8& byte)
 
   case cmdSetStatus:
   {
-    bool wasactive = m_status.is_active;
+    const bool was_active = m_status.is_active;
     Common::BitCastPtr<u8>(&m_status)[pos ^ 1] = byte;
 
     // safe to do since these can only be entered if both bytes of status have been written
-    if (!wasactive && m_status.is_active)
+    if (!was_active && m_status.is_active)
     {
       m_sample_rate = RATE_BASE << m_status.sample_rate;
       m_buff_size = RING_BASE << m_status.buff_size;
@@ -298,7 +299,7 @@ void CEXIMic::TransferByte(u8& byte)
 
       StreamStart();
     }
-    else if (wasactive && !m_status.is_active)
+    else if (was_active && !m_status.is_active)
     {
       StreamStop();
     }

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -179,9 +179,6 @@ void CEXIMic::StreamReadOne()
 // buffer size settings. When the console handles the interrupt, it will send
 // cmdGetBuffer, which is when we actually read data from a buffer filled
 // in the background.
-
-u8 const CEXIMic::exi_id[] = {0, 0x0a, 0, 0, 0};
-
 CEXIMic::CEXIMic(Core::System& system, int index)
     : IEXIDevice(system), slot(index)
 #ifdef _WIN32
@@ -192,9 +189,9 @@ CEXIMic::CEXIMic(Core::System& system, int index)
   m_position = 0;
   command = 0;
 
-  sample_rate = rate_base;
-  buff_size = ring_base;
-  buff_size_samples = buff_size / sample_size;
+  sample_rate = RATE_BASE;
+  buff_size = RING_BASE;
+  buff_size_samples = buff_size / SAMPLE_SIZE;
 
   ring_pos = 0;
   std::memset(ring_buffer, 0, sizeof(ring_buffer));
@@ -280,7 +277,7 @@ void CEXIMic::TransferByte(u8& byte)
   switch (command)
   {
   case cmdID:
-    byte = exi_id[pos];
+    byte = EXI_ID[pos];
     break;
 
   case cmdGetStatus:
@@ -301,9 +298,9 @@ void CEXIMic::TransferByte(u8& byte)
     // safe to do since these can only be entered if both bytes of status have been written
     if (!wasactive && status.is_active)
     {
-      sample_rate = rate_base << status.sample_rate;
-      buff_size = ring_base << status.buff_size;
-      buff_size_samples = buff_size / sample_size;
+      sample_rate = RATE_BASE << status.sample_rate;
+      buff_size = RING_BASE << status.buff_size;
+      buff_size_samples = buff_size / SAMPLE_SIZE;
 
       UpdateNextInterruptTicks();
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -10,6 +10,7 @@
 #include <cubeb/cubeb.h>
 
 #include "AudioCommon/CubebUtils.h"
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
@@ -190,7 +191,6 @@ CEXIMic::CEXIMic(Core::System& system, int index)
 {
   m_position = 0;
   command = 0;
-  status.U16 = 0;
 
   sample_rate = rate_base;
   buff_size = ring_base;
@@ -287,7 +287,7 @@ void CEXIMic::TransferByte(u8& byte)
     if (pos == 0)
       status.button = Pad::GetMicButton(slot);
 
-    byte = status.U8[pos ^ 1];
+    byte = Common::BitCastPtr<u8>(&status)[pos ^ 1];
 
     if (pos == 1)
       status.buff_ovrflw = 0;
@@ -296,7 +296,7 @@ void CEXIMic::TransferByte(u8& byte)
   case cmdSetStatus:
   {
     bool wasactive = status.is_active;
-    status.U8[pos ^ 1] = byte;
+    Common::BitCastPtr<u8>(&status)[pos ^ 1] = byte;
 
     // safe to do since these can only be entered if both bytes of status have been written
     if (!wasactive && status.is_active)

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -28,7 +28,7 @@ namespace ExpansionInterface
 {
 void CEXIMic::StreamInit()
 {
-  m_stream_buffer = nullptr;
+  m_stream_buffer.clear();
   m_samples_avail = 0;
   m_stream_wpos = 0;
   m_stream_rpos = 0;
@@ -102,7 +102,7 @@ void CEXIMic::StreamStart()
 #endif
     // Open stream with current parameters
     m_stream_size = m_buff_size_samples * 500;
-    m_stream_buffer = new s16[m_stream_size];
+    m_stream_buffer.reset(m_stream_size);
 
     cubeb_stream_params params{};
     params.format = CUBEB_SAMPLE_S16LE;
@@ -157,8 +157,7 @@ void CEXIMic::StreamStop()
   m_stream_wpos = 0;
   m_stream_rpos = 0;
 
-  delete[] m_stream_buffer;
-  m_stream_buffer = nullptr;
+  m_stream_buffer.clear();
 }
 
 void CEXIMic::StreamReadOne()

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -240,19 +240,15 @@ void CEXIMic::UpdateNextInterruptTicks()
 
 bool CEXIMic::IsInterruptSet()
 {
-  if (m_next_int_ticks && m_system.GetCoreTiming().GetTicks() >= m_next_int_ticks)
-  {
-    if (m_status.is_active)
-      UpdateNextInterruptTicks();
-    else
-      m_next_int_ticks = 0;
-
-    return true;
-  }
-  else
-  {
+  if (m_next_int_ticks == 0 || m_system.GetCoreTiming().GetTicks() < m_next_int_ticks)
     return false;
-  }
+
+  if (m_status.is_active)
+    UpdateNextInterruptTicks();
+  else
+    m_next_int_ticks = 0;
+
+  return true;
 }
 
 void CEXIMic::TransferByte(u8& byte)
@@ -265,15 +261,25 @@ void CEXIMic::TransferByte(u8& byte)
     return;
   }
 
-  const int pos = m_position - 1;
+  const u32 pos = m_position - 1;
 
   switch (m_command)
   {
   case cmdID:
+    if (pos >= EXI_ID.size())
+    {
+      ERROR_LOG_FMT(EXPANSIONINTERFACE, "ID command will overflow, pos={}", pos);
+      break;
+    }
     byte = EXI_ID[pos];
     break;
 
   case cmdGetStatus:
+    if (pos >= sizeof(m_status))
+    {
+      ERROR_LOG_FMT(EXPANSIONINTERFACE, "GetStatus command will overflow, pos={}", pos);
+      break;
+    }
     if (pos == 0)
       m_status.button = Pad::GetMicButton(m_slot);
 
@@ -285,6 +291,11 @@ void CEXIMic::TransferByte(u8& byte)
 
   case cmdSetStatus:
   {
+    if (pos >= sizeof(m_status))
+    {
+      ERROR_LOG_FMT(EXPANSIONINTERFACE, "SetStatus command will overflow, pos={}", pos);
+      break;
+    }
     const bool was_active = m_status.is_active;
     Common::BitCastPtr<u8>(&m_status)[pos ^ 1] = byte;
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -164,7 +164,7 @@ void CEXIMic::StreamReadOne()
   if (samples_avail >= buff_size_samples)
   {
     s16* last_buffer = &stream_buffer[stream_rpos];
-    std::memcpy(ring_buffer, last_buffer, buff_size);
+    std::memcpy(ring_buffer.data(), last_buffer, buff_size);
 
     samples_avail -= buff_size_samples;
 
@@ -194,7 +194,6 @@ CEXIMic::CEXIMic(Core::System& system, int index)
   buff_size_samples = buff_size / SAMPLE_SIZE;
 
   ring_pos = 0;
-  std::memset(ring_buffer, 0, sizeof(ring_buffer));
 
   next_int_ticks = 0;
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -26,9 +26,9 @@ public:
 
 private:
   static constexpr std::array<u8, 5> EXI_ID{0, 0x0a, 0, 0, 0};
-  static constexpr int SAMPLE_SIZE = sizeof(s16);
-  static constexpr int RATE_BASE = 11025;
-  static constexpr int RING_BASE = 32;
+  static constexpr u32 SAMPLE_SIZE = sizeof(s16);
+  static constexpr u32 RATE_BASE = 11025;
+  static constexpr u32 RING_BASE = 32;
 
   enum
   {
@@ -68,7 +68,7 @@ private:
   void StreamReadOne();
 
   // 64 is the max size, can be 16 or 32 as well
-  int m_ring_pos = 0;
+  std::size_t m_ring_pos = 0;
   std::array<u8, 64 * SAMPLE_SIZE> m_ring_buffer{};
 
   // 0 to disable interrupts, else it will be checked against current CPU ticks
@@ -85,17 +85,17 @@ private:
   std::mutex m_ring_lock;
 
   // status bits converted to nice numbers
-  int m_sample_rate = RATE_BASE;
-  int m_buff_size = RING_BASE;
-  int m_buff_size_samples = m_buff_size / SAMPLE_SIZE;
+  u32 m_sample_rate = RATE_BASE;
+  u32 m_buff_size = RING_BASE;
+  u32 m_buff_size_samples = m_buff_size / SAMPLE_SIZE;
 
   // Arbitrarily small ringbuffer used by audio input backend in order to
   // keep delay tolerable
   s16* m_stream_buffer;
-  int m_stream_size;
-  int m_stream_wpos;
-  int m_stream_rpos;
-  int m_samples_avail;
+  u32 m_stream_size;
+  u32 m_stream_wpos;
+  u32 m_stream_rpos;
+  u32 m_samples_avail;
 
 #ifdef _WIN32
   Common::AsyncWorkThread m_work_queue;

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -42,22 +42,17 @@ private:
 
   u32 m_position;
   int command;
-  union UStatus
+  struct Status
   {
-    u16 U16;
-    u8 U8[2];
-    struct
-    {
-      u16 out : 4;          // MICSet/GetOut...???
-      u16 id : 1;           // Used for MICGetDeviceID (always 0)
-      u16 button_unk : 3;   // Button bits which appear unused
-      u16 button : 1;       // The actual button on the mic
-      u16 buff_ovrflw : 1;  // Ring buffer wrote over bytes which weren't read by console
-      u16 gain : 1;         // Gain: 0dB or 15dB
-      u16 sample_rate : 2;  // Sample rate, 00-11025, 01-22050, 10-44100, 11-??
-      u16 buff_size : 2;    // Ring buffer size in bytes, 00-32, 01-64, 10-128, 11-???
-      u16 is_active : 1;    // If we are sampling or not
-    };
+    u16 out : 4;          // MICSet/GetOut...???
+    u16 id : 1;           // Used for MICGetDeviceID (always 0)
+    u16 button_unk : 3;   // Button bits which appear unused
+    u16 button : 1;       // The actual button on the mic
+    u16 buff_ovrflw : 1;  // Ring buffer wrote over bytes which weren't read by console
+    u16 gain : 1;         // Gain: 0dB or 15dB
+    u16 sample_rate : 2;  // Sample rate, 00-11025, 01-22050, 10-44100, 11-??
+    u16 buff_size : 2;    // Ring buffer size in bytes, 00-32, 01-64, 10-128, 11-???
+    u16 is_active : 1;    // If we are sampling or not
   };
 
   static long DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
@@ -84,7 +79,7 @@ private:
   std::shared_ptr<cubeb> m_cubeb_ctx = nullptr;
   cubeb_stream* m_cubeb_stream = nullptr;
 
-  UStatus status;
+  Status status{};
 
   std::mutex ring_lock;
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -24,10 +24,10 @@ public:
   bool IsPresent() const override;
 
 private:
-  static u8 const exi_id[];
-  static int const sample_size = sizeof(s16);
-  static int const rate_base = 11025;
-  static int const ring_base = 32;
+  static constexpr u8 EXI_ID[] = {0, 0x0a, 0, 0, 0};
+  static constexpr int SAMPLE_SIZE = sizeof(s16);
+  static constexpr int RATE_BASE = 11025;
+  static constexpr int RING_BASE = 32;
 
   enum
   {
@@ -68,7 +68,7 @@ private:
 
   // 64 is the max size, can be 16 or 32 as well
   int ring_pos;
-  u8 ring_buffer[64 * sample_size];
+  u8 ring_buffer[64 * SAMPLE_SIZE];
 
   // 0 to disable interrupts, else it will be checked against current CPU ticks
   // to determine if interrupt should be raised

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -39,10 +39,10 @@ private:
     cmdReset = 0xFF,
   };
 
-  int slot;
+  int m_slot;
 
   u32 m_position = 0;
-  int command = 0;
+  int m_command = 0;
   struct Status
   {
     u16 out : 4;          // MICSet/GetOut...???
@@ -68,34 +68,34 @@ private:
   void StreamReadOne();
 
   // 64 is the max size, can be 16 or 32 as well
-  int ring_pos = 0;
-  std::array<u8, 64 * SAMPLE_SIZE> ring_buffer{};
+  int m_ring_pos = 0;
+  std::array<u8, 64 * SAMPLE_SIZE> m_ring_buffer{};
 
   // 0 to disable interrupts, else it will be checked against current CPU ticks
   // to determine if interrupt should be raised
-  u64 next_int_ticks = 0;
+  u64 m_next_int_ticks = 0;
   void UpdateNextInterruptTicks();
 
   // Streaming input interface
   std::shared_ptr<cubeb> m_cubeb_ctx = nullptr;
   cubeb_stream* m_cubeb_stream = nullptr;
 
-  Status status{};
+  Status m_status{};
 
-  std::mutex ring_lock;
+  std::mutex m_ring_lock;
 
   // status bits converted to nice numbers
-  int sample_rate = RATE_BASE;
-  int buff_size = RING_BASE;
-  int buff_size_samples = buff_size / SAMPLE_SIZE;
+  int m_sample_rate = RATE_BASE;
+  int m_buff_size = RING_BASE;
+  int m_buff_size_samples = m_buff_size / SAMPLE_SIZE;
 
   // Arbitrarily small ringbuffer used by audio input backend in order to
   // keep delay tolerable
-  s16* stream_buffer;
-  int stream_size;
-  int stream_wpos;
-  int stream_rpos;
-  int samples_avail;
+  s16* m_stream_buffer;
+  int m_stream_size;
+  int m_stream_wpos;
+  int m_stream_rpos;
+  int m_samples_avail;
 
 #ifdef _WIN32
   Common::AsyncWorkThread m_work_queue;

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <mutex>
 
+#include "AudioCommon/Microphone.h"
 #include "Common/Buffer.h"
 #include "Common/CommonTypes.h"
 #include "Common/WorkQueueThread.h"
@@ -16,6 +17,37 @@ struct cubeb_stream;
 
 namespace ExpansionInterface
 {
+class GameCubeMicState final : public AudioCommon::MicrophoneState
+{
+public:
+  static constexpr u32 DEFAULT_SAMPLING_RATE = 11025;
+  static constexpr u32 RING_BASE = 32;
+  static constexpr u32 SAMPLE_SIZE = sizeof(s16);
+
+  bool IsSampleOn() const override;
+  bool IsMuted() const override;
+  u32 GetDefaultSamplingRate() const override;
+
+  u32 GetSampleRate() const;
+  u32 GetBufferSize() const;
+  u32 GetBufferSizeSamples() const;
+
+  struct Status
+  {
+    u16 out : 4;          // MICSet/GetOut...???
+    u16 id : 1;           // Used for MICGetDeviceID (always 0)
+    u16 button_unk : 3;   // Button bits which appear unused
+    u16 button : 1;       // The actual button on the mic
+    u16 buff_ovrflw : 1;  // Ring buffer wrote over bytes which weren't read by console
+    u16 gain : 1;         // Gain: 0dB or 15dB
+    u16 sample_rate : 2;  // Sample rate, 00-11025, 01-22050, 10-44100, 11-??
+    u16 buff_size : 2;    // Ring buffer size in bytes, 00-32, 01-64, 10-128, 11-???
+    u16 is_active : 1;    // If we are sampling or not
+  };
+
+  Status status{};
+};
+
 class CEXIMic : public IEXIDevice
 {
 public:
@@ -27,9 +59,6 @@ public:
 
 private:
   static constexpr std::array<u8, 5> EXI_ID{0, 0x0a, 0, 0, 0};
-  static constexpr u32 SAMPLE_SIZE = sizeof(s16);
-  static constexpr u32 RATE_BASE = 11025;
-  static constexpr u32 RING_BASE = 32;
 
   enum
   {
@@ -44,33 +73,15 @@ private:
 
   u32 m_position = 0;
   int m_command = 0;
-  struct Status
-  {
-    u16 out : 4;          // MICSet/GetOut...???
-    u16 id : 1;           // Used for MICGetDeviceID (always 0)
-    u16 button_unk : 3;   // Button bits which appear unused
-    u16 button : 1;       // The actual button on the mic
-    u16 buff_ovrflw : 1;  // Ring buffer wrote over bytes which weren't read by console
-    u16 gain : 1;         // Gain: 0dB or 15dB
-    u16 sample_rate : 2;  // Sample rate, 00-11025, 01-22050, 10-44100, 11-??
-    u16 buff_size : 2;    // Ring buffer size in bytes, 00-32, 01-64, 10-128, 11-???
-    u16 is_active : 1;    // If we are sampling or not
-  };
 
   static long DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
                            void* output_buffer, long nframes);
 
   void TransferByte(u8& byte) override;
 
-  void StreamInit();
-  void StreamTerminate();
-  void StreamStart();
-  void StreamStop();
-  void StreamReadOne();
-
   // 64 is the max size, can be 16 or 32 as well
   std::size_t m_ring_pos = 0;
-  std::array<u8, 64 * SAMPLE_SIZE> m_ring_buffer{};
+  std::array<u8, 64 * GameCubeMicState::SAMPLE_SIZE> m_ring_buffer{};
 
   // 0 to disable interrupts, else it will be checked against current CPU ticks
   // to determine if interrupt should be raised
@@ -81,27 +92,16 @@ private:
   std::shared_ptr<cubeb> m_cubeb_ctx = nullptr;
   cubeb_stream* m_cubeb_stream = nullptr;
 
-  Status m_status{};
-
   std::mutex m_ring_lock;
 
   // status bits converted to nice numbers
-  u32 m_sample_rate = RATE_BASE;
-  u32 m_buff_size = RING_BASE;
-  u32 m_buff_size_samples = m_buff_size / SAMPLE_SIZE;
+  u32 m_sample_rate = GameCubeMicState::DEFAULT_SAMPLING_RATE;
+  u32 m_buff_size = GameCubeMicState::RING_BASE;
+  u32 m_buff_size_samples = m_buff_size / GameCubeMicState::SAMPLE_SIZE;
 
   // Arbitrarily small ringbuffer used by audio input backend in order to
   // keep delay tolerable
-  Common::UniqueBuffer<s16> m_stream_buffer;
-  u32 m_stream_size;
-  u32 m_stream_wpos;
-  u32 m_stream_rpos;
-  u32 m_samples_avail;
-
-#ifdef _WIN32
-  Common::AsyncWorkThread m_work_queue;
-  bool m_coinit_success = false;
-  bool m_should_couninit = false;
-#endif
+  GameCubeMicState m_sampler{};
+  std::unique_ptr<AudioCommon::Microphone> m_microphone{};
 };
 }  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <mutex>
 
 #include "Common/CommonTypes.h"
@@ -24,7 +25,7 @@ public:
   bool IsPresent() const override;
 
 private:
-  static constexpr u8 EXI_ID[] = {0, 0x0a, 0, 0, 0};
+  static constexpr std::array<u8, 5> EXI_ID{0, 0x0a, 0, 0, 0};
   static constexpr int SAMPLE_SIZE = sizeof(s16);
   static constexpr int RATE_BASE = 11025;
   static constexpr int RING_BASE = 32;
@@ -68,7 +69,7 @@ private:
 
   // 64 is the max size, can be 16 or 32 as well
   int ring_pos;
-  u8 ring_buffer[64 * SAMPLE_SIZE];
+  std::array<u8, 64 * SAMPLE_SIZE> ring_buffer{};
 
   // 0 to disable interrupts, else it will be checked against current CPU ticks
   // to determine if interrupt should be raised

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -41,8 +41,8 @@ private:
 
   int slot;
 
-  u32 m_position;
-  int command;
+  u32 m_position = 0;
+  int command = 0;
   struct Status
   {
     u16 out : 4;          // MICSet/GetOut...???
@@ -68,12 +68,12 @@ private:
   void StreamReadOne();
 
   // 64 is the max size, can be 16 or 32 as well
-  int ring_pos;
+  int ring_pos = 0;
   std::array<u8, 64 * SAMPLE_SIZE> ring_buffer{};
 
   // 0 to disable interrupts, else it will be checked against current CPU ticks
   // to determine if interrupt should be raised
-  u64 next_int_ticks;
+  u64 next_int_ticks = 0;
   void UpdateNextInterruptTicks();
 
   // Streaming input interface
@@ -85,9 +85,9 @@ private:
   std::mutex ring_lock;
 
   // status bits converted to nice numbers
-  int sample_rate;
-  int buff_size;
-  int buff_size_samples;
+  int sample_rate = RATE_BASE;
+  int buff_size = RING_BASE;
+  int buff_size_samples = buff_size / SAMPLE_SIZE;
 
   // Arbitrarily small ringbuffer used by audio input backend in order to
   // keep delay tolerable

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <mutex>
 
+#include "Common/Buffer.h"
 #include "Common/CommonTypes.h"
 #include "Common/WorkQueueThread.h"
 #include "Core/HW/EXI/EXI_Device.h"
@@ -91,7 +92,7 @@ private:
 
   // Arbitrarily small ringbuffer used by audio input backend in order to
   // keep delay tolerable
-  s16* m_stream_buffer;
+  Common::UniqueBuffer<s16> m_stream_buffer;
   u32 m_stream_size;
   u32 m_stream_wpos;
   u32 m_stream_rpos;

--- a/Source/Core/Core/IOS/USB/Emulated/LogitechMic.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/LogitechMic.cpp
@@ -64,7 +64,7 @@ u32 LogitechMicState::GetDefaultSamplingRate() const
 
 namespace
 {
-class MicrophoneLogitech final : public Microphone
+class MicrophoneLogitech final : public AudioCommon::Microphone
 {
 public:
   explicit MicrophoneLogitech(const LogitechMicState& sampler, u8 index)

--- a/Source/Core/Core/IOS/USB/Emulated/LogitechMic.h
+++ b/Source/Core/Core/IOS/USB/Emulated/LogitechMic.h
@@ -7,14 +7,14 @@
 #include <memory>
 #include <vector>
 
+#include "AudioCommon/Microphone.h"
 #include "Common/CommonTypes.h"
 #include "Core/IOS/USB/Common.h"
-#include "Core/IOS/USB/Emulated/Microphone.h"
 
 namespace IOS::HLE::USB
 {
 
-class LogitechMicState final : public MicrophoneState
+class LogitechMicState final : public AudioCommon::MicrophoneState
 {
 public:
   // Use atomic for members concurrently used by the data callback
@@ -61,6 +61,6 @@ private:
   u8 m_index = 0;
   u8 m_active_interface = 0;
   bool m_device_attached = false;
-  std::unique_ptr<Microphone> m_microphone{};
+  std::unique_ptr<AudioCommon::Microphone> m_microphone{};
 };
 }  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/Emulated/WiiSpeak.cpp
+++ b/Source/Core/Core/IOS/USB/Emulated/WiiSpeak.cpp
@@ -28,7 +28,7 @@ u32 WiiSpeakState::GetDefaultSamplingRate() const
 
 namespace
 {
-class MicrophoneWiiSpeak final : public Microphone
+class MicrophoneWiiSpeak final : public AudioCommon::Microphone
 {
 public:
   explicit MicrophoneWiiSpeak(const WiiSpeakState& sampler)

--- a/Source/Core/Core/IOS/USB/Emulated/WiiSpeak.h
+++ b/Source/Core/Core/IOS/USB/Emulated/WiiSpeak.h
@@ -7,13 +7,13 @@
 #include <memory>
 #include <vector>
 
+#include "AudioCommon/Microphone.h"
 #include "Common/CommonTypes.h"
 #include "Core/IOS/USB/Common.h"
-#include "Core/IOS/USB/Emulated/Microphone.h"
 
 namespace IOS::HLE::USB
 {
-class WiiSpeakState final : public MicrophoneState
+class WiiSpeakState final : public AudioCommon::MicrophoneState
 {
 public:
   // Use atomic for members concurrently used by the data callback
@@ -89,7 +89,7 @@ private:
   u8 m_active_interface = 0;
   bool m_device_attached = false;
   bool init = false;
-  std::unique_ptr<Microphone> m_microphone{};
+  std::unique_ptr<AudioCommon::Microphone> m_microphone{};
   const DeviceDescriptor m_device_descriptor{0x12,  0x1,    0x200,  0,   0,   0,   0x10,
                                              0x57E, 0x0308, 0x0214, 0x1, 0x2, 0x0, 0x1};
   const std::vector<ConfigDescriptor> m_config_descriptor{


### PR DESCRIPTION
This PR replaces https://github.com/dolphin-emu/dolphin/pull/14203 and is based on https://github.com/dolphin-emu/dolphin/pull/14772. It deduplicates the Wii and GameCube microphones code. I'll put it as a draft for now, as I'd like to implement some more features:
 - [x] Move the code to AudioCommon
 - [x] Refactor the GC microphone code
 - [ ] Check the GC microphone code for regressions/improvements
   * _I haven't seen nor heard regression so far_
 - [ ] Allow to configure the GC microphone device (like WiiSpeak/Logitech USB)
 - [ ] Ensure 2 GC microphones can work simultaneously

I'm able to test the following GC games:
 - [ ] Karaoke Revolution Party
    - You can hear your voice back
    - It supports 2 microphones when playing duet songs
 - [ ] Mario Party 6
 - [ ] Mario Party 7

I also have several Wii games compatible with the Wii Speak and USB microphones.

Ready to be reviewed & tested.