### PR TITLE
GameSettings: Set texture cache accuracy for Pokémon Channel

### DIFF
--- a/Data/Sys/GameSettings/GPA.ini
+++ b/Data/Sys/GameSettings/GPA.ini
@@ -10,5 +10,9 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
+# Required for Smeargle Paint
 EFBToTextureEnable = False
 
+[Video_Settings]
+# Avoid skipping frames in the anime (most noticeable in part 3)
+SafeTextureCacheColorSamples = 2048


### PR DESCRIPTION
This game contains a special episode of the Pokémon anime as an FMV. When playing it, if only a tiny part of the image has changed between frames, Dolphin's texture hashing can fail to notice that anything changed, or it can notice that the chroma changed but not the luma, or vice versa.

512 samples reduces the problem but doesn't get rid of it entirely, but with 2048 I'm unable to see the problem.