### PR TITLE
Android: Implement Save File Manager

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -148,6 +148,12 @@
             android:exported="false"
             android:theme="@style/Theme.Dolphin.Main" />
 
+        <activity
+            android:name=".savemanager.ui.SaveManagerActivity"
+            android:exported="false"
+            android:label="@string/save_file_manager"
+            android:theme="@style/Theme.Dolphin.Main" />
+
         <service
             android:name=".services.SyncChannelJobService"
             android:exported="false"

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.kt
@@ -117,7 +117,9 @@ enum class StringSetting(
     NETPLAY_ADDRESS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_NETPLAY, "Address", "127.0.0.1"),
     NETPLAY_NICKNAME(Settings.FILE_DOLPHIN, Settings.SECTION_INI_NETPLAY, "Nickname", "Player"),
     NETPLAY_GAME(Settings.FILE_DOLPHIN, Settings.SECTION_INI_NETPLAY, "Game", ""),
-    NETPLAY_NETWORK_MODE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_NETPLAY, "NetworkMode", "fixeddelay");
+    NETPLAY_NETWORK_MODE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_NETPLAY, "NetworkMode", "fixeddelay"),
+    MAIN_MEMCARD_A_PATH(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "MemcardAPath", ""),
+    MAIN_MEMCARD_B_PATH(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "MemcardBPath", "");
 
     override val isOverridden: Boolean
         get() = NativeConfig.isOverridden(file, section, key)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.kt
@@ -17,6 +17,7 @@ enum class MenuTag {
     CONFIG_ACHIEVEMENTS("config_achievements"),
     CONFIG_ADVANCED("config_advanced"),
     CONFIG_LOG("config_log"),
+    CONFIG_SAVE_FILE_MANAGER("config_save_file_manager"),
     DEBUG("debug"),
     GRAPHICS("graphics"),
     ENHANCEMENTS("enhancements"),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.dolphinemu.dolphinemu.R
 import org.dolphinemu.dolphinemu.databinding.FragmentSettingsBinding
+import org.dolphinemu.dolphinemu.savemanager.ui.SaveManagerActivity
 import org.dolphinemu.dolphinemu.features.settings.model.Settings
 import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem
 import org.dolphinemu.dolphinemu.features.settings.ui.viewholder.SettingViewHolder
@@ -227,6 +228,12 @@ class SettingsFragment : Fragment(), SettingsFragmentView {
             return
         }
 
+        if (menuKey == MenuTag.CONFIG_SAVE_FILE_MANAGER) {
+            val intent = Intent(requireContext(), SaveManagerActivity::class.java)
+            startActivity(intent)
+            return
+        }
+
         activityView!!.showSettingsFragment(
             menuKey, null, true, requireArguments().getString(ARGUMENT_GAME_ID)!!
         )
@@ -392,6 +399,7 @@ class SettingsFragment : Fragment(), SettingsFragmentView {
             titles[MenuTag.STATISTICS] = R.string.statistics_submenu
             titles[MenuTag.ADVANCED_GRAPHICS] = R.string.advanced_graphics_submenu
             titles[MenuTag.CONFIG_LOG] = R.string.log_submenu
+            titles[MenuTag.CONFIG_SAVE_FILE_MANAGER] = R.string.save_file_manager
             titles[MenuTag.GCPAD_TYPE] = R.string.gcpad_settings
             titles[MenuTag.WIIMOTE] = R.string.wiimote_settings
             titles[MenuTag.WIIMOTE_EXTENSION] = R.string.wiimote_extensions

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -367,6 +367,7 @@ class SettingsFragmentPresenter(
         sl.add(SubmenuSetting(context, R.string.achievements_submenu, MenuTag.CONFIG_ACHIEVEMENTS))
         sl.add(SubmenuSetting(context, R.string.advanced_submenu, MenuTag.CONFIG_ADVANCED))
         sl.add(SubmenuSetting(context, R.string.log_submenu, MenuTag.CONFIG_LOG))
+        sl.add(SubmenuSetting(context, R.string.save_file_manager, MenuTag.CONFIG_SAVE_FILE_MANAGER))
         sl.add(SubmenuSetting(context, R.string.debug_submenu, MenuTag.DEBUG))
         sl.add(
             RunRunnable(

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/savemanager/model/SaveManagerModels.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/savemanager/model/SaveManagerModels.kt
@@ -1,0 +1,45 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.savemanager.model
+
+import androidx.annotation.Keep
+
+@Keep
+data class GCSaveFile(
+    val index: Int,
+    val title: String,
+    val subtitle: String,
+    val gameId: String,
+    val companyId: String,
+    val region: Int,
+    val blockSize: Int,
+    val banner: IntArray?,
+    val iconFrames: Array<IntArray>?,
+    val iconDelay: Int
+)
+
+@Keep
+data class GCMemcardStats(
+    val freeBlocks: Int,
+    val freeFiles: Int
+)
+
+@Keep
+data class WiiSaveFile(
+    val titleId: Long,
+    val gameId: String,
+    val title: String,
+    val description: String,
+    val region: Int,
+    val banner: IntArray?
+)
+
+@Keep
+data class GBASaveFile(
+    val fileName: String,
+    val filePath: String,
+    val slot: Int,
+    val gameName: String,
+    val lastModified: Long
+)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/savemanager/model/SaveManagerNative.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/savemanager/model/SaveManagerNative.kt
@@ -1,0 +1,44 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.savemanager.model
+
+object SaveManagerNative {
+    // GameCube methods
+    @JvmStatic
+    external fun getGCSaveFiles(path: String): Array<GCSaveFile>
+
+    @JvmStatic
+    external fun getGCMemcardStats(path: String): GCMemcardStats?
+
+    @JvmStatic
+    external fun copyGCSaveFile(srcPath: String, index: Int, dstPath: String): Boolean
+
+    @JvmStatic
+    external fun deleteGCSaveFile(path: String, index: Int): Boolean
+
+    @JvmStatic
+    external fun exportGCSaveFile(srcPath: String, index: Int, dstPath: String): Boolean
+
+    @JvmStatic
+    external fun importGCSaveFile(srcPath: String, dstPath: String): Boolean
+
+    @JvmStatic
+    external fun fixGCChecksums(path: String): Boolean
+
+    // Wii methods
+    @JvmStatic
+    external fun getWiiSaveFiles(): Array<WiiSaveFile>
+
+    @JvmStatic
+    external fun deleteWiiSaveFile(titleId: Long): Boolean
+
+    @JvmStatic
+    external fun exportWiiSaveFile(titleId: Long, dstPath: String): Int
+
+    @JvmStatic
+    external fun importWiiSaveFile(srcPath: String, overwrite: Boolean): Int
+
+    @JvmStatic
+    external fun getWiiSaveTitleId(srcPath: String): Long
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/savemanager/ui/SaveManagerActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/savemanager/ui/SaveManagerActivity.kt
@@ -1,0 +1,1122 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.savemanager.ui
+
+import android.content.res.Configuration
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.math.abs
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.graphics.createBitmap
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.dolphinemu.dolphinemu.R
+import org.dolphinemu.dolphinemu.features.savemanager.model.GBASaveFile
+import org.dolphinemu.dolphinemu.features.savemanager.model.GCSaveFile
+import org.dolphinemu.dolphinemu.features.savemanager.model.WiiSaveFile
+import org.dolphinemu.dolphinemu.features.savemanager.ui.SaveManagerViewModel
+import org.dolphinemu.dolphinemu.ui.main.ThemeProvider
+import org.dolphinemu.dolphinemu.ui.theme.DolphinTheme
+import org.dolphinemu.dolphinemu.utils.ContentHandler
+import org.dolphinemu.dolphinemu.utils.ThemeHelper
+import java.io.File
+import java.io.FileOutputStream
+import kotlin.time.Duration.Companion.milliseconds
+
+class SaveManagerActivity : AppCompatActivity(), ThemeProvider {
+    override var themeId: Int = 0
+    private val viewModel: SaveManagerViewModel by viewModels()
+
+    // GameCube state
+    private var pendingGCImportSlot = 0
+    private var pendingGCExportSlot = 0
+    private var pendingGCExportIndex = 0
+
+    // Wii state
+    private var pendingWiiExportTitleId = 0L
+    private var pendingWiiImportPath by mutableStateOf<String?>(null)
+    private var pendingWiiImportTitle by mutableStateOf<String?>(null)
+
+    private val gcImportPicker =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+            uri?.let {
+                lifecycleScope.launch {
+                    if (!viewModel.importSave(pendingGCImportSlot, it.toString())) {
+                        Toast.makeText(
+                            this@SaveManagerActivity,
+                            R.string.import_failed_generic,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+        }
+
+    private val gcExportPicker =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) { uri ->
+            uri?.let {
+                lifecycleScope.launch {
+                    if (!viewModel.exportSave(
+                            pendingGCExportSlot,
+                            pendingGCExportIndex,
+                            it.toString()
+                        )
+                    ) {
+                        Toast.makeText(
+                            this@SaveManagerActivity,
+                            R.string.export_failed,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+        }
+
+    private val wiiImportPicker =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+            uri?.let {
+                lifecycleScope.launch {
+                    val titleId = viewModel.getImportTitleId(it.toString())
+                    val existing = viewModel.wiiSaves.value.find { it.titleId == titleId }
+                    if (existing != null) {
+                        pendingWiiImportPath = it.toString()
+                        pendingWiiImportTitle = existing.title
+                    } else {
+                        performWiiImport(it.toString())
+                    }
+                }
+            }
+        }
+
+    private fun performWiiImport(path: String, overwrite: Boolean = false) {
+        lifecycleScope.launch {
+            if (!viewModel.importSave(path, overwrite)) {
+                Toast.makeText(
+                    this@SaveManagerActivity,
+                    R.string.import_failed_generic,
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+            pendingWiiImportPath = null
+            pendingWiiImportTitle = null
+        }
+    }
+
+    private val wiiExportPicker =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) { uri ->
+            uri?.let {
+                lifecycleScope.launch {
+                    if (!viewModel.exportSave(pendingWiiExportTitleId, it.toString())) {
+                        Toast.makeText(
+                            this@SaveManagerActivity,
+                            R.string.export_failed,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+        }
+
+    private var gbaImportSlotSelector: ((File) -> Unit)? = null
+    private val gbaImportPicker =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+            uri?.let {
+                lifecycleScope.launch {
+                    val displayName =
+                        ContentHandler.getDisplayName(it) ?: it.lastPathSegment ?: "import.sav"
+                    val tempFile = File(cacheDir, displayName)
+                    contentResolver.openInputStream(it)?.use { input ->
+                        FileOutputStream(tempFile).use { output -> input.copyTo(output) }
+                    }
+                    gbaImportSlotSelector?.invoke(tempFile)
+                }
+            }
+        }
+
+    private var pendingGbaExportPath: String? = null
+    private val gbaExportPicker =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) { uri ->
+            uri?.let {
+                lifecycleScope.launch {
+                    pendingGbaExportPath?.let { srcPath ->
+                        val srcFile = File(srcPath)
+                        if (srcFile.exists()) {
+                            contentResolver.openOutputStream(it)?.use { output ->
+                                srcFile.inputStream().use { input -> input.copyTo(output) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        ThemeHelper.setTheme(this)
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        viewModel.refreshAvailableFiles()
+        viewModel.loadSaves()
+        viewModel.loadGbaSaves()
+
+        val initialTab = TAB_GAMECUBE
+
+        setContent {
+            DolphinTheme {
+                SaveManagerScreen(
+                    viewModel = viewModel,
+                    initialTab = initialTab,
+                    onGCImport = { slot ->
+                        pendingGCImportSlot = slot
+                        gcImportPicker.launch("*/*")
+                    },
+                    onGCExport = { slot, index, name ->
+                        pendingGCExportSlot = slot
+                        pendingGCExportIndex = index
+                        gcExportPicker.launch(name)
+                    },
+                    onWiiImport = { wiiImportPicker.launch("*/*") },
+                    onWiiExport = { titleId, name ->
+                        pendingWiiExportTitleId = titleId
+                        wiiExportPicker.launch(name)
+                    },
+                    onGbaImport = { selector ->
+                        gbaImportSlotSelector = selector
+                        gbaImportPicker.launch("*/*")
+                    },
+                    onGbaExport = { path, name ->
+                        pendingGbaExportPath = path
+                        gbaExportPicker.launch(name)
+                    }
+                )
+
+                if (pendingWiiImportPath != null) {
+                    AlertDialog(
+                        onDismissRequest = {
+                            pendingWiiImportPath = null
+                            pendingWiiImportTitle = null
+                        },
+                        title = { Text(stringResource(R.string.import_save)) },
+                        text = {
+                            Text(
+                                "A save already exists for ${pendingWiiImportTitle ?: "this game"}. Overwrite it?"
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                performWiiImport(pendingWiiImportPath!!, overwrite = true)
+                            }) {
+                                Text(stringResource(R.string.ok))
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = {
+                                pendingWiiImportPath = null
+                                pendingWiiImportTitle = null
+                            }) {
+                                Text(stringResource(R.string.cancel))
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun setTheme(themeId: Int) {
+        super.setTheme(themeId)
+        this.themeId = themeId
+    }
+
+    override fun onResume() {
+        ThemeHelper.setCorrectTheme(this)
+        super.onResume()
+    }
+
+    companion object {
+        const val TAB_GAMECUBE = 0
+        const val TAB_WII = 1
+        const val TAB_GBA = 2
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SaveManagerScreen(
+    viewModel: SaveManagerViewModel,
+    initialTab: Int,
+    onGCImport: (Int) -> Unit,
+    onGCExport: (Int, Int, String) -> Unit,
+    onWiiImport: () -> Unit,
+    onWiiExport: (Long, String) -> Unit,
+    onGbaImport: (((File) -> Unit)) -> Unit,
+    onGbaExport: (String, String) -> Unit
+) {
+    var selectedTab by remember { mutableIntStateOf(initialTab) }
+    val tabs = listOf(R.string.gamecube_submenu, R.string.wii_submenu, R.string.gba_submenu)
+
+    var showGbaSlotDialog by remember { mutableStateOf(false) }
+    var pendingGbaFile by remember { mutableStateOf<File?>(null) }
+    var gbaImportOverwriteSlot by remember { mutableStateOf<Int?>(null) }
+    val scope = rememberCoroutineScope()
+
+    if (showGbaSlotDialog && pendingGbaFile != null) {
+        val context = LocalContext.current
+        AlertDialog(
+            onDismissRequest = { showGbaSlotDialog = false },
+            title = { Text(stringResource(R.string.gba_select_import_slot)) },
+            text = {
+                Column {
+                    (1..5).forEach { slot ->
+                        val label = if (slot == 5) "GBPlayer" else "Slot $slot"
+                        DropdownMenuItem(
+                            text = { Text(label) },
+                            onClick = {
+                                val nameWithoutExt = pendingGbaFile!!.nameWithoutExtension.let {
+                                    if (it.length >= 3 && it[it.length - 2] == '-' && it.last() in '1'..'5') {
+                                        it.substring(0, it.length - 2)
+                                    } else it
+                                }
+                                if (viewModel.gbaSaveExists(nameWithoutExt, slot)) {
+                                    gbaImportOverwriteSlot = slot
+                                    showGbaSlotDialog = false
+                                } else {
+                                    scope.launch {
+                                        if (viewModel.importGbaSave(pendingGbaFile!!, slot)) {
+                                            Toast.makeText(
+                                                context,
+                                                "Imported to $label",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        } else {
+                                            Toast.makeText(
+                                                context,
+                                                R.string.import_failed_generic,
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        }
+                                        showGbaSlotDialog = false
+                                    }
+                                }
+                            }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showGbaSlotDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    if (gbaImportOverwriteSlot != null && pendingGbaFile != null) {
+        val context = LocalContext.current
+        val slot = gbaImportOverwriteSlot!!
+        val label = if (slot == 5) "GBPlayer" else "Slot $slot"
+        AlertDialog(
+            onDismissRequest = { gbaImportOverwriteSlot = null },
+            title = { Text(stringResource(R.string.import_save)) },
+            text = {
+                Text(stringResource(R.string.gba_slot_taken_overwrite, label))
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    scope.launch {
+                        if (viewModel.importGbaSave(pendingGbaFile!!, slot)) {
+                            Toast.makeText(
+                                context,
+                                "Imported to $label",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                        gbaImportOverwriteSlot = null
+                        pendingGbaFile = null
+                    }
+                }) {
+                    Text(stringResource(R.string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    gbaImportOverwriteSlot = null
+                }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            Column {
+                TopAppBar(title = { Text(stringResource(R.string.save_file_manager)) })
+                TabRow(selectedTabIndex = selectedTab) {
+                    tabs.forEachIndexed { index, titleRes ->
+                        Tab(
+                            selected = selectedTab == index,
+                            onClick = { selectedTab = index },
+                            text = { Text(stringResource(titleRes)) }
+                        )
+                    }
+                }
+            }
+        }
+    ) { paddingValues ->
+        Box(Modifier.padding(paddingValues)) {
+            when (selectedTab) {
+                SaveManagerActivity.TAB_GAMECUBE -> GCMemcardManagerContent(
+                    viewModel,
+                    onGCImport,
+                    onGCExport
+                )
+
+                SaveManagerActivity.TAB_WII -> WiiSaveManagerContent(
+                    viewModel,
+                    onWiiImport,
+                    onWiiExport
+                )
+
+                SaveManagerActivity.TAB_GBA -> GBASaveManagerContent(viewModel, {
+                    onGbaImport { file ->
+                        pendingGbaFile = file
+                        showGbaSlotDialog = true
+                    }
+                }, onGbaExport)
+            }
+        }
+    }
+}
+
+@Composable
+fun GCMemcardManagerContent(
+    viewModel: SaveManagerViewModel,
+    onImport: (Int) -> Unit,
+    onExport: (Int, Int, String) -> Unit
+) {
+    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val modifier = Modifier.fillMaxSize()
+
+    val slot = @Composable { num: Int, weightModifier: Modifier ->
+        SlotSection(
+            slotNum = num,
+            viewModel = viewModel,
+            onImport = { onImport(num) },
+            onExport = { idx: Int, name: String -> onExport(num, idx, name) },
+            modifier = weightModifier
+        )
+    }
+
+    if (isLandscape) {
+        Row(modifier) {
+            slot(1, Modifier.weight(1f))
+            VerticalDivider(thickness = 2.dp, color = Color.Gray)
+            slot(2, Modifier.weight(1f))
+        }
+    } else {
+        Column(modifier) {
+            slot(1, Modifier.weight(1f))
+            HorizontalDivider(thickness = 2.dp, color = Color.Gray)
+            slot(2, Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+fun WiiSaveManagerContent(
+    viewModel: SaveManagerViewModel,
+    onImport: () -> Unit,
+    onExport: (Long, String) -> Unit
+) {
+    val saves by viewModel.wiiSaves.collectAsState()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Spacer(Modifier.weight(1f))
+            Button(
+                onClick = onImport,
+                modifier = Modifier
+                    .height(32.dp)
+                    .widthIn(min = 110.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp),
+                shape = MaterialTheme.shapes.small
+            ) {
+                Text(
+                    stringResource(R.string.import_save),
+                    maxLines = 1,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            contentPadding = PaddingValues(8.dp),
+        ) {
+            items(saves, key = { it.titleId }) { save ->
+                WiiSaveItem(save) { action: String ->
+                    when (action) {
+                        "delete" -> viewModel.deleteSave(save.titleId)
+                        "export" -> onExport(save.titleId, "${save.gameId}.bin")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SlotSection(
+    slotNum: Int,
+    viewModel: SaveManagerViewModel,
+    onImport: () -> Unit,
+    onExport: (Int, String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val saves by (if (slotNum == 1) viewModel.slot1Saves else viewModel.slot2Saves).collectAsState()
+    val path by (if (slotNum == 1) viewModel.slot1Path else viewModel.slot2Path).collectAsState()
+    val stats by (if (slotNum == 1) viewModel.slot1Stats else viewModel.slot2Stats).collectAsState()
+    val availableFiles by viewModel.availableFiles.collectAsState()
+
+    var expanded by remember { mutableStateOf(false) }
+    val currentMemcard = remember(availableFiles, path) { availableFiles.find { it.path == path } }
+
+    Column(modifier.padding(horizontal = 8.dp, vertical = 2.dp)) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(if (slotNum == 1) R.string.slot_1 else R.string.slot_2),
+                style = MaterialTheme.typography.titleSmall
+            )
+            Spacer(Modifier.width(8.dp))
+            Box(Modifier.weight(1f)) {
+                OutlinedButton(
+                    onClick = { expanded = true },
+                    modifier = Modifier.fillMaxWidth(),
+                    contentPadding = PaddingValues(horizontal = 4.dp),
+                    shape = MaterialTheme.shapes.small
+                ) {
+                    Column(Modifier.weight(1f, fill = false)) {
+                        Text(
+                            text = currentMemcard?.displayName ?: "Select Card",
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                        stats?.let {
+                            Text(
+                                text = stringResource(
+                                    R.string.memcard_stats,
+                                    it.freeBlocks,
+                                    it.freeFiles
+                                ),
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontSize = 8.sp,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            )
+                        }
+                    }
+                    Icon(Icons.Default.ArrowDropDown, null)
+                }
+                DropdownMenu(expanded, { expanded = false }) {
+                    availableFiles.forEach { memcard ->
+                        DropdownMenuItem(
+                            text = { Text(memcard.displayName) },
+                            onClick = {
+                                viewModel.loadSaves(slotNum, memcard.path); expanded = false
+                            }
+                        )
+                    }
+                    if (path.isNotEmpty() && !File(path).isDirectory) {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.fix_checksums)) },
+                            leadingIcon = { Icon(Icons.Default.Build, null, Modifier.size(18.dp)) },
+                            onClick = {
+                                viewModel.fixChecksums(slotNum)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Button(
+                    onClick = onImport,
+                    enabled = path.isNotEmpty(),
+                    modifier = Modifier
+                        .padding(start = 4.dp)
+                        .height(32.dp)
+                        .widthIn(min = 110.dp),
+                    contentPadding = PaddingValues(horizontal = 8.dp),
+                    shape = MaterialTheme.shapes.small
+                ) {
+                    Text(
+                        stringResource(R.string.import_save),
+                        maxLines = 1,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                }
+            }
+        }
+
+        LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(vertical = 2.dp)) {
+            items(saves, key = { it.gameId + it.index }) { save ->
+                SaveItem(save) { action: String ->
+                    when (action) {
+                        "copy" -> viewModel.copySave(slotNum, save.index)
+                        "delete" -> viewModel.deleteSave(slotNum, save.index)
+                        "export" -> onExport(save.index, "${save.gameId}.gci")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SaveItem(save: GCSaveFile, onAction: (String) -> Unit) {
+    var showMenu by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 1.dp)
+            .clickable { showMenu = true },
+        shape = MaterialTheme.shapes.extraSmall,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(
+                alpha = 0.5f
+            )
+        )
+    ) {
+        Row(Modifier.padding(4.dp), verticalAlignment = Alignment.CenterVertically) {
+            AnimatedGCIcon(save, Modifier.size(40.dp))
+            Spacer(Modifier.width(8.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    save.title,
+                    style = MaterialTheme.typography.bodySmall.copy(fontSize = 12.sp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    save.subtitle,
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RegionFlag(save.region)
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        "${save.blockSize} blocks",
+                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp)
+                    )
+                }
+            }
+            save.banner?.let { banner ->
+                val bitmap = remember(save.gameId + save.index) {
+                    createBitmap(96, 32).apply { setPixels(banner, 0, 96, 0, 0, 96, 32) }
+                        .asImageBitmap()
+                }
+                Image(
+                    bitmap,
+                    null,
+                    Modifier.size(width = 120.dp, height = 40.dp),
+                    contentScale = ContentScale.FillBounds
+                )
+            }
+            Box {
+                IconButton(onClick = { showMenu = true }, Modifier.size(28.dp)) {
+                    Icon(Icons.Default.MoreVert, null, Modifier.size(16.dp))
+                }
+                DropdownMenu(showMenu, { showMenu = false }) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.copy_to_other_slot)) },
+                        onClick = { onAction("copy"); showMenu = false })
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.delete_save)) },
+                        onClick = { onAction("delete"); showMenu = false })
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.export_save)) },
+                        onClick = { onAction("export"); showMenu = false })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AnimatedGCIcon(save: GCSaveFile, modifier: Modifier = Modifier) {
+    val frames = save.iconFrames?.takeIf { it.isNotEmpty() } ?: return
+    var currentFrameIndex by remember(save.gameId + save.index) { mutableIntStateOf(0) }
+
+    val bitmaps = remember(save.gameId + save.index) {
+        frames.map { frame ->
+            createBitmap(32, 32).apply { setPixels(frame, 0, 32, 0, 0, 32, 32) }.asImageBitmap()
+        }
+    }
+
+    LaunchedEffect(save.gameId + save.index) {
+        if (bitmaps.size > 1) {
+            val msPerFrame = (when (save.iconDelay) {
+                1 -> 4; 2 -> 8; 3 -> 12; else -> 4
+            } * 1000L) / 60L
+            while (true) {
+                delay(msPerFrame.milliseconds)
+                currentFrameIndex = (currentFrameIndex + 1) % bitmaps.size
+            }
+        }
+    }
+
+    Image(bitmaps[currentFrameIndex], null, modifier)
+}
+
+@Composable
+fun WiiSaveItem(save: WiiSaveFile, onAction: (String) -> Unit) {
+    var showMenu by remember { mutableStateOf(value = false) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clickable { showMenu = true },
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Row(Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            save.banner?.let { banner ->
+                val bitmap = remember(save.titleId) {
+                    createBitmap(192, 64).apply { setPixels(banner, 0, 192, 0, 0, 192, 64) }
+                        .asImageBitmap()
+                }
+                Image(
+                    bitmap,
+                    null,
+                    Modifier.size(width = 96.dp, height = 32.dp),
+                    contentScale = ContentScale.FillBounds
+                )
+            } ?: Box(Modifier.size(width = 96.dp, height = 32.dp))
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(Modifier.weight(1f)) {
+                Text(
+                    save.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RegionFlag(save.region)
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        save.gameId,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Box {
+                IconButton(onClick = { showMenu = true }) {
+                    Icon(Icons.Default.MoreVert, null)
+                }
+                DropdownMenu(showMenu, { showMenu = false }) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.delete_save)) },
+                        onClick = { onAction("delete"); showMenu = false }
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.export_save)) },
+                        onClick = { onAction("export"); showMenu = false }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun RegionFlag(region: Int) {
+    val flagName = when (region) {
+        0 -> "Flag_Japan.png"; 1 -> "Flag_USA.png"; 2 -> "Flag_Europe.png"; else -> null
+    } ?: return
+    val context = LocalContext.current
+    val bitmap = remember(flagName) {
+        runCatching {
+            context.assets.open("Sys/Resources/$flagName").use { BitmapFactory.decodeStream(it) }
+        }.getOrNull()
+    }?.asImageBitmap() ?: return
+    Image(bitmap, null, Modifier.height(10.dp), contentScale = ContentScale.FillHeight)
+}
+
+@Composable
+fun GBASaveManagerContent(
+    viewModel: SaveManagerViewModel,
+    onImport: () -> Unit,
+    onExport: (String, String) -> Unit
+) {
+    val saves by viewModel.gbaSaves.collectAsState()
+    var showRenameDialog by remember { mutableStateOf<GBASaveFile?>(null) }
+    var showSlotDialog by remember { mutableStateOf<GBASaveFile?>(null) }
+    var gbaSlotOverwriteTarget by remember { mutableStateOf<Pair<GBASaveFile, Int>?>(null) }
+    var showDeleteConfirmation by remember { mutableStateOf<GBASaveFile?>(null) }
+
+    val tintColors = remember {
+        listOf(
+            Color(0x44FF8A80), // Red
+            Color(0x44FF80AB), // Pink
+            Color(0x44EA80FC), // Purple
+            Color(0x44B388FF), // Deep Purple
+            Color(0x448C9EFF), // Indigo
+            Color(0x4482B1FF), // Blue
+            Color(0x4480D8FF), // Light Blue
+            Color(0x4484FFFF), // Cyan
+            Color(0x44A7FFEB), // Teal
+            Color(0x44B9F6CA), // Green
+            Color(0x44CCFF90), // Light Green
+            Color(0x44F4FF81), // Lime
+            Color(0x44FFFF8D), // Yellow
+            Color(0x44FFE57F), // Amber
+            Color(0x44FFD180), // Orange
+            Color(0x44FF9E80)  // Deep Orange
+        )
+    }
+
+    val gameColors = remember(saves) {
+        saves.map { it.gameName }.distinct().associateWith { gameName ->
+            tintColors[abs(gameName.hashCode()) % tintColors.size]
+        }
+    }
+
+    if (gbaSlotOverwriteTarget != null) {
+        val (save, slot) = gbaSlotOverwriteTarget!!
+        val label = if (slot == 5) "GBPlayer" else "Slot $slot"
+        AlertDialog(
+            onDismissRequest = { gbaSlotOverwriteTarget = null },
+            title = { Text("Change Slot") },
+            text = {
+                Text(stringResource(R.string.gba_slot_taken_overwrite, label))
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.changeGbaSaveSlot(save, slot)
+                    gbaSlotOverwriteTarget = null
+                }) {
+                    Text(stringResource(R.string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { gbaSlotOverwriteTarget = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    if (showDeleteConfirmation != null) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmation = null },
+            title = { Text(stringResource(R.string.delete_save)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.cheats_delete_confirmation,
+                        showDeleteConfirmation!!.gameName
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteGbaSave(showDeleteConfirmation!!.filePath)
+                    showDeleteConfirmation = null
+                }) {
+                    Text(stringResource(R.string.delete_save))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirmation = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    if (showRenameDialog != null) {
+        var newName by remember { mutableStateOf(showRenameDialog!!.gameName) }
+        AlertDialog(
+            onDismissRequest = { showRenameDialog = null },
+            title = { Text(stringResource(R.string.cheats_edit)) },
+            text = {
+                TextField(
+                    value = newName,
+                    onValueChange = { newName = it },
+                    singleLine = true
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.renameGbaSave(showRenameDialog!!, newName)
+                    showRenameDialog = null
+                }) {
+                    Text(stringResource(R.string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRenameDialog = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    if (showSlotDialog != null) {
+        AlertDialog(
+            onDismissRequest = { showSlotDialog = null },
+            title = { Text(stringResource(R.string.gba_change_slot)) },
+            text = {
+                Column {
+                    (1..5).forEach { slot ->
+                        val label = if (slot == 5) "GBPlayer" else "Slot $slot"
+                        DropdownMenuItem(
+                            text = { Text(label) },
+                            onClick = {
+                                if (viewModel.gbaSaveExists(showSlotDialog!!.gameName, slot)) {
+                                    gbaSlotOverwriteTarget = showSlotDialog!! to slot
+                                } else {
+                                    viewModel.changeGbaSaveSlot(showSlotDialog!!, slot)
+                                }
+                                showSlotDialog = null
+                            }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showSlotDialog = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Spacer(Modifier.weight(1f))
+            Button(
+                onClick = onImport,
+                modifier = Modifier
+                    .height(32.dp)
+                    .widthIn(min = 110.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp),
+                shape = MaterialTheme.shapes.small
+            ) {
+                Text(
+                    stringResource(R.string.import_save),
+                    maxLines = 1,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            contentPadding = PaddingValues(8.dp),
+        ) {
+            items(saves, key = { it.filePath }) { save ->
+                val tintColor = gameColors[save.gameName] ?: Color.Transparent
+                GBASaveItem(save, tintColor) { action ->
+                    when (action) {
+                        "delete" -> showDeleteConfirmation = save
+                        "export" -> onExport(save.filePath, "${save.gameName}.sav")
+                        "rename" -> showRenameDialog = save
+                        "slot" -> showSlotDialog = save
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun GBASaveItem(save: GBASaveFile, tintColor: Color, onAction: (String) -> Unit) {
+    var showMenu by remember { mutableStateOf(false) }
+    val dateFormat = remember { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()) }
+    val dateText = remember(save.lastModified) { dateFormat.format(Date(save.lastModified)) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clickable { showMenu = true },
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(
+            containerColor = if (tintColor == Color.Transparent)
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+            else
+                tintColor
+        )
+    ) {
+        Row(Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier.size(40.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "GBA",
+                    style = MaterialTheme.typography.labelLarge.copy(
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                )
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(Modifier.weight(1f)) {
+                Text(
+                    save.gameName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    val slotText = if (save.slot == 5) "GBPlayer" else "Slot ${save.slot}"
+                    Card(
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer
+                        ),
+                        shape = MaterialTheme.shapes.extraSmall
+                    ) {
+                        Text(
+                            text = slotText,
+                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = dateText,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Box {
+                IconButton(onClick = { showMenu = true }) {
+                    Icon(Icons.Default.MoreVert, null)
+                }
+                DropdownMenu(showMenu, { showMenu = false }) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.export_save)) },
+                        onClick = { onAction("export"); showMenu = false }
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.cheats_edit)) },
+                        onClick = { onAction("rename"); showMenu = false }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Change Slot") },
+                        onClick = { onAction("slot"); showMenu = false }
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.delete_save)) },
+                        onClick = { onAction("delete"); showMenu = false }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/savemanager/ui/SaveManagerViewModel.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/savemanager/ui/SaveManagerViewModel.kt
@@ -1,0 +1,302 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package org.dolphinemu.dolphinemu.features.savemanager.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.dolphinemu.dolphinemu.NativeLibrary
+import org.dolphinemu.dolphinemu.features.savemanager.model.GBASaveFile
+import org.dolphinemu.dolphinemu.features.savemanager.model.GCMemcardStats
+import org.dolphinemu.dolphinemu.features.savemanager.model.GCSaveFile
+import org.dolphinemu.dolphinemu.features.savemanager.model.SaveManagerNative
+import org.dolphinemu.dolphinemu.features.savemanager.model.WiiSaveFile
+import java.io.File
+
+data class MemcardInfo(val path: String, val displayName: String)
+
+class SaveManagerViewModel : ViewModel() {
+    // GameCube Memcard State
+    private val _slot1Saves = MutableStateFlow<List<GCSaveFile>>(emptyList())
+    val slot1Saves: StateFlow<List<GCSaveFile>> = _slot1Saves
+
+    private val _slot2Saves = MutableStateFlow<List<GCSaveFile>>(emptyList())
+    val slot2Saves: StateFlow<List<GCSaveFile>> = _slot2Saves
+
+    private val _slot1Stats = MutableStateFlow<GCMemcardStats?>(null)
+    val slot1Stats: StateFlow<GCMemcardStats?> = _slot1Stats
+
+    private val _slot2Stats = MutableStateFlow<GCMemcardStats?>(null)
+    val slot2Stats: StateFlow<GCMemcardStats?> = _slot2Stats
+
+    private val _slot1Path = MutableStateFlow("")
+    val slot1Path: StateFlow<String> = _slot1Path
+
+    private val _slot2Path = MutableStateFlow("")
+    val slot2Path: StateFlow<String> = _slot2Path
+
+    private val _availableFiles = MutableStateFlow<List<MemcardInfo>>(emptyList())
+    val availableFiles: StateFlow<List<MemcardInfo>> = _availableFiles
+
+    // Wii State
+    private val _wiiSaves = MutableStateFlow<List<WiiSaveFile>>(emptyList())
+    val wiiSaves: StateFlow<List<WiiSaveFile>> = _wiiSaves
+
+    // GBA State
+    private val _gbaSaves = MutableStateFlow<List<GBASaveFile>>(emptyList())
+    val gbaSaves: StateFlow<List<GBASaveFile>> = _gbaSaves
+
+    // GameCube Memcard Methods
+    fun refreshAvailableFiles() {
+        val gcDir = File(NativeLibrary.GetUserDirectory(), "GC")
+
+        val priorityFolders = listOf(
+            "EUR/Card A", "EUR/Card B",
+            "USA/Card A", "USA/Card B",
+            "JAP/Card A", "JAP/Card B"
+        )
+
+        val files = mutableListOf<MemcardInfo>()
+
+        // Add priority folders
+        priorityFolders.forEach { relativePath ->
+            val folder = File(gcDir, relativePath)
+            files.add(MemcardInfo(folder.absolutePath, relativePath))
+        }
+
+        // Scan for .raw files
+        val rawFiles = mutableListOf<MemcardInfo>()
+        gcDir.listFiles()?.forEach { file ->
+            if (file.isFile && file.extension.lowercase() == "raw") {
+                rawFiles.add(MemcardInfo(file.absolutePath, file.name))
+            }
+        }
+        files.addAll(rawFiles.sortedBy { it.displayName })
+
+        _availableFiles.value = files
+    }
+
+    fun loadSaves(slot: Int, path: String) {
+        val saves = SaveManagerNative.getGCSaveFiles(path).toList()
+        val stats = SaveManagerNative.getGCMemcardStats(path)
+        if (slot == 1) {
+            _slot1Path.value = path
+            _slot1Saves.value = saves
+            _slot1Stats.value = stats
+        } else {
+            _slot2Path.value = path
+            _slot2Saves.value = saves
+            _slot2Stats.value = stats
+        }
+    }
+
+    fun copySave(srcSlot: Int, saveIndex: Int) {
+        viewModelScope.launch {
+            val srcPath = if (srcSlot == 1) _slot1Path.value else _slot2Path.value
+            val dstPath = if (srcSlot == 1) _slot2Path.value else _slot1Path.value
+
+            if (srcPath.isEmpty() || dstPath.isEmpty()) return@launch
+
+            if (withContext(Dispatchers.IO) {
+                    SaveManagerNative.copyGCSaveFile(
+                        srcPath,
+                        saveIndex,
+                        dstPath
+                    )
+                }) {
+                loadSaves(1, _slot1Path.value)
+                loadSaves(2, _slot2Path.value)
+            }
+        }
+    }
+
+    fun deleteSave(slot: Int, saveIndex: Int) {
+        viewModelScope.launch {
+            val path = if (slot == 1) _slot1Path.value else _slot2Path.value
+            if (path.isEmpty()) return@launch
+
+            if (withContext(Dispatchers.IO) {
+                    SaveManagerNative.deleteGCSaveFile(
+                        path,
+                        saveIndex
+                    )
+                }) {
+                loadSaves(slot, path)
+            }
+        }
+    }
+
+    suspend fun exportSave(slot: Int, saveIndex: Int, dstPath: String): Boolean =
+        withContext(Dispatchers.IO) {
+            val srcPath = if (slot == 1) _slot1Path.value else _slot2Path.value
+            if (srcPath.isEmpty()) return@withContext false
+
+            SaveManagerNative.exportGCSaveFile(srcPath, saveIndex, dstPath)
+        }
+
+    suspend fun importSave(slot: Int, srcPath: String): Boolean = withContext(Dispatchers.IO) {
+        val dstPath = if (slot == 1) _slot1Path.value else _slot2Path.value
+        if (dstPath.isEmpty()) return@withContext false
+
+        if (SaveManagerNative.importGCSaveFile(srcPath, dstPath)) {
+            loadSaves(slot, dstPath)
+            true
+        } else {
+            false
+        }
+    }
+
+    fun fixChecksums(slot: Int) {
+        viewModelScope.launch {
+            val path = if (slot == 1) _slot1Path.value else _slot2Path.value
+            if (path.isEmpty()) return@launch
+
+            if (withContext(Dispatchers.IO) { SaveManagerNative.fixGCChecksums(path) }) {
+                loadSaves(slot, path)
+            }
+        }
+    }
+
+    // Wii Methods
+    fun loadSaves() {
+        viewModelScope.launch {
+            val loadedSaves = withContext(Dispatchers.IO) {
+                SaveManagerNative.getWiiSaveFiles().toList()
+            }
+            _wiiSaves.value = loadedSaves
+        }
+    }
+
+    fun deleteSave(titleId: Long) {
+        viewModelScope.launch {
+            val success = withContext(Dispatchers.IO) {
+                SaveManagerNative.deleteWiiSaveFile(titleId)
+            }
+            if (success) {
+                loadSaves()
+            }
+        }
+    }
+
+    suspend fun exportSave(titleId: Long, dstPath: String): Boolean = withContext(Dispatchers.IO) {
+        SaveManagerNative.exportWiiSaveFile(titleId, dstPath) == 0
+    }
+
+    suspend fun importSave(srcPath: String, overwrite: Boolean = false): Boolean =
+        withContext(Dispatchers.IO) {
+            val result = SaveManagerNative.importWiiSaveFile(srcPath, overwrite)
+            if (result == 0) {
+                loadSaves()
+                true
+            } else {
+                false
+            }
+        }
+
+    fun getImportTitleId(srcPath: String): Long {
+        return SaveManagerNative.getWiiSaveTitleId(srcPath)
+    }
+
+    // GBA Methods
+    fun loadGbaSaves() {
+        viewModelScope.launch {
+            val gbaDir = File(NativeLibrary.GetUserDirectory(), "GBA/Saves")
+            val saves =
+                gbaDir.listFiles()?.filter { it.extension.lowercase() == "sav" }?.map { file ->
+                    val name = file.nameWithoutExtension
+                    var slot = 1
+                    var gameName = name
+                    if (name.length >= 3 && name[name.length - 2] == '-' && name.last().isDigit()) {
+                        val digit = name.last().toString().toInt()
+                        if (digit in 1..5) {
+                            slot = digit
+                            gameName = name.substring(0, name.length - 2)
+                        }
+                    }
+                    GBASaveFile(file.name, file.absolutePath, slot, gameName, file.lastModified())
+                }?.sortedWith(compareBy({ it.gameName }, { it.slot })) ?: emptyList()
+            _gbaSaves.value = saves
+        }
+    }
+
+    fun gbaSaveExists(gameName: String, slot: Int): Boolean {
+        val gbaDir = File(NativeLibrary.GetUserDirectory(), "GBA/Saves")
+        return File(gbaDir, "$gameName-$slot.sav").exists()
+    }
+
+    fun deleteGbaSave(filePath: String) {
+        viewModelScope.launch {
+            val file = File(filePath)
+            if (file.exists() && withContext(Dispatchers.IO) { file.delete() }) {
+                loadGbaSaves()
+            }
+        }
+    }
+
+    suspend fun importGbaSave(srcFile: File, slot: Int): Boolean = withContext(Dispatchers.IO) {
+        val gbaDir = File(NativeLibrary.GetUserDirectory(), "GBA/Saves")
+        if (!gbaDir.exists()) gbaDir.mkdirs()
+
+        var nameWithoutExt = srcFile.nameWithoutExtension
+        // If the file already has a slot suffix strip it before re-appending
+        if (nameWithoutExt.length >= 3 && nameWithoutExt[nameWithoutExt.length - 2] == '-') {
+            val lastChar = nameWithoutExt.last()
+            if (lastChar in '1'..'5') {
+                nameWithoutExt = nameWithoutExt.substring(0, nameWithoutExt.length - 2)
+            }
+        }
+
+        val destFileName = "$nameWithoutExt-$slot.sav"
+        val destFile = File(gbaDir, destFileName)
+
+        try {
+            srcFile.inputStream().use { input ->
+                destFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+            loadGbaSaves()
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    fun renameGbaSave(save: GBASaveFile, newName: String) {
+        viewModelScope.launch {
+            val file = File(save.filePath)
+            if (!file.exists()) return@launch
+
+            val gbaDir = file.parentFile ?: return@launch
+            val newFile = File(gbaDir, "$newName-${save.slot}.sav")
+
+            if (withContext(Dispatchers.IO) { file.renameTo(newFile) }) {
+                loadGbaSaves()
+            }
+        }
+    }
+
+    fun changeGbaSaveSlot(save: GBASaveFile, newSlot: Int) {
+        viewModelScope.launch {
+            val file = File(save.filePath)
+            if (!file.exists()) return@launch
+
+            val gbaDir = file.parentFile ?: return@launch
+            val newFile = File(gbaDir, "${save.gameName}-$newSlot.sav")
+
+            if (newFile.absolutePath == file.absolutePath) return@launch
+
+            if (withContext(Dispatchers.IO) {
+                    if (newFile.exists()) newFile.delete()
+                    file.renameTo(newFile)
+                }) {
+                loadGbaSaves()
+            }
+        }
+    }
+}

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -153,7 +153,22 @@
     <string name="triforce_ip_redirections">IP Redirections</string>
 
     <!-- Interface Preference Fragment -->
+    <string name="gba_submenu">GBA</string>
+    <string name="gba_change_slot">Change Slot</string>
+    <string name="gba_select_import_slot">Select Import Slot</string>
+    <string name="gba_slot_taken_overwrite">This slot is already taken by \"%1$s\". Overwrite it?</string>
     <string name="interface_submenu">Interface</string>
+    <string name="save_file_manager">Save File Manager</string>
+    <string name="slot_1">Slot 1</string>
+    <string name="slot_2">Slot 2</string>
+    <string name="import_save">Import Save</string>
+    <string name="export_save">Export Save</string>
+    <string name="import_failed_generic">Import failed</string>
+    <string name="export_failed">Export failed</string>
+    <string name="copy_to_other_slot">Copy to other slot</string>
+    <string name="delete_save">Delete Save</string>
+    <string name="fix_checksums">Fix Checksums</string>
+    <string name="memcard_stats">Free Blocks: %1$d      Free Files: %2$d</string>
     <string name="emulation_screen_orientation">Screen Orientation During Emulation</string>
     <string name="expand_to_cutout_area">Expand to Cutout Area</string>
     <string name="expand_to_cutout_area_description">Expands the display area to include the cutout (or notch) area.</string>

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -151,6 +151,15 @@ static jclass s_audio_utils_class;
 static jmethodID s_audio_utils_get_sample_rate;
 static jmethodID s_audio_utils_get_frames_per_buffer;
 
+static jclass s_gc_save_file_class;
+static jmethodID s_gc_save_file_constructor;
+
+static jclass s_gc_memcard_stats_class;
+static jmethodID s_gc_memcard_stats_constructor;
+
+static jclass s_wii_save_file_class;
+static jmethodID s_wii_save_file_constructor;
+
 namespace IDCache
 {
 JNIEnv* GetEnvForThread()
@@ -721,6 +730,36 @@ jmethodID GetAudioUtilsGetFramesPerBuffer()
   return s_audio_utils_get_frames_per_buffer;
 }
 
+jclass GetGCSaveFileClass()
+{
+  return s_gc_save_file_class;
+}
+
+jmethodID GetGCSaveFileConstructor()
+{
+  return s_gc_save_file_constructor;
+}
+
+jclass GetGCMemcardStatsClass()
+{
+  return s_gc_memcard_stats_class;
+}
+
+jmethodID GetGCMemcardStatsConstructor()
+{
+  return s_gc_memcard_stats_constructor;
+}
+
+jclass GetWiiSaveFileClass()
+{
+  return s_wii_save_file_class;
+}
+
+jmethodID GetWiiSaveFileConstructor()
+{
+  return s_wii_save_file_constructor;
+}
+
 }  // namespace IDCache
 
 extern "C" {
@@ -1015,6 +1054,29 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
       env->GetStaticMethodID(audio_utils_class, "getFramesPerBuffer", "()I");
   env->DeleteLocalRef(audio_utils_class);
 
+  const jclass gc_save_file_class =
+      env->FindClass("org/dolphinemu/dolphinemu/features/savemanager/model/GCSaveFile");
+  s_gc_save_file_class = reinterpret_cast<jclass>(env->NewGlobalRef(gc_save_file_class));
+  s_gc_save_file_constructor =
+      env->GetMethodID(s_gc_save_file_class, "<init>",
+                       "(ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/"
+                       "lang/String;II[I[[II)V");
+  env->DeleteLocalRef(gc_save_file_class);
+
+  const jclass gc_memcard_stats_class =
+      env->FindClass("org/dolphinemu/dolphinemu/features/savemanager/model/GCMemcardStats");
+  s_gc_memcard_stats_class = reinterpret_cast<jclass>(env->NewGlobalRef(gc_memcard_stats_class));
+  s_gc_memcard_stats_constructor = env->GetMethodID(s_gc_memcard_stats_class, "<init>", "(II)V");
+  env->DeleteLocalRef(gc_memcard_stats_class);
+
+  const jclass wii_save_file_class =
+      env->FindClass("org/dolphinemu/dolphinemu/features/savemanager/model/WiiSaveFile");
+  s_wii_save_file_class = reinterpret_cast<jclass>(env->NewGlobalRef(wii_save_file_class));
+  s_wii_save_file_constructor =
+      env->GetMethodID(s_wii_save_file_class, "<init>",
+                       "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;I[I)V");
+  env->DeleteLocalRef(wii_save_file_class);
+
   return JNI_VERSION;
 }
 
@@ -1054,5 +1116,8 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved)
   env->DeleteGlobalRef(s_input_detector_class);
   env->DeleteGlobalRef(s_permission_handler_class);
   env->DeleteGlobalRef(s_audio_utils_class);
+  env->DeleteGlobalRef(s_gc_save_file_class);
+  env->DeleteGlobalRef(s_gc_memcard_stats_class);
+  env->DeleteGlobalRef(s_wii_save_file_class);
 }
 }

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -150,4 +150,13 @@ jclass GetAudioUtilsClass();
 jmethodID GetAudioUtilsGetSampleRate();
 jmethodID GetAudioUtilsGetFramesPerBuffer();
 
+jclass GetGCSaveFileClass();
+jmethodID GetGCSaveFileConstructor();
+
+jclass GetGCMemcardStatsClass();
+jmethodID GetGCMemcardStatsConstructor();
+
+jclass GetWiiSaveFileClass();
+jmethodID GetWiiSaveFileConstructor();
+
 }  // namespace IDCache

--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -37,6 +37,8 @@ add_library(main SHARED
   RiivolutionPatches.cpp
   SkylanderConfig.cpp
   WiiUtils.cpp
+  GCMemcardManager.cpp
+  WiiSaveManager.cpp
 )
 
 target_link_libraries(main

--- a/Source/Android/jni/GCMemcardManager.cpp
+++ b/Source/Android/jni/GCMemcardManager.cpp
@@ -1,0 +1,266 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <cctype>
+#include <jni.h>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "Common/CommonPaths.h"
+#include "Common/FileUtil.h"
+#include "Core/HW/GCMemcard/GCMemcard.h"
+#include "Core/HW/GCMemcard/GCMemcardUtils.h"
+#include "DiscIO/Enums.h"
+#include "jni/AndroidCommon/AndroidCommon.h"
+#include "jni/AndroidCommon/IDCache.h"
+
+namespace
+{
+jintArray ToJIntArray(JNIEnv* env, const std::vector<u32>& data)
+{
+  jintArray jarray = env->NewIntArray(static_cast<jsize>(data.size()));
+  env->SetIntArrayRegion(jarray, 0, static_cast<jsize>(data.size()),
+                         reinterpret_cast<const jint*>(data.data()));
+  return jarray;
+}
+
+jobject CreateGCSaveFile(JNIEnv* env, const Memcard::GCMemcard& card, u8 file_index,
+                         int override_index = -1)
+{
+  auto dentry = card.GetDEntry(file_index);
+  if (!dentry)
+    return nullptr;
+
+  auto comments = card.GetSaveComments(file_index);
+  auto banner = card.ReadBannerRGBA8(file_index);
+  auto anim = card.ReadAnimRGBA8(file_index);
+
+  jintArray jbanner = banner ? ToJIntArray(env, *banner) : nullptr;
+  jobjectArray jicons = nullptr;
+  int delay = 0;
+  if (anim && !anim->empty())
+  {
+    jclass int_array_class = env->FindClass("[I");
+    jicons = env->NewObjectArray(static_cast<jsize>(anim->size()), int_array_class, nullptr);
+    for (size_t i = 0; i < anim->size(); ++i)
+    {
+      jintArray jframe = ToJIntArray(env, (*anim)[i].image_data);
+      env->SetObjectArrayElement(jicons, static_cast<jsize>(i), jframe);
+      env->DeleteLocalRef(jframe);
+    }
+    delay = (*anim)[0].delay;
+    env->DeleteLocalRef(int_array_class);
+  }
+
+  int region = static_cast<int>(DiscIO::CountryCodeToRegion(static_cast<u8>(dentry->m_gamecode[3]),
+                                                            DiscIO::Platform::GameCubeDisc,
+                                                            DiscIO::Region::Unknown));
+
+  jstring jtitle = ToJString(env, comments ? comments->first : "");
+  jstring jsubtitle = ToJString(env, comments ? comments->second : "");
+  jstring jgame_id =
+      ToJString(env, std::string(reinterpret_cast<const char*>(dentry->m_gamecode.data()), 4));
+  jstring jcompany_id =
+      ToJString(env, std::string(reinterpret_cast<const char*>(dentry->m_makercode.data()), 2));
+
+  jobject jfile = env->NewObject(IDCache::GetGCSaveFileClass(), IDCache::GetGCSaveFileConstructor(),
+                                 (jint)(override_index >= 0 ? override_index : file_index), jtitle,
+                                 jsubtitle, jgame_id, jcompany_id, (jint)region,
+                                 (jint)dentry->m_block_count, jbanner, jicons, (jint)delay);
+
+  env->DeleteLocalRef(jtitle);
+  env->DeleteLocalRef(jsubtitle);
+  env->DeleteLocalRef(jgame_id);
+  env->DeleteLocalRef(jcompany_id);
+  if (jbanner)
+    env->DeleteLocalRef(jbanner);
+  if (jicons)
+    env->DeleteLocalRef(jicons);
+
+  return jfile;
+}
+
+void GetGciFiles(const File::FSTEntry& entry, std::vector<std::string>& gci_files)
+{
+  if (entry.isDirectory)
+  {
+    for (const auto& child : entry.children)
+      GetGciFiles(child, gci_files);
+  }
+  else
+  {
+    auto pos = entry.physicalName.find_last_of('.');
+    if (pos != std::string::npos)
+    {
+      std::string ext = entry.physicalName.substr(pos + 1);
+      std::transform(ext.begin(), ext.end(), ext.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      if (ext == "gci")
+        gci_files.push_back(entry.physicalName);
+    }
+  }
+}
+
+std::optional<Memcard::Savefile> ExportFromFileOrCard(const std::string& path, int index)
+{
+  if (File::IsDirectory(path))
+  {
+    std::vector<std::string> gci_files;
+    GetGciFiles(File::ScanDirectoryTree(path, false), gci_files);
+    if (index < 0 || index >= static_cast<int>(gci_files.size()))
+      return std::nullopt;
+
+    auto res = Memcard::ReadSavefile(gci_files[index]);
+    if (auto* savefile = std::get_if<Memcard::Savefile>(&res))
+      return *savefile;
+    return std::nullopt;
+  }
+  auto [error, card] = Memcard::GCMemcard::Open(path);
+  return card ? card->ExportFile(static_cast<u8>(index)) : std::nullopt;
+}
+
+bool ImportToFileOrCard(const std::string& path, const Memcard::Savefile& savefile)
+{
+  if (File::IsDirectory(path))
+  {
+    std::string full_path = path + DIR_SEP + Memcard::GenerateFilename(savefile.dir_entry) + ".gci";
+    return Memcard::WriteSavefile(full_path, savefile, Memcard::SavefileFormat::GCI);
+  }
+  auto [error, card] = Memcard::GCMemcard::Open(path);
+  return card && card->ImportFile(savefile) == Memcard::GCMemcardImportFileRetVal::SUCCESS &&
+         card->Save();
+}
+}  // namespace
+
+extern "C" {
+
+JNIEXPORT jobjectArray JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_getGCSaveFiles(
+    JNIEnv* env, jclass, jstring jpath)
+{
+  std::string path = GetJString(env, jpath);
+  if (File::IsDirectory(path))
+  {
+    std::vector<std::string> gci_files;
+    GetGciFiles(File::ScanDirectoryTree(path, false), gci_files);
+
+    jobjectArray jfiles = env->NewObjectArray(static_cast<jsize>(gci_files.size()),
+                                              IDCache::GetGCSaveFileClass(), nullptr);
+    std::string dummy_path = File::GetUserPath(D_CACHE_IDX) + "temp_card.raw";
+    if (auto card = Memcard::GCMemcard::Create(dummy_path, {}, Memcard::MBIT_SIZE_MEMORY_CARD_2043,
+                                               false, 0, 0, 0))
+    {
+      for (size_t i = 0; i < gci_files.size(); ++i)
+      {
+        auto res = Memcard::ReadSavefile(gci_files[i]);
+        if (auto* savefile = std::get_if<Memcard::Savefile>(&res))
+        {
+          card->Format({}, Memcard::MBIT_SIZE_MEMORY_CARD_2043, false, 0, 0, 0);
+          card->ImportFile(*savefile);
+          if (auto index = card->TitlePresent(savefile->dir_entry))
+          {
+            if (jobject jfile = CreateGCSaveFile(env, *card, *index, static_cast<int>(i)))
+            {
+              env->SetObjectArrayElement(jfiles, static_cast<jsize>(i), jfile);
+              env->DeleteLocalRef(jfile);
+            }
+          }
+        }
+      }
+    }
+    File::Delete(dummy_path);
+    return jfiles;
+  }
+
+  auto [error_code, memcard] = Memcard::GCMemcard::Open(path);
+  if (error_code.HasCriticalErrors() || !memcard || !memcard->IsValid())
+    return env->NewObjectArray(0, IDCache::GetGCSaveFileClass(), nullptr);
+
+  u8 num_files = memcard->GetNumFiles();
+  jobjectArray jfiles = env->NewObjectArray(num_files, IDCache::GetGCSaveFileClass(), nullptr);
+  for (u8 i = 0; i < num_files; ++i)
+  {
+    jobject jfile = CreateGCSaveFile(env, *memcard, memcard->GetFileIndex(i));
+    env->SetObjectArrayElement(jfiles, i, jfile);
+    env->DeleteLocalRef(jfile);
+  }
+  return jfiles;
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_getGCMemcardStats(
+    JNIEnv* env, jclass, jstring jpath)
+{
+  std::string path = GetJString(env, jpath);
+  if (File::IsDirectory(path))
+    return nullptr;
+
+  auto [error_code, memcard] = Memcard::GCMemcard::Open(path);
+  if (error_code.HasCriticalErrors() || !memcard || !memcard->IsValid())
+    return nullptr;
+
+  return env->NewObject(IDCache::GetGCMemcardStatsClass(), IDCache::GetGCMemcardStatsConstructor(),
+                        (jint)memcard->GetFreeBlocks(),
+                        (jint)(Memcard::DIRLEN - memcard->GetNumFiles()));
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_copyGCSaveFile(
+    JNIEnv* env, jclass, jstring jsrcPath, jint index, jstring jdstPath)
+{
+  auto savefile = ExportFromFileOrCard(GetJString(env, jsrcPath), index);
+  return savefile && ImportToFileOrCard(GetJString(env, jdstPath), *savefile);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_deleteGCSaveFile(
+    JNIEnv* env, jclass, jstring jpath, jint index)
+{
+  std::string path = GetJString(env, jpath);
+  if (File::IsDirectory(path))
+  {
+    std::vector<std::string> gci_files;
+    GetGciFiles(File::ScanDirectoryTree(path, false), gci_files);
+    return (index >= 0 && index < static_cast<int>(gci_files.size())) ?
+               File::Delete(gci_files[index]) :
+               JNI_FALSE;
+  }
+  auto [error, card] = Memcard::GCMemcard::Open(path);
+  return card &&
+         card->RemoveFile(static_cast<u8>(index)) == Memcard::GCMemcardRemoveFileRetVal::SUCCESS &&
+         card->Save();
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_exportGCSaveFile(
+    JNIEnv* env, jclass, jstring jsrcPath, jint index, jstring jdstPath)
+{
+  auto savefile = ExportFromFileOrCard(GetJString(env, jsrcPath), index);
+  return savefile &&
+         Memcard::WriteSavefile(GetJString(env, jdstPath), *savefile, Memcard::SavefileFormat::GCI);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_importGCSaveFile(
+    JNIEnv* env, jclass, jstring jsrcPath, jstring jdstPath)
+{
+  auto res = Memcard::ReadSavefile(GetJString(env, jsrcPath));
+  if (auto* savefile = std::get_if<Memcard::Savefile>(&res))
+    return ImportToFileOrCard(GetJString(env, jdstPath), *savefile);
+  return JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_fixGCChecksums(
+    JNIEnv* env, jclass, jstring jpath)
+{
+  std::string path = GetJString(env, jpath);
+  if (File::IsDirectory(path))
+    return JNI_FALSE;
+
+  auto [error, card] = Memcard::GCMemcard::Open(path);
+  return card && card->FixChecksums() && card->Save();
+}
+}

--- a/Source/Android/jni/WiiSaveManager.cpp
+++ b/Source/Android/jni/WiiSaveManager.cpp
@@ -1,0 +1,198 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <cstring>
+#include <jni.h>
+#include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
+#include "Common/IOFile.h"
+#include "Core/HW/WiiSave.h"
+#include "Core/HW/WiiSaveStructs.h"
+#include "Core/IOS/ES/ES.h"
+#include "Core/IOS/IOS.h"
+#include "DiscIO/Enums.h"
+#include "DiscIO/WiiSaveBanner.h"
+#include "jni/AndroidCommon/AndroidCommon.h"
+#include "jni/AndroidCommon/IDCache.h"
+
+#include <fmt/format.h>
+
+namespace
+{
+jintArray ToJIntArray(JNIEnv* env, const std::vector<u32>& data)
+{
+  jintArray jarray = env->NewIntArray(static_cast<jsize>(data.size()));
+  env->SetIntArrayRegion(jarray, 0, static_cast<jsize>(data.size()),
+                         reinterpret_cast<const jint*>(data.data()));
+  return jarray;
+}
+
+jobject CreateWiiSaveFile(JNIEnv* env, u64 title_id)
+{
+  DiscIO::WiiSaveBanner banner_info(title_id);
+  if (!banner_info.IsValid())
+    return nullptr;
+
+  u32 width, height;
+  std::vector<u32> banner_pixels = banner_info.GetBanner(&width, &height);
+  jintArray jbanner = !banner_pixels.empty() ? ToJIntArray(env, banner_pixels) : nullptr;
+
+  jstring jtitle = ToJString(env, banner_info.GetName());
+  jstring jdescription = ToJString(env, banner_info.GetDescription());
+
+  char game_id_str[5];
+  std::memcpy(game_id_str, &title_id, 4);
+  std::reverse(game_id_str, game_id_str + 4);
+  game_id_str[4] = '\0';
+  jstring jgame_id = ToJString(env, game_id_str);
+
+  int region = static_cast<int>(DiscIO::CountryCodeToRegion(
+      static_cast<u8>(game_id_str[3]), DiscIO::Platform::WiiDisc, DiscIO::Region::Unknown));
+
+  jobject jfile =
+      env->NewObject(IDCache::GetWiiSaveFileClass(), IDCache::GetWiiSaveFileConstructor(),
+                     (jlong)title_id, jgame_id, jtitle, jdescription, (jint)region, jbanner);
+
+  env->DeleteLocalRef(jtitle);
+  env->DeleteLocalRef(jdescription);
+  env->DeleteLocalRef(jgame_id);
+  if (jbanner)
+    env->DeleteLocalRef(jbanner);
+
+  return jfile;
+}
+}  // namespace
+
+extern "C" {
+
+JNIEXPORT jobjectArray JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_getWiiSaveFiles(
+    JNIEnv* env, jclass)
+{
+  IOS::HLE::Kernel ios;
+  std::vector<u64> titles = ios.GetESCore().GetInstalledTitles();
+  std::vector<jobject> save_files;
+
+  for (u64 title_id : titles)
+  {
+    const u32 high = static_cast<u32>(title_id >> 32);
+    if (high != 0x00010000 && high != 0x00010001 && high != 0x00010002 && high != 0x00010004)
+      continue;
+
+    jobject jfile = CreateWiiSaveFile(env, title_id);
+    if (jfile)
+      save_files.push_back(jfile);
+  }
+
+  jobjectArray jarray = env->NewObjectArray(static_cast<jsize>(save_files.size()),
+                                            IDCache::GetWiiSaveFileClass(), nullptr);
+  for (size_t i = 0; i < save_files.size(); ++i)
+  {
+    env->SetObjectArrayElement(jarray, static_cast<jsize>(i), save_files[i]);
+    env->DeleteLocalRef(save_files[i]);
+  }
+
+  return jarray;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_deleteWiiSaveFile(
+    JNIEnv* env, jclass, jlong titleId)
+{
+  IOS::HLE::Kernel ios;
+  auto storage = WiiSave::MakeNandStorage(ios.GetFS().get(), (u64)titleId);
+  if (storage && storage->SaveExists())
+  {
+    return storage->EraseSave();
+  }
+  return JNI_FALSE;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_exportWiiSaveFile(
+    JNIEnv* env, jclass, jlong titleId, jstring jdstPath)
+{
+  std::string dst_path = GetJString(env, jdstPath);
+  u64 tid = static_cast<u64>(titleId);
+
+  // We use a temporary directory to let the core's Export function create its
+  // expected folder structure, then we move the resulting data.bin to the destination.
+  std::string temp_dir = File::GetUserPath(D_CACHE_IDX) + "wii_export";
+  File::DeleteDirRecursively(temp_dir);
+  File::CreateFullPath(temp_dir);
+
+  jint result = static_cast<jint>(WiiSave::Export(tid, temp_dir));
+
+  if (result == 0)
+  {
+    std::string game_id;
+    game_id += static_cast<char>(tid >> 24);
+    game_id += static_cast<char>(tid >> 16);
+    game_id += static_cast<char>(tid >> 8);
+    game_id += static_cast<char>(tid);
+
+    std::string generated_path = fmt::format("{}/private/wii/title/{}/data.bin", temp_dir, game_id);
+    if (File::Exists(generated_path))
+    {
+      File::IOFile f_src(generated_path, "rb");
+      File::IOFile f_dst(dst_path, "wb");
+      if (f_src && f_dst)
+      {
+        u64 remaining = f_src.GetSize();
+        std::vector<u8> buffer(1024 * 1024);
+        while (remaining > 0)
+        {
+          const size_t to_read = static_cast<size_t>(std::min<u64>(remaining, buffer.size()));
+          if (!f_src.ReadBytes(buffer.data(), to_read) || !f_dst.WriteBytes(buffer.data(), to_read))
+          {
+            result = 100;
+            break;
+          }
+          remaining -= to_read;
+        }
+      }
+      else
+      {
+        // Open failed
+        result = 100;
+      }
+    }
+    else
+    {
+      // Generated file not found
+      result = 101;
+    }
+  }
+
+  File::DeleteDirRecursively(temp_dir);
+  return result;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_importWiiSaveFile(
+    JNIEnv* env, jclass, jstring jsrcPath, jboolean overwrite)
+{
+  std::string src_path = GetJString(env, jsrcPath);
+  return static_cast<jint>(WiiSave::Import(src_path, [overwrite] { return overwrite; }));
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_dolphinemu_dolphinemu_features_savemanager_model_SaveManagerNative_getWiiSaveTitleId(
+    JNIEnv* env, jclass, jstring jsrcPath)
+{
+  std::string src_path = GetJString(env, jsrcPath);
+  IOS::HLE::Kernel ios;
+  auto data_bin = WiiSave::MakeDataBinStorage(&ios.GetIOSC(), src_path, "rb");
+  if (data_bin)
+  {
+    auto header = data_bin->ReadHeader();
+    if (header)
+      return static_cast<jlong>(header->tid);
+  }
+  return 0;
+}
+}

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -273,6 +273,9 @@ public:
   explicit DataBinStorage(IOS::HLE::IOSC* iosc, const std::string& path, const char* mode)
       : m_iosc{*iosc}
   {
+#ifdef ANDROID
+    if (!IsPathAndroidContent(path))
+#endif
     File::CreateFullPath(path);
     m_file = File::IOFile{path, mode};
   }

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -276,7 +276,7 @@ public:
 #ifdef ANDROID
     if (!IsPathAndroidContent(path))
 #endif
-    File::CreateFullPath(path);
+      File::CreateFullPath(path);
     m_file = File::IOFile{path, mode};
   }
 


### PR DESCRIPTION
Adds a save file manager allowing users to manage GameCube, Wii, and GBA save files.

Since gameTDB doesnt have GB/GBA covers I just use colour coding for blocks of saves, this is easier on the eyes than a list of saves

Includes everything for importing exporting etc, suports GC GCI folders and .raw for moving saves around, wii saves at least need 1st run. The GBA save manager has some unique features for the GBA implimentation so the user can play on the gameboy player and then move their save easily for linking (pokemon colosium/XD, Sonic advance, what ever other games)

The main use for this was originally just for the GBA game saves for the purpose above, but expanded for GC and wii since theres no real easy way to manage save data for those
<img width="720" height="1120" alt="gbasave" src="https://github.com/user-attachments/assets/c39c3736-e3a3-4212-8b94-c08ca0874bc5" />
<img width="720" height="1120" alt="gc" src="https://github.com/user-attachments/assets/7d0ba656-79b8-4c0f-aa6b-ab0cf96c4203" />
<img width="720" height="1120" alt="wii" src="https://github.com/user-attachments/assets/88d23546-fdb3-4bca-87f7-ec48ddbe64f0" />
