### PR TITLE
VideoBackends/OGL: Don't call glMemoryBarrier without ARB_shader_image_load_store

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLBoundingBox.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLBoundingBox.cpp
@@ -5,6 +5,7 @@
 
 #include <cstring>
 
+#include "VideoBackends/OGL/OGLConfig.h"
 #include "VideoBackends/OGL/OGLGfx.h"
 #include "VideoCommon/DriverDetails.h"
 
@@ -37,7 +38,7 @@ std::vector<BBoxType> OGLBoundingBox::Read(u32 index, u32 length)
   // on nVidia drivers. This is more noticeable at higher internal resolutions.
   // Using glGetBufferSubData instead does not seem to exhibit this slowdown.
   if (!DriverDetails::HasBug(DriverDetails::BUG_SLOW_GETBUFFERSUBDATA) &&
-      !static_cast<OGLGfx*>(g_gfx.get())->IsGLES())
+      !static_cast<OGLGfx*>(g_gfx.get())->IsGLES() && g_ogl_config.bSupportsImageLoadStore)
   {
     // We also need to ensure the the CPU does not receive stale values which have been updated by
     // the GPU. Apparently the buffer here is not coherent on NVIDIA drivers. Not sure if this is a


### PR DESCRIPTION
`OGLBoundingBox::Read` calls `glMemoryBarrier` on the non-GLES path, but that comes from ARB_shader_image_load_store, so on a desktop context below GL 4.2 the pointer is null. `bSupportsBBox` is set from `bSupportsFragmentStoresAndAtomics`, which such a driver can still have, so saving a state reads the bounding box and calls a null pointer. `UsePersistentStagingBuffers()` in OGLTexture.cpp already guards the same call with `bSupportsImageLoadStore`.

Hit on Mesa v3d (Raspberry Pi 5, `3.1 Mesa 26.1.5`): saving a state segfaulted every time, now works. Found through the libretro fork, where this function is identical, so that is where it is tested. Only the one GL 3.1 driver here, and the GLES path is untouched.
