### PR TITLE
VideoCommon: Fix padding in shader UIDs

### DIFF
--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -19,7 +19,7 @@ namespace VideoCommon
 // As pipelines encompass both shader UIDs and render states, changes to either of these should
 // also increment the pipeline UID version. Incrementing the UID version will cause all UID
 // caches to be invalidated.
-constexpr u32 GX_PIPELINE_UID_VERSION = 8;  // Last changed in PR 12185
+constexpr u32 GX_PIPELINE_UID_VERSION = 9;  // Last changed in PR 14795
 
 struct GXPipelineUid
 {

--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -31,6 +31,7 @@ struct LightingUidData
   u32 matsource : 4;       // 4x1 bit
   u32 enablelighting : 4;  // 4x1 bit
   u32 ambsource : 4;       // 4x1 bit
+  u32 pad : 4;             // (byte-align values below)
   u32 diffusefunc : 8;     // 4x2 bits
   u32 attnfunc : 8;        // 4x2 bits
   u32 light_mask : 32;     // 4x8 bits

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -25,21 +25,20 @@ struct pixel_shader_uid_data
 {
   // TODO: Optimize field order for easy access!
 
-  u32 num_values;  // TODO: Shouldn't be a u32
+  u32 num_values : 16;  // TODO: Shouldn't be a u32
   u32 NumValues() const { return num_values; }
-  u32 pad0 : 4;
   u32 useDstAlpha : 1;
   u32 no_dual_src : 1;
   AlphaTestResult Pretest : 2;
   u32 nIndirectStagesUsed : 4;
   u32 genMode_numtexgens : 4;
   u32 genMode_numtevstages : 4;
+
   u32 genMode_numindstages : 3;
   CompareMode alpha_test_comp0 : 3;
   CompareMode alpha_test_comp1 : 3;
   AlphaTestOp alpha_test_logic : 2;
   FogProjection fog_proj : 1;
-
   FogType fog_fsel : 3;
   u32 fog_RangeBaseEnabled : 1;
   ZTexOp ztex_op : 2;
@@ -51,6 +50,8 @@ struct pixel_shader_uid_data
   u32 rgba6_format : 1;
   u32 dither : 1;
   u32 uint_output : 1;
+  u32 pad0 : 3;
+
   u32 blend_enable : 1;                       // Only used with shader_framebuffer_fetch blend
   SrcBlendFactor blend_src_factor : 3;        // Only used with shader_framebuffer_fetch blend
   SrcBlendFactor blend_src_factor_alpha : 3;  // Only used with shader_framebuffer_fetch blend
@@ -61,6 +62,7 @@ struct pixel_shader_uid_data
   u32 emulate_logic_op_with_blend : 1;        // Only used with logic op blend emulation
   u32 logic_op_enable : 1;                    // Only used with shader_framebuffer_fetch logic ops
   u32 logic_op_mode : 4;  // Only used with shader_framebuffer_fetch logic ops and blend emulation
+  u32 pad1 : 11;
 
   u32 texMtxInfo_n_projection : 8;  // 8x1 bit
   u32 tevindref_bi0 : 3;
@@ -124,15 +126,16 @@ struct pixel_shader_uid_data
 
   struct
   {
-    // TODO: Can save a lot space by removing the padding bits
+    // TODO: Can save space on unix by removing the padding bits
     u32 cc : 24;
-    u32 ac : 24;  // tswap and rswap are left blank (decoded into the swap fields below)
-
-    u32 tevorders_texmap : 3;
-    u32 tevorders_texcoord : 3;
     u32 tevorders_enable : 1;
     RasColorChan tevorders_colorchan : 3;
-    u32 pad1 : 7;
+    u32 pad0 : 4;
+
+    u32 ac : 24;  // tswap and rswap are left blank (decoded into the swap fields below)
+    u32 tevorders_texmap : 3;
+    u32 tevorders_texcoord : 3;
+    u32 pad1 : 2;
 
     // TODO: We could save space by storing the 4 swap tables elsewhere and only storing references
     // to which table is used (the tswap and rswap fields), instead of duplicating them here
@@ -141,7 +144,7 @@ struct pixel_shader_uid_data
     ColorChannel ras_swap_g : 2;
     ColorChannel ras_swap_b : 2;
     ColorChannel ras_swap_a : 2;
-    u32 pad2 : 2;
+    u32 pad2 : 3;
 
     ColorChannel tex_swap_r : 2;
     ColorChannel tex_swap_g : 2;
@@ -155,6 +158,8 @@ struct pixel_shader_uid_data
   LightingUidData lighting;
 };
 #pragma pack()
+
+static_assert(sizeof(pixel_shader_uid_data) == 280, "If this changes, you should recheck padding");
 
 using PixelShaderUid = ShaderUid<pixel_shader_uid_data>;
 

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -60,11 +60,12 @@ struct vertex_shader_uid_data
   u32 numColorChans : 2;
   u32 dualTexTrans_enabled : 1;
   VSExpand vs_expand : 2;
-  u32 position_has_3_elems : 1;
 
-  u16 texcoord_elem_count;      // 2 bits per texcoord input
-  u16 texMtxInfo_n_projection;  // Stored separately to guarantee that the texMtxInfo struct is
-                                // 8 bits wide
+  u8 position_has_3_elems : 1;
+  u8 pad : 7;
+  u8 texMtxInfo_n_projection;  // Stored separately to guarantee that the texMtxInfo struct is
+                               // 8 bits wide
+  u16 texcoord_elem_count;     // 2 bits per texcoord input
 
   struct
   {
@@ -77,14 +78,20 @@ struct vertex_shader_uid_data
 
   struct
   {
-    u32 index : 6;
-    u32 normalize : 1;
-    u32 pad : 1;
+    u8 index : 6;
+    u8 normalize : 1;
+    u8 pad : 1;
   } postMtxInfo[8];
 
   LightingUidData lighting;
 };
 #pragma pack()
+
+#ifdef _WIN32  // MSVC layout is terrible and makes each texMtxInfo 32 bits
+static_assert(sizeof(vertex_shader_uid_data) == 56, "If this changes, you should verify padding");
+#else
+static_assert(sizeof(vertex_shader_uid_data) == 40, "If this changes, you should verify padding");
+#endif
 
 using VertexShaderUid = ShaderUid<vertex_shader_uid_data>;
 


### PR DESCRIPTION
Looks like over time, shader UIDs' padding bits have gotten completely desynced from where padding bits actually exist / are needed.

This redoes all the padding to match reality, rearranges a few fields to reduce padding where possible, and adds some static_asserts reminding people to look back at the padding if they add things.

BTW, at least according to compiler explorer (and to be verified by CI as it runs), only GCC/Clang let you use `#pragma pack(1)` to make structs smaller than their contained types (e.g. `struct { u32 blah : 8 }` being 1 byte instead of 4), so currently, VS UIDs are smaller on unix than Windows.  Do we want to do anything about this?  I changed `postMtxInfo` to use `u8`s to avoid this, but `texMtxInfo` contains enums that are defined as `: u32`.