### PR TITLE
EmbossMap: don't zero out light when binormals are missing

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -40,16 +40,9 @@ VertexShaderUid GetVertexShaderUid()
     switch (texinfo.texgentype)
     {
     case TexGenType::EmbossMap:  // calculate tex coords into bump map
-      if ((uid_data->components & (VB_HAS_TANGENT | VB_HAS_BINORMAL)) != 0)
-      {
-        // transform the light dir into tangent space
-        texinfo.embosslightshift = xfmem.texMtxInfo[i].embosslightshift;
-        texinfo.embosssourceshift = xfmem.texMtxInfo[i].embosssourceshift;
-      }
-      else
-      {
-        texinfo.embosssourceshift = xfmem.texMtxInfo[i].embosssourceshift;
-      }
+      // transform the light dir into tangent space
+      texinfo.embosslightshift = xfmem.texMtxInfo[i].embosslightshift;
+      texinfo.embosssourceshift = xfmem.texMtxInfo[i].embosssourceshift;
       break;
     case TexGenType::Color0:
     case TexGenType::Color1:


### PR DESCRIPTION
Just pushing this for a quick FIFO CI run, I suspect this might impact RS2/RS3 which use emboss mapping with "cached binormals".