### PR TITLE
Require VS2026; Update Redist WinUpdater Pulls

### DIFF
--- a/Source/Core/Common/build_info.txt.in
+++ b/Source/Core/Common/build_info.txt.in
@@ -6,18 +6,18 @@ OSMinimumVersionWin11=10.0.22000.0
 // This is the runtime which was compiled against - providing a way for Updater to detect if update
 // is needed before executing this binary. Note that, annoyingly, the version in environment
 // variables does not match the "real" version. Consider:
-// VersionInfo    : File:             C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.32.31326\vc_redist.x64.exe
+// VersionInfo    : File:             C:\Program Files\Microsoft Visual Studio\18\Community\VC\Redist\MSVC\14.51.36231\vc_redist.x64.exe
 //                  InternalName:     setup
 //                  OriginalFilename: VC_redist.x64.exe
-//                  FileVersion:      14.32.31332.0
-//                  FileDescription:  Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.32.31332
-//                  Product:          Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.32.31332
-//                  ProductVersion:   14.32.31332.0
+//                  FileVersion:      14.51.36247.0
+//                  FileDescription:  Microsoft Visual C++ v14 Redistributable (x64) - 14.51.36247
+//                  Product:          Microsoft Visual C++ v14 Redistributable (x64) - 14.51.36247
+//                  ProductVersion:   14.51.36247.0
 // Whereas the environment variables look like:
-//   VCToolsInstallDir=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.33.31629\
-//   VCToolsRedistDir=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.32.31326\
-//   VCToolsVersion=14.33.31629
-// We're really looking for "14.32.31332.0" (because that's what will appear in the registry once
+//   VCToolsInstallDir=C:\Program Files\Microsoft Visual Studio\18\Community\VC\Tools\MSVC\14.51.36231\
+//   VCToolsRedistDir=C:\Program Files\Microsoft Visual Studio\18\Community\VC\Redist\MSVC\14.51.36231\
+//   VCToolsVersion=14.51.36231
+// We're really looking for "14.51.36247.00" (because that's what will appear in the registry once
 // installed), NOT the other values!
 VCToolsVersion=${VC_TOOLS_VERSION}
-VCToolsUpdateURL=https://aka.ms/vs/17/release/vc_redist.x64.exe
+VCToolsUpdateURL=https://aka.ms/vc14/vc_redist.x64.exe

--- a/Source/Core/WinUpdater/Platform.cpp
+++ b/Source/Core/WinUpdater/Platform.cpp
@@ -120,7 +120,7 @@ struct BuildInfos
 
 // This default value should be kept in sync with the value of VCToolsUpdateURL in
 // build_info.txt.in
-static const char* VCToolsUpdateURLDefault = "https://aka.ms/vs/17/release/vc_redist.x64.exe";
+static const char* VCToolsUpdateURLDefault = "https://aka.ms/vc14/vc_redist.x64.exe";
 #define VC_RUNTIME_REGKEY R"(SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\)"
 
 static const char* VCRuntimeRegistrySubkey()

--- a/Source/PCH/pch.h
+++ b/Source/PCH/pch.h
@@ -6,9 +6,9 @@
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#if defined _MSC_FULL_VER && _MSC_FULL_VER < 193632532
+#if defined _MSC_FULL_VER && _MSC_FULL_VER < 195136252
 #pragma message("Current _MSC_FULL_VER: " STRINGIFY(_MSC_FULL_VER))
-#error Please update your build environment to the latest Visual Studio 2022!
+#error Please update your build environment to the latest Visual Studio 2026!
 #endif
 
 #include <sdkddkver.h>


### PR DESCRIPTION
Saw some users having Dolphin prompt for VC++ redist update, but its pulling the wrong version so Dolphin fails to open after.

<img width="517" height="367" alt="image" src="https://github.com/user-attachments/assets/9e8b75e8-919c-4470-8a81-a694984aff10" />

<img width="496" height="434" alt="image" src="https://github.com/user-attachments/assets/dabfe127-05d5-4a7b-9d01-893a3e5191df" />



I'm not entirely clear if Microsoft changed something in the build tools recently, because on the main dolphin website it still says the requirement is VC++ 2022, not 2026 (aka vc14).

~~Note I didn't update the comment in build_info.txt.in - that should probably be updated before this merged.~~ Done
Mainly opening this for awareness, feel free to make your own PR with the proper fix esp if the solution is downgrading the CI tools to ensure VC++ 2022 is used instead when building.
