### PR TITLE
Common/BitCastPtr: Prevent destination type to be a pointer

### DIFF
--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -137,6 +137,7 @@ public:
                 "BitCastPtr source type must be trivially copyable.");
   static_assert(std::is_trivially_copyable<T>(),
                 "BitCastPtr destination type must be trivially copyable.");
+  static_assert(!std::is_pointer<T>(), "BitCastPtr destination type must not be a pointer.");
 
   explicit BitCastPtrType(PtrType* ptr) : m_ptr(ptr) {}
 


### PR DESCRIPTION
This PR prevents misuse of the `BitCastPtr` helper as I don't see valid reasons for Dolphin to handle such case (i.e. copy memory content as a valid memory address for a pointer type).

The only case where I can see this being potentially valid would be a program exploring itself based on some kind of unaligned live snapshot _but why so?_

Ready to be reviewed and merged.