### PR TITLE
GameList: Enable word wrap in grid view

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -359,7 +359,7 @@ void GameList::MakeGridView()
 
   m_grid->setViewMode(QListView::IconMode);
   m_grid->setResizeMode(QListView::Adjust);
-  m_grid->setUniformItemSizes(true);
+  m_grid->setWordWrap(true);
   m_grid->setContextMenuPolicy(Qt::CustomContextMenu);
   m_grid->setFrameStyle(QFrame::NoFrame);
 


### PR DESCRIPTION
Before/After Comparison:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/74daf7b4-a722-4cb4-88c3-5b4f11d71b6c" />

<img width="1920" height="1073" alt="image" src="https://github.com/user-attachments/assets/e5efc2ac-8706-46ee-98c2-805df91904af" />
