### PR TITLE
Android: Use TitleDatabase for game list

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.kt
@@ -61,13 +61,14 @@ class GameAdapter : RecyclerView.Adapter<GameViewHolder>(),
         val gameFile = mGameFiles[position]
 
         holder.apply {
+            val title = gameFile.getTitle(GameFileCacheManager.getTitleDatabase())
             if (BooleanSetting.MAIN_SHOW_GAME_TITLES.boolean) {
-                binding.textGameTitle.text = gameFile.getTitle()
+                binding.textGameTitle.text = title
                 binding.textGameTitle.visibility = View.VISIBLE
                 binding.textGameTitleInner.visibility = View.GONE
                 binding.textGameCaption.visibility = View.VISIBLE
             } else {
-                binding.textGameTitleInner.text = gameFile.getTitle()
+                binding.textGameTitleInner.text = title
                 binding.textGameTitleInner.visibility = View.VISIBLE
                 binding.textGameTitle.visibility = View.GONE
                 binding.textGameCaption.visibility = View.GONE

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.kt
@@ -48,7 +48,7 @@ class GameRowPresenter : Presenter() {
 
         holder.apply {
             imageScreenshot.setImageDrawable(null)
-            cardParent.titleText = gameFile.getTitle()
+            cardParent.titleText = gameFile.getTitle(GameFileCacheManager.getTitleDatabase())
             holder.gameFile = gameFile
 
             // Set the background color of the card

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GameDetailsDialog.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GameDetailsDialog.kt
@@ -51,7 +51,7 @@ class GameDetailsDialog : DialogFragment() {
                     textTimePlayed.visibility = View.GONE
                 }
 
-                textGameTitle.text = gameFile.getTitle()
+                textGameTitle.text = gameFile.getTitle(GameFileCacheManager.getTitleDatabase())
                 textDescription.text = gameFile.getDescription()
                 if (gameFile.getDescription().isEmpty()) {
                     textDescription.visibility = View.GONE
@@ -118,7 +118,7 @@ class GameDetailsDialog : DialogFragment() {
                     textTimePlayed.visibility = View.GONE
                 }
 
-                textGameTitle.text = gameFile.getTitle()
+                textGameTitle.text = gameFile.getTitle(GameFileCacheManager.getTitleDatabase())
                 textDescription.text = gameFile.getDescription()
                 if (gameFile.getDescription().isEmpty()) {
                     tvBinding.textDescription.visibility = View.GONE

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/netplay/ui/NetplayScreen.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/netplay/ui/NetplayScreen.kt
@@ -104,6 +104,7 @@ import org.dolphinemu.dolphinemu.features.netplay.model.Player
 import org.dolphinemu.dolphinemu.features.netplay.model.SaveTransferProgress
 import org.dolphinemu.dolphinemu.features.netplay.model.TraversalState
 import org.dolphinemu.dolphinemu.model.GameFile
+import org.dolphinemu.dolphinemu.services.GameFileCacheManager
 import org.dolphinemu.dolphinemu.ui.theme.DolphinScaffold
 import org.dolphinemu.dolphinemu.ui.theme.DolphinTheme
 import org.dolphinemu.dolphinemu.ui.theme.MenuSpacer
@@ -753,6 +754,7 @@ private fun GameGridItem(
     gameFile: GameFile,
     onClick: () -> Unit,
 ) {
+    val titleDatabase = GameFileCacheManager.getTitleDatabase()
     Card(
         onClick = onClick,
     ) {
@@ -762,7 +764,7 @@ private fun GameGridItem(
                     .data(gameFile)
                     .error(R.drawable.no_banner)
                     .build(),
-                contentDescription = gameFile.getTitle(),
+                contentDescription = gameFile.getTitle(titleDatabase),
                 contentScale = ContentScale.Crop,
                 imageLoader = CoilUtils.imageLoader,
                 modifier = Modifier
@@ -770,7 +772,7 @@ private fun GameGridItem(
                     .aspectRatio(0.7f)
             )
             Text(
-                text = gameFile.getTitle(),
+                text = gameFile.getTitle(titleDatabase),
                 style = MaterialTheme.typography.bodySmall,
                 maxLines = 2,
                 minLines = 2,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.kt
@@ -12,7 +12,7 @@ class GameFile private constructor(private val pointer: Long) {
 
     external fun getPlatform(): Int
 
-    external fun getTitle(): String
+    external fun getTitle(titleDatabase: TitleDatabase?): String
 
     external fun getDescription(): String
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/TitleDatabase.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/TitleDatabase.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.model
+
+import androidx.annotation.Keep
+
+@Keep
+class TitleDatabase private constructor(private val pointer: Long) {
+    external fun finalize()
+
+    external fun userTitleMapEquals(other: TitleDatabase?): Boolean
+
+    companion object {
+        @JvmStatic
+        external suspend fun load(): TitleDatabase
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/TitleDatabase.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/TitleDatabase.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.model
+
+import androidx.annotation.Keep
+
+@Keep
+class TitleDatabase private constructor(private val pointer: Long) {
+    external fun finalize()
+
+    external fun areUserTitleMapsEqual(other: TitleDatabase?): Boolean
+
+    companion object {
+        @JvmStatic
+        external suspend fun load(): TitleDatabase
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -14,10 +15,12 @@ import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import org.dolphinemu.dolphinemu.features.settings.model.ConfigChangedCallback
 import org.dolphinemu.dolphinemu.model.GameFile
 import org.dolphinemu.dolphinemu.model.GameFileCache
+import org.dolphinemu.dolphinemu.model.TitleDatabase
 import org.dolphinemu.dolphinemu.ui.platform.Platform
 import org.dolphinemu.dolphinemu.ui.platform.PlatformTab
 import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner
 import java.util.Arrays
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Loads game list data in the background.
@@ -25,6 +28,7 @@ import java.util.Arrays
 object GameFileCacheManager {
     private var gameFileCache: GameFileCache? = null
     private val gameFiles = MutableLiveData(emptyArray<GameFile>())
+    private var titleDatabase = AtomicReference<TitleDatabase>(null)
     private var firstLoadDone = false
     private var recursiveScanEnabled = false
 
@@ -87,6 +91,8 @@ object GameFileCacheManager {
             arrayOf(nonNullGameFile.getPath(), secondFile.getPath())
         }
     }
+
+    fun getTitleDatabase(): TitleDatabase? = titleDatabase.get()
 
     /**
      * Returns true if in the process of loading the cache for the first time.
@@ -171,13 +177,22 @@ object GameFileCacheManager {
      */
     private suspend fun load() {
         if (!firstLoadDone) {
+            val titleDatabaseJob = MainScope().async {
+                withContext(Dispatchers.IO) { TitleDatabase.load() }
+            }
+
             withContext(Dispatchers.IO) {
                 setUpAutomaticRescan()
+
                 gameFileCache!!.load()
+
+                titleDatabase.set(titleDatabaseJob.await())
+
                 if (gameFileCache!!.getSize() != 0) {
                     updateGameFileArray()
                 }
             }
+
             firstLoadDone = true
         }
 
@@ -196,16 +211,31 @@ object GameFileCacheManager {
             loadInProgress.asFlow().first { !it }
         }
 
+        val titleDatabaseJob = MainScope().async {
+            withContext(Dispatchers.IO) {
+                val newTitleDatabase = TitleDatabase.load()
+                val titleDatabaseChanged =
+                    newTitleDatabase.areUserTitleMapsEqual(titleDatabase.get())
+                if (!titleDatabaseChanged) newTitleDatabase else null
+            }
+        }
+
         withContext(Dispatchers.IO) {
             val gamePaths = GameFileCache.getAllGamePaths()
-
             val changed = gameFileCache!!.update(gamePaths)
             if (changed) {
                 updateGameFileArray()
             }
 
             val additionalMetadataChanged = gameFileCache!!.updateAdditionalMetadata()
-            if (additionalMetadataChanged) {
+
+            val newTitleDatabase = titleDatabaseJob.await()
+            val titleDatabaseChanged = newTitleDatabase != null
+            if (titleDatabaseChanged) {
+                titleDatabase.set(newTitleDatabase)
+            }
+
+            if (additionalMetadataChanged || titleDatabaseChanged) {
                 updateGameFileArray()
             }
 
@@ -219,8 +249,9 @@ object GameFileCacheManager {
 
     private fun updateGameFileArray() {
         val gameFilesTemp = gameFileCache!!.getAllGames()
+        val titleDatabase = titleDatabase.get()
         Arrays.sort(gameFilesTemp) { lhs, rhs ->
-            lhs.getTitle().compareTo(rhs.getTitle(), ignoreCase = true)
+            lhs.getTitle(titleDatabase).compareTo(rhs.getTitle(titleDatabase), ignoreCase = true)
         }
         gameFiles.postValue(gameFilesTemp)
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
@@ -4,8 +4,10 @@ package org.dolphinemu.dolphinemu.services
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
@@ -24,7 +26,6 @@ object GameFileCacheManager {
     private var gameFileCache: GameFileCache? = null
     private val gameFiles = MutableLiveData(emptyArray<GameFile>())
     private var firstLoadDone = false
-    private var runRescanAfterLoad = false
     private var recursiveScanEnabled = false
 
     private val loadInProgress = MutableLiveData(false)
@@ -181,11 +182,6 @@ object GameFileCacheManager {
         }
 
         loadInProgress.value = false
-
-        if (runRescanAfterLoad) {
-            runRescanAfterLoad = false
-            rescan()
-        }
     }
 
     /**
@@ -195,9 +191,9 @@ object GameFileCacheManager {
      * will be postponed until after load runs.
      */
     private suspend fun rescan() {
-        if (!firstLoadDone) {
-            runRescanAfterLoad = true
-            return
+        while (!firstLoadDone) {
+            // Wait until loadInProgress becomes false
+            loadInProgress.asFlow().first { !it }
         }
 
         withContext(Dispatchers.IO) {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
@@ -2,10 +2,12 @@
 
 package org.dolphinemu.dolphinemu.services
 
-import android.os.Handler
-import android.os.Looper
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import org.dolphinemu.dolphinemu.features.settings.model.ConfigChangedCallback
 import org.dolphinemu.dolphinemu.model.GameFile
@@ -14,11 +16,9 @@ import org.dolphinemu.dolphinemu.ui.platform.Platform
 import org.dolphinemu.dolphinemu.ui.platform.PlatformTab
 import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner
 import java.util.Arrays
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 /**
- * Loads game list data on a separate thread.
+ * Loads game list data in the background.
  */
 object GameFileCacheManager {
     private var gameFileCache: GameFileCache? = null
@@ -27,7 +27,6 @@ object GameFileCacheManager {
     private var runRescanAfterLoad = false
     private var recursiveScanEnabled = false
 
-    private val executor: ExecutorService = Executors.newFixedThreadPool(1)
     private val loadInProgress = MutableLiveData(false)
     private val rescanInProgress = MutableLiveData(false)
 
@@ -120,7 +119,9 @@ object GameFileCacheManager {
 
         if (!loadInProgress.value!!) {
             loadInProgress.value = true
-            AfterDirectoryInitializationRunner().runWithoutLifecycle { executor.execute(::load) }
+            AfterDirectoryInitializationRunner().runWithoutLifecycle {
+                MainScope().launch { load() }
+            }
         }
     }
 
@@ -136,7 +137,9 @@ object GameFileCacheManager {
 
         if (!rescanInProgress.value!!) {
             rescanInProgress.value = true
-            AfterDirectoryInitializationRunner().runWithoutLifecycle { executor.execute(::rescan) }
+            AfterDirectoryInitializationRunner().runWithoutLifecycle {
+                MainScope().launch { rescan() }
+            }
         }
     }
 
@@ -144,9 +147,9 @@ object GameFileCacheManager {
     fun addOrGet(gamePath: String?): GameFile {
         val nonNullGamePath = gamePath!!
 
-        // Common case: The game is in the cache, so just grab it from there. (GameFileCache.addOrGet
+        // Common case: The game is in the cache, so we grab it from there. (GameFileCache.addOrGet
         // actually already checks for this case, but we want to avoid calling it if possible
-        // because the executor thread may hold a lock on gameFileCache for extended periods of time.)
+        // because rescan() may hold a lock on gameFileCache for extended periods of time.)
         val allGames = gameFiles.value!!
         for (game in allGames) {
             if (game.getPath() == nonNullGamePath) {
@@ -165,17 +168,19 @@ object GameFileCacheManager {
      * games are still present in the user's configured folders.
      * If this has already been called, calling it again has no effect.
      */
-    private fun load() {
+    private suspend fun load() {
         if (!firstLoadDone) {
-            firstLoadDone = true
-            setUpAutomaticRescan()
-            gameFileCache!!.load()
-            if (gameFileCache!!.getSize() != 0) {
-                updateGameFileArray()
+            withContext(Dispatchers.IO) {
+                setUpAutomaticRescan()
+                gameFileCache!!.load()
+                if (gameFileCache!!.getSize() != 0) {
+                    updateGameFileArray()
+                }
             }
+            firstLoadDone = true
         }
 
-        loadInProgress.postValue(false)
+        loadInProgress.value = false
 
         if (runRescanAfterLoad) {
             runRescanAfterLoad = false
@@ -189,10 +194,13 @@ object GameFileCacheManager {
      * If load hasn't been called before this, the execution of this
      * will be postponed until after load runs.
      */
-    private fun rescan() {
+    private suspend fun rescan() {
         if (!firstLoadDone) {
             runRescanAfterLoad = true
-        } else {
+            return
+        }
+
+        withContext(Dispatchers.IO) {
             val gamePaths = GameFileCache.getAllGamePaths()
 
             val changed = gameFileCache!!.update(gamePaths)
@@ -208,9 +216,9 @@ object GameFileCacheManager {
             if (changed || additionalMetadataChanged) {
                 gameFileCache!!.save()
             }
-
-            rescanInProgress.postValue(false)
         }
+
+        rescanInProgress.value = false
     }
 
     private fun updateGameFileArray() {
@@ -233,10 +241,10 @@ object GameFileCacheManager {
     private fun setUpAutomaticRescan() {
         recursiveScanEnabled = BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.boolean
         ConfigChangedCallback {
-            Handler(Looper.getMainLooper()).post {
-                val recursiveScanEnabled = BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.boolean
-                if (this.recursiveScanEnabled != recursiveScanEnabled) {
-                    this.recursiveScanEnabled = recursiveScanEnabled
+            MainScope().launch {
+                val newRecursiveScanEnabled = BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.boolean
+                if (recursiveScanEnabled != newRecursiveScanEnabled) {
+                    recursiveScanEnabled = newRecursiveScanEnabled
                     startRescan()
                 }
             }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
@@ -175,12 +175,6 @@ object GameFileCacheManager {
             }
         }
 
-        if (runRescanAfterLoad) {
-            // Without this, there will be a short blip where the loading indicator in the GUI disappears
-            // because neither loadInProgress nor rescanInProgress is true
-            rescanInProgress.postValue(true)
-        }
-
         loadInProgress.postValue(false)
 
         if (runRescanAfterLoad) {
@@ -214,9 +208,9 @@ object GameFileCacheManager {
             if (changed || additionalMetadataChanged) {
                 gameFileCache!!.save()
             }
-        }
 
-        rescanInProgress.postValue(false)
+            rescanInProgress.postValue(false)
+        }
     }
 
     private fun updateGameFileArray() {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheManager.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -14,10 +15,12 @@ import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
 import org.dolphinemu.dolphinemu.features.settings.model.ConfigChangedCallback
 import org.dolphinemu.dolphinemu.model.GameFile
 import org.dolphinemu.dolphinemu.model.GameFileCache
+import org.dolphinemu.dolphinemu.model.TitleDatabase
 import org.dolphinemu.dolphinemu.ui.platform.Platform
 import org.dolphinemu.dolphinemu.ui.platform.PlatformTab
 import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner
 import java.util.Arrays
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Loads game list data in the background.
@@ -25,6 +28,7 @@ import java.util.Arrays
 object GameFileCacheManager {
     private var gameFileCache: GameFileCache? = null
     private val gameFiles = MutableLiveData(emptyArray<GameFile>())
+    private var titleDatabase = AtomicReference<TitleDatabase>(null)
     private var firstLoadDone = false
     private var recursiveScanEnabled = false
 
@@ -87,6 +91,8 @@ object GameFileCacheManager {
             arrayOf(nonNullGameFile.getPath(), secondFile.getPath())
         }
     }
+
+    fun getTitleDatabase(): TitleDatabase? = titleDatabase.get()
 
     /**
      * Returns true if in the process of loading the cache for the first time.
@@ -171,13 +177,22 @@ object GameFileCacheManager {
      */
     private suspend fun load() {
         if (!firstLoadDone) {
+            val titleDatabaseJob = MainScope().async(Dispatchers.IO) {
+                TitleDatabase.load()
+            }
+
             withContext(Dispatchers.IO) {
                 setUpAutomaticRescan()
+
                 gameFileCache!!.load()
+
+                titleDatabase.set(titleDatabaseJob.await())
+
                 if (gameFileCache!!.getSize() != 0) {
                     updateGameFileArray()
                 }
             }
+
             firstLoadDone = true
         }
 
@@ -196,16 +211,29 @@ object GameFileCacheManager {
             loadInProgress.asFlow().first { !it }
         }
 
+        val titleDatabaseJob = MainScope().async(Dispatchers.IO) {
+            val newTitleDatabase = TitleDatabase.load()
+            val titleDatabaseChanged =
+                !newTitleDatabase.userTitleMapEquals(titleDatabase.get())
+            if (titleDatabaseChanged) newTitleDatabase else null
+        }
+
         withContext(Dispatchers.IO) {
             val gamePaths = GameFileCache.getAllGamePaths()
-
             val changed = gameFileCache!!.update(gamePaths)
             if (changed) {
                 updateGameFileArray()
             }
 
             val additionalMetadataChanged = gameFileCache!!.updateAdditionalMetadata()
-            if (additionalMetadataChanged) {
+
+            val newTitleDatabase = titleDatabaseJob.await()
+            val titleDatabaseChanged = newTitleDatabase != null
+            if (titleDatabaseChanged) {
+                titleDatabase.set(newTitleDatabase)
+            }
+
+            if (additionalMetadataChanged || titleDatabaseChanged) {
                 updateGameFileArray()
             }
 
@@ -219,8 +247,9 @@ object GameFileCacheManager {
 
     private fun updateGameFileArray() {
         val gameFilesTemp = gameFileCache!!.getAllGames()
+        val titleDatabase = titleDatabase.get()
         Arrays.sort(gameFilesTemp) { lhs, rhs ->
-            lhs.getTitle().compareTo(rhs.getTitle(), ignoreCase = true)
+            lhs.getTitle(titleDatabase).compareTo(rhs.getTitle(titleDatabase), ignoreCase = true)
         }
         gameFiles.postValue(gameFilesTemp)
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/SyncProgramsJobService.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/SyncProgramsJobService.kt
@@ -138,7 +138,10 @@ class SyncProgramsJobService : JobService() {
                 TvContractCompat.PreviewPrograms.COLUMN_TYPE,
                 TvContractCompat.PreviewProgramColumns.TYPE_GAME
             )
-            values.put(TvContract.Programs.COLUMN_TITLE, game.getTitle())
+            values.put(
+                TvContract.Programs.COLUMN_TITLE,
+                game.getTitle(GameFileCacheManager.getTitleDatabase())
+            )
             values.put(TvContract.Programs.COLUMN_SHORT_DESCRIPTION, game.getDescription())
             values.put(TvContract.Programs.COLUMN_POSTER_ART_URI, banner.toString())
             values.put(

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -151,6 +151,10 @@ static jclass s_audio_utils_class;
 static jmethodID s_audio_utils_get_sample_rate;
 static jmethodID s_audio_utils_get_frames_per_buffer;
 
+static jclass s_title_database_class;
+static jfieldID s_title_database_pointer;
+static jmethodID s_title_database_constructor;
+
 namespace IDCache
 {
 JNIEnv* GetEnvForThread()
@@ -721,6 +725,21 @@ jmethodID GetAudioUtilsGetFramesPerBuffer()
   return s_audio_utils_get_frames_per_buffer;
 }
 
+jclass GetTitleDatabaseClass()
+{
+  return s_title_database_class;
+}
+
+jfieldID GetTitleDatabasePointer()
+{
+  return s_title_database_pointer;
+}
+
+jmethodID GetTitleDatabaseConstructor()
+{
+  return s_title_database_constructor;
+}
+
 }  // namespace IDCache
 
 extern "C" {
@@ -1014,6 +1033,13 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
   s_audio_utils_get_frames_per_buffer =
       env->GetStaticMethodID(audio_utils_class, "getFramesPerBuffer", "()I");
   env->DeleteLocalRef(audio_utils_class);
+
+  const jclass title_database_class =
+      env->FindClass("org/dolphinemu/dolphinemu/model/TitleDatabase");
+  s_title_database_class = reinterpret_cast<jclass>(env->NewGlobalRef(title_database_class));
+  s_title_database_pointer = env->GetFieldID(title_database_class, "pointer", "J");
+  s_title_database_constructor = env->GetMethodID(title_database_class, "<init>", "(J)V");
+  env->DeleteLocalRef(title_database_class);
 
   return JNI_VERSION;
 }

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -150,4 +150,8 @@ jclass GetAudioUtilsClass();
 jmethodID GetAudioUtilsGetSampleRate();
 jmethodID GetAudioUtilsGetFramesPerBuffer();
 
+jclass GetTitleDatabaseClass();
+jfieldID GetTitleDatabasePointer();
+jmethodID GetTitleDatabaseConstructor();
+
 }  // namespace IDCache

--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(main SHARED
   GameList/GameFile.cpp
   GameList/GameFile.h
   GameList/GameFileCache.cpp
+  GameList/TitleDatabase.cpp
+  GameList/TitleDatabase.h
   GpuDriver.cpp
   InfinityConfig.cpp
   Input/Control.cpp

--- a/Source/Android/jni/GameList/GameFile.cpp
+++ b/Source/Android/jni/GameList/GameFile.cpp
@@ -16,6 +16,7 @@
 #include "UICommon/GameFile.h"
 #include "jni/AndroidCommon/AndroidCommon.h"
 #include "jni/AndroidCommon/IDCache.h"
+#include "jni/GameList/TitleDatabase.h"
 
 static std::shared_ptr<const UICommon::GameFile>* GetPointer(JNIEnv* env, jobject obj)
 {
@@ -52,11 +53,19 @@ JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getPlatform
   return static_cast<jint>(GetRef(env, obj)->GetPlatform());
 }
 
-JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getTitle(JNIEnv* env,
-                                                                                 jobject obj)
+JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getTitle(
+    JNIEnv* env, jobject obj, jobject j_title_database)
 {
-  return ToJString(env,
-                   GetRef(env, obj)->GetName(UICommon::GameFile::Variant::LongAndPossiblyCustom));
+  const Core::TitleDatabase* title_database = TitleDatabaseFromJava(env, j_title_database);
+  if (title_database)
+  {
+    return ToJString(env, GetRef(env, obj)->GetName(*title_database));
+  }
+  else
+  {
+    return ToJString(env,
+                     GetRef(env, obj)->GetName(UICommon::GameFile::Variant::LongAndPossiblyCustom));
+  }
 }
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getDescription(JNIEnv* env,

--- a/Source/Android/jni/GameList/TitleDatabase.cpp
+++ b/Source/Android/jni/GameList/TitleDatabase.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "jni/GameList/TitleDatabase.h"
+
+#include <jni.h>
+
+#include "Core/TitleDatabase.h"
+#include "jni/AndroidCommon/IDCache.h"
+
+Core::TitleDatabase* TitleDatabaseFromJava(JNIEnv* env, jobject obj)
+{
+  return reinterpret_cast<Core::TitleDatabase*>(
+      env->GetLongField(obj, IDCache::GetTitleDatabasePointer()));
+}
+extern "C" {
+
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_model_TitleDatabase_finalize(JNIEnv* env,
+                                                                                   jobject obj)
+{
+  delete TitleDatabaseFromJava(env, obj);
+}
+
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_model_TitleDatabase_areUserTitleMapsEqual(
+    JNIEnv* env, jobject obj, jobject other)
+{
+  return other != nullptr && TitleDatabaseFromJava(env, obj)->GetUserTitleMap() ==
+                                 TitleDatabaseFromJava(env, other)->GetUserTitleMap();
+}
+
+JNIEXPORT jobject JNICALL Java_org_dolphinemu_dolphinemu_model_TitleDatabase_load(JNIEnv* env,
+                                                                                  jclass)
+{
+  return env->NewObject(IDCache::GetTitleDatabaseClass(), IDCache::GetTitleDatabaseConstructor(),
+                        reinterpret_cast<jlong>(new Core::TitleDatabase));
+}
+}

--- a/Source/Android/jni/GameList/TitleDatabase.cpp
+++ b/Source/Android/jni/GameList/TitleDatabase.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "jni/GameList/TitleDatabase.h"
+
+#include <jni.h>
+
+#include "Core/TitleDatabase.h"
+#include "jni/AndroidCommon/IDCache.h"
+
+Core::TitleDatabase* TitleDatabaseFromJava(JNIEnv* env, jobject obj)
+{
+  return reinterpret_cast<Core::TitleDatabase*>(
+      env->GetLongField(obj, IDCache::GetTitleDatabasePointer()));
+}
+extern "C" {
+
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_model_TitleDatabase_finalize(JNIEnv* env,
+                                                                                   jobject obj)
+{
+  delete TitleDatabaseFromJava(env, obj);
+}
+
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_model_TitleDatabase_userTitleMapEquals(
+    JNIEnv* env, jobject obj, jobject other)
+{
+  return other != nullptr && TitleDatabaseFromJava(env, obj)->GetUserTitleMap() ==
+                                 TitleDatabaseFromJava(env, other)->GetUserTitleMap();
+}
+
+JNIEXPORT jobject JNICALL Java_org_dolphinemu_dolphinemu_model_TitleDatabase_load(JNIEnv* env,
+                                                                                  jclass)
+{
+  return env->NewObject(IDCache::GetTitleDatabaseClass(), IDCache::GetTitleDatabaseConstructor(),
+                        reinterpret_cast<jlong>(new Core::TitleDatabase));
+}
+}

--- a/Source/Android/jni/GameList/TitleDatabase.h
+++ b/Source/Android/jni/GameList/TitleDatabase.h
@@ -1,0 +1,13 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <jni.h>
+
+namespace Core
+{
+class TitleDatabase;
+}
+
+Core::TitleDatabase* TitleDatabaseFromJava(JNIEnv* env, jobject obj);

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -135,4 +135,9 @@ std::string TitleDatabase::Describe(const std::string& gametdb_id, DiscIO::Langu
     return gametdb_id;
   return fmt::format("{} ({})", title_name, gametdb_id);
 }
+
+const std::unordered_map<std::string, std::string>& TitleDatabase::GetUserTitleMap() const
+{
+  return m_user_title_map;
+}
 }  // namespace Core

--- a/Source/Core/Core/TitleDatabase.h
+++ b/Source/Core/Core/TitleDatabase.h
@@ -33,6 +33,8 @@ public:
   // Get a description for a GameTDB ID (title name if available + GameTDB ID).
   std::string Describe(const std::string& gametdb_id, DiscIO::Language language) const;
 
+  const std::unordered_map<std::string, std::string>& GetUserTitleMap() const;
+
 private:
   void AddLazyMap(DiscIO::Language language, const std::string& language_code);
 


### PR DESCRIPTION
By using the title database we ship with Dolphin, we get more uniform game titles than if we grab what's in each game's opening.bnr file. It also becomes possible for users to supply a custom titles.txt file.

This has been implemented in DolphinQt since a long time ago.