### PR TITLE
Fix crashes when using `std::locale{""}` with an invalid LC_ALL

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -101,6 +101,8 @@ add_library(common
   Lazy.h
   LinearDiskCache.h
   UnixUtil.h
+  LocaleUtil.cpp
+  LocaleUtil.h
   Logging/ConsoleListener.h
   Logging/Log.h
   Logging/LogManager.cpp

--- a/Source/Core/Common/LocaleUtil.cpp
+++ b/Source/Core/Common/LocaleUtil.cpp
@@ -1,0 +1,27 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "Common/LocaleUtil.h"
+
+#include <locale.h>
+
+namespace Common
+{
+std::locale GetEnvironmentLocale()
+{
+#ifdef _WIN32
+  if (_locale_t loc = _create_locale(LC_ALL, ""))
+  {
+    _free_locale(loc);
+    return std::locale{""};
+  }
+#else
+  if (locale_t loc = newlocale(LC_ALL_MASK, "", static_cast<locale_t>(0)))
+  {
+    freelocale(loc);
+    return std::locale{""};
+  }
+#endif
+  return std::locale::classic();
+}
+}  // Namespace Common

--- a/Source/Core/Common/LocaleUtil.h
+++ b/Source/Core/Common/LocaleUtil.h
@@ -1,0 +1,12 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <locale>
+
+namespace Common
+{
+// std::locale{""} equivalent that doesn't throw
+std::locale GetEnvironmentLocale();
+}  // Namespace Common

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -25,6 +25,7 @@
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/IOFile.h"
+#include "Common/LocaleUtil.h"
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
@@ -158,7 +159,7 @@ std::string MovieManager::GetRTCDisplay() const
   const tm gm_time = fmt::gmtime(current_time);
 
   // Use current locale for formatting time, as fmt is locale-agnostic by default.
-  return fmt::format(std::locale{""}, "Date/Time: {:%c}", gm_time);
+  return fmt::format(Common::GetEnvironmentLocale(), "Date/Time: {:%c}", gm_time);
 }
 
 // NOTE: GPU Thread

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -26,6 +26,7 @@
 #include "Common/Contains.h"
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
+#include "Common/LocaleUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
@@ -300,7 +301,7 @@ static std::string SystemTimeAsDoubleToString(double time)
     return "";
 
   // fmt is locale agnostic by default, so explicitly use current locale.
-  return fmt::format(std::locale{""}, "{:%x %X}", *local_time);
+  return fmt::format(Common::GetEnvironmentLocale(), "{:%x %X}", *local_time);
 }
 
 static std::string MakeStateFilename(u32 number)

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -330,7 +330,7 @@ void PostProcessingConfiguration::SaveOptionsConfiguration()
     case ConfigurationOption::OptionType::Float:
     {
       std::ostringstream value;
-      value.imbue(std::locale("C"));
+      value.imbue(std::locale::classic());
 
       for (size_t i = 0; i < it.second.m_float_values.size(); ++i)
       {


### PR DESCRIPTION
Tested on Windows and Linux. I've also slipped in a semi-related clean up in `PostProcessing.cpp` that isn't worth its own PR imo but if anyone feels strongly about it I can remove it.