### PR TITLE
Core: Fix controllers resetting when starting input recording

### DIFF
--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -116,6 +116,29 @@ void SaveToDTM(Movie::DTMHeader* dtm)
 
   dtm->bFollowBranch = Config::Get(Config::MAIN_JIT_FOLLOW_BRANCH);
 
+  dtm->controllers = 0;
+  dtm->bongos = 0;
+  dtm->GBAControllers = 0;
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
+  {
+    const SerialInterface::SIDevices si_device = Config::Get(Config::GetInfoForSIDevice(i));
+    if (si_device != SerialInterface::SIDEVICE_NONE)
+      dtm->controllers |= 1 << i;
+
+    if (si_device == SerialInterface::SIDEVICE_GC_GBA_EMULATED)
+      dtm->GBAControllers |= 1 << i;
+    else if (si_device == SerialInterface::SIDEVICE_GC_TARUKONGA)
+      dtm->bongos |= 1 << i;
+  }
+  if (dtm->bWii)
+  {
+    for (int i = 0; i < MAX_WIIMOTES; ++i)
+    {
+      if (Config::Get(Config::GetInfoForWiimoteSource(i)) != WiimoteSource::None)
+        dtm->controllers |= 1 << (i + 4);
+    }
+  }
+
   // Settings which only existed in old Dolphin versions
   dtm->bSkipIdle = true;
   dtm->bEFBCopyEnable = true;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1309,17 +1309,6 @@ void MovieManager::SaveRecording(const std::string& filename)
   header.filetype[3] = 0x1A;
   strncpy(header.gameID.data(), SConfig::GetInstance().GetGameID().c_str(), 6);
   header.bWii = m_system.IsWii();
-  header.controllers = 0;
-  header.GBAControllers = 0;
-  for (int i = 0; i < 4; ++i)
-  {
-    if (IsUsingGBA(i))
-      header.GBAControllers |= 1 << i;
-    if (IsUsingPad(i))
-      header.controllers |= 1 << i;
-    if (IsUsingWiimote(i) && m_system.IsWii())
-      header.controllers |= 1 << (i + 4);
-  }
 
   header.bFromSaveState = m_recording_from_save_state;
   header.frameCount = m_total_frames;
@@ -1336,7 +1325,6 @@ void MovieManager::SaveRecording(const std::string& filename)
   strncpy(header.discChange.data(), m_disc_change_filename.c_str(), header.discChange.size());
   strncpy(header.author.data(), m_author.c_str(), header.author.size());
   header.md5 = m_md5;
-  header.bongos = m_bongos;
   header.revision = m_revision;
   header.DSPiromHash = m_dsp_irom_hash;
   header.DSPcoefHash = m_dsp_coef_hash;


### PR DESCRIPTION
PR #14619 added controller handling to `MovieConfigLayerLoader`'s `LoadFromDTM` but not `SaveToDTM`. This caused a regression. When starting a new input recording, `MovieManager::BeginRecordingInput` calls `SaveToDTM`, which doesn't set the controller values in the DTM header to anything. Then it loads the newly created movie config layer, causing `LoadFromDTM` to be called, which in turn causes zeroed out controller values to be loaded from the DTM header. This leaves the player with all controllers set to None, making it impossible to control the game.

To fix this, let's move the saving of controllers from `MovieManager::SaveRecording` to `ConfigLoaders::SaveToDTM`.