### PR TITLE
Enable Fallthrough warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ set(AppleClang_min_version 14.0.3)
 set(MSVC_min_version 19.32)
 # Standard libraries
 set(libstdc++_min_version 12) # This should match GCC_min_version's major version.
-set(libc++_min_version 150000) # This should match Clang_min_version in the format "xxyyzz" instead of "xx.yy.zz" 
+set(libc++_min_version 150000) # This should match Clang_min_version in the format "xxyyzz" instead of "xx.yy.zz"
 
 dolphin_check_toolset_version("Xcode" XCODE_VERSION ${Xcode_min_version})
 dolphin_check_toolset_version("MSVC Toolset" MSVC_TOOLSET_VERSION ${MSVC_toolset_min_version})
@@ -273,6 +273,7 @@ if(MSVC)
 
   # Additional warnings
   add_compile_options(
+    /w15262 # Unannotated fallthrough between switch labels
     /w44263 # Non-virtual member function hides base class virtual function
     /w44265 # Class has virtual functions, but destructor is not virtual
     /w44946 # Reinterpret cast between related types

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -45,6 +45,7 @@ else()
   check_and_add_flag(INIT_SELF -Winit-self)
   check_and_add_flag(MISSING_DECLARATIONS -Wmissing-declarations)
   check_and_add_flag(MISSING_VARIABLE_DECLARATIONS -Wmissing-variable-declarations)
+  check_and_add_flag(IMPLICIT_FALLTHROUGH -Wimplicit-fallthrough)
 
   # Disable -Wstringop-truncation warnings as they result in many false positives.
   # In most (all?) cases where std::strncpy is used, we want to fill the entire buffer

--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
@@ -2157,8 +2157,10 @@ static void InitExtensionList(GLContext* context)
     default:
     case 320:
       s_extension_list["VERSION_GLES_3_2"] = true;
+      [[fallthrough]];
     case 310:
       s_extension_list["VERSION_GLES_3_1"] = true;
+      [[fallthrough]];
     case 300:
       s_extension_list["VERSION_GLES_3"] = true;
       break;
@@ -2195,6 +2197,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl450exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 440:
     {
@@ -2211,6 +2214,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl440exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 430:
     {
@@ -2239,6 +2243,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl430exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 420:
     {
@@ -2259,6 +2264,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl420exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 410:
     {
@@ -2273,6 +2279,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl410exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 400:
     {
@@ -2293,6 +2300,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl400exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 330:
     {
@@ -2311,6 +2319,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl330exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 320:
     {
@@ -2328,6 +2337,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl320exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 310:
     {
@@ -2343,6 +2353,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl310exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 300:
     {
@@ -2374,6 +2385,7 @@ static void InitExtensionList(GLContext* context)
       };
       for (auto it : gl300exts)
         s_extension_list[it] = true;
+      [[fallthrough]];
     }
     case 210:
     case 200:

--- a/Source/Core/Common/Hash.cpp
+++ b/Source/Core/Common/Hash.cpp
@@ -136,33 +136,46 @@ static u64 GetMurmurHash3(const u8* src, u32 len, u32 samples)
   {
   case 15:
     k2 ^= u64(tail[14]) << 48;
+    [[fallthrough]];
   case 14:
     k2 ^= u64(tail[13]) << 40;
+    [[fallthrough]];
   case 13:
     k2 ^= u64(tail[12]) << 32;
+    [[fallthrough]];
   case 12:
     k2 ^= u64(tail[11]) << 24;
+    [[fallthrough]];
   case 11:
     k2 ^= u64(tail[10]) << 16;
+    [[fallthrough]];
   case 10:
     k2 ^= u64(tail[9]) << 8;
+    [[fallthrough]];
   case 9:
     k2 ^= u64(tail[8]) << 0;
-
+    [[fallthrough]];
   case 8:
     k1 ^= u64(tail[7]) << 56;
+    [[fallthrough]];
   case 7:
     k1 ^= u64(tail[6]) << 48;
+    [[fallthrough]];
   case 6:
     k1 ^= u64(tail[5]) << 40;
+    [[fallthrough]];
   case 5:
     k1 ^= u64(tail[4]) << 32;
+    [[fallthrough]];
   case 4:
     k1 ^= u64(tail[3]) << 24;
+    [[fallthrough]];
   case 3:
     k1 ^= u64(tail[2]) << 16;
+    [[fallthrough]];
   case 2:
     k1 ^= u64(tail[1]) << 8;
+    [[fallthrough]];
   case 1:
     k1 ^= u64(tail[0]) << 0;
     bmix64(h1, h2, k1, k2, c1, c2);

--- a/Source/Core/Core/HW/MagCard/MagneticCardReader.cpp
+++ b/Source/Core/Core/HW/MagCard/MagneticCardReader.cpp
@@ -193,6 +193,7 @@ void MagneticCardReader::Command_33_ReadData()
 
       AppendRange(&m_command_payload, *track_data);
     }
+    break;
   }
   default:
     break;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -146,6 +146,7 @@ std::optional<IPCReply> BluetoothRealDevice::IOCtlV(const IOCtlVRequest& request
     }
 
     ERROR_LOG_FMT(IOS_WIIMOTE, "IOCTLV_USBV0_INTRMSG: Unknown endpoint: 0x{:02x}", cmd->endpoint);
+    break;
   }
   default:
     ERROR_LOG_FMT(IOS_WIIMOTE, "IOCtlV: Unknown request: 0x{:08x}", request.request);

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -1174,7 +1174,9 @@ void CodeViewWidget::keyPressEvent(QKeyEvent* event)
     if (event->modifiers() == Qt::ControlModifier)
     {
       emit ActivateSearch();
+      return;
     }
+    [[fallthrough]];
   default:
     QWidget::keyPressEvent(event);
     break;

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -126,7 +126,9 @@ public:
       if (event->modifiers() == Qt::ControlModifier)
       {
         m_view->TriggerActivateSearch();
+        return;
       }
+      [[fallthrough]];
     default:
       QWidget::keyPressEvent(event);
       return;

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -356,6 +356,7 @@ void MemoryViewWidget::UpdateDispatcher(UpdateType type)
     // Values were captured on CPU thread while doing a callback.
     if (m_values.size() != 0)
       UpdateColumns();
+    break;
   default:
     break;
   }


### PR DESCRIPTION
Looks like we are pretty close to being able to enable this.

Most of these fixes should be no change in behaviour, but the behaviour is now slightly different for the CodeView/MemoryVIew widgets. 
