### PR TITLE
NetPlay: reject oversized input buffer messages

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -754,8 +754,13 @@ void NetPlayClient::OnPadBuffer(sf::Packet& packet)
   u32 size = 0;
   packet >> size;
 
-  m_target_buffer_size = size;
-  m_dialog->OnPadBufferChanged(size);
+  if (size > MAX_BUFFER_SIZE)
+  {
+    WARN_LOG_FMT(NETPLAY, "Ignoring invalid pad buffer size {}.", size);
+    return;
+  }
+
+  AdjustPadBufferSize(size);
 }
 
 void NetPlayClient::OnHostInputAuthority(sf::Packet& packet)
@@ -2577,8 +2582,8 @@ const PadMappingArray& NetPlayClient::GetWiimoteMapping() const
 
 void NetPlayClient::AdjustPadBufferSize(const unsigned int size)
 {
-  m_target_buffer_size = size;
-  m_dialog->OnPadBufferChanged(size);
+  m_target_buffer_size = std::min(size, MAX_BUFFER_SIZE);
+  m_dialog->OnPadBufferChanged(m_target_buffer_size);
 }
 
 void NetPlayClient::SetWiiSyncData(std::unique_ptr<IOS::HLE::FS::FileSystem> fs,

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -754,7 +754,7 @@ void NetPlayClient::OnPadBuffer(sf::Packet& packet)
   u32 size = 0;
   packet >> size;
 
-  if (size > MAX_BUFFER_SIZE)
+  if (size > MAX_TARGET_PAD_BUFFER_SIZE)
   {
     WARN_LOG_FMT(NETPLAY, "Ignoring invalid pad buffer size {}.", size);
     return;
@@ -2582,7 +2582,7 @@ const PadMappingArray& NetPlayClient::GetWiimoteMapping() const
 
 void NetPlayClient::AdjustPadBufferSize(const unsigned int size)
 {
-  m_target_buffer_size = std::min(size, MAX_BUFFER_SIZE);
+  m_target_buffer_size = std::min(size, MAX_TARGET_PAD_BUFFER_SIZE);
   m_dialog->OnPadBufferChanged(m_target_buffer_size);
 }
 

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -244,7 +244,7 @@ enum class SyncCodeID : u8
 };
 
 constexpr u32 MAX_NAME_LENGTH = 30;
-constexpr u32 MAX_BUFFER_SIZE = 99;
+constexpr u32 MAX_TARGET_PAD_BUFFER_SIZE = 99;
 constexpr size_t CHUNKED_DATA_UNIT_SIZE = 16384;
 constexpr u32 MAX_ENET_MTU = 1392;  // see https://github.com/lsalzman/enet/issues/132
 

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -244,6 +244,7 @@ enum class SyncCodeID : u8
 };
 
 constexpr u32 MAX_NAME_LENGTH = 30;
+constexpr u32 MAX_BUFFER_SIZE = 99;
 constexpr size_t CHUNKED_DATA_UNIT_SIZE = 16384;
 constexpr u32 MAX_ENET_MTU = 1392;  // see https://github.com/lsalzman/enet/issues/132
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -686,7 +686,7 @@ void NetPlayServer::AdjustPadBufferSize(unsigned int size)
 {
   std::lock_guard lkg(m_crit.game);
 
-  m_target_buffer_size = std::min(size, MAX_BUFFER_SIZE);
+  m_target_buffer_size = std::min(size, MAX_TARGET_PAD_BUFFER_SIZE);
 
   // not needed on clients with host input authority
   if (!m_host_input_authority)

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -686,7 +686,7 @@ void NetPlayServer::AdjustPadBufferSize(unsigned int size)
 {
   std::lock_guard lkg(m_crit.game);
 
-  m_target_buffer_size = size;
+  m_target_buffer_size = std::min(size, MAX_BUFFER_SIZE);
 
   // not needed on clients with host input authority
   if (!m_host_input_authority)

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -33,6 +33,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/TraversalClient.h"
 #include "Core/NetPlayCommon.h"
+#include "Core/NetPlayProto.h"
 
 #include "Core/Boot/Boot.h"
 #include "Core/Config/GraphicsSettings.h"
@@ -130,6 +131,7 @@ void NetPlayDialog::CreateMainLayout()
   m_game_button = new QPushButton;
   m_start_button = new QPushButton(tr("Start"));
   m_buffer_size_box = new QSpinBox;
+  m_buffer_size_box->setMaximum(MAX_TARGET_PAD_BUFFER_SIZE);
   m_buffer_label = new QLabel(tr("Buffer:"));
   m_quit_button = new QPushButton(tr("Quit"));
   m_splitter = new QSplitter(Qt::Horizontal);


### PR DESCRIPTION
`OnPadBuffer()` accepts the `PadBuffer` value received from the host and passes it directly to `AdjustPadBufferSize()`. A malicious or broken host can therefore make a client allocate input states up to an arbitrary buffer size.

Define the existing UI maximum as `MAX_BUFFER_SIZE`, reject larger peer values in the client, and clamp sizes on both the client and server paths. This preserves the normal 0–99 buffer range while preventing unbounded queue growth.