### PR TITLE
Common: Add Android to GetNetplayDolphinVer

### DIFF
--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -80,11 +80,15 @@ const std::string& GetScmUpdateTrackStr()
 const std::string& GetNetplayDolphinVer()
 {
 #ifdef _WIN32
-  static const std::string netplay_dolphin_ver = SCM_DESC_STR " Win";
+  static const std::string netplay_dolphin_ver = SCM_DESC_STR " Windows";
 #elif __APPLE__
-  static const std::string netplay_dolphin_ver = SCM_DESC_STR " Mac";
+  static const std::string netplay_dolphin_ver = SCM_DESC_STR " macOS";
+#elif ANDROID
+  static const std::string netplay_dolphin_ver = SCM_DESC_STR " Android";
+#elif __linux__
+  static const std::string netplay_dolphin_ver = SCM_DESC_STR " Linux";
 #else
-  static const std::string netplay_dolphin_ver = SCM_DESC_STR " Lin";
+  static const std::string netplay_dolphin_ver = SCM_DESC_STR;
 #endif
   return netplay_dolphin_ver;
 }


### PR DESCRIPTION
This makes Android players show up as "Droid" instead of "Lin". (This is only visible in DolphinQt, not in the Android GUI.)