### PR TITLE
Mach exception thread: Fix msg alignment

### DIFF
--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -134,7 +134,7 @@ static void ExceptionThread(mach_port_t port)
 {
   Common::SetCurrentThreadName("Mach exception thread");
 #pragma pack(4)
-  struct
+  struct alignas(8)
   {
     mach_msg_header_t Head;
     NDR_record_t NDR;
@@ -147,7 +147,7 @@ static void ExceptionThread(mach_port_t port)
     mach_msg_trailer_t trailer;
   } msg_in;
 
-  struct
+  struct alignas(8)
   {
     mach_msg_header_t Head;
     NDR_record_t NDR;


### PR DESCRIPTION
`msg_in` and `msg_out` were ending up with only 4-byte alignment, which is undefined behaviour, since they contain 64-bit fields. Probably doesn't cause any issues, but it showed up in ubsan.