### PR TITLE
Android: Fix Crash when loading Skylanders file

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
@@ -43,6 +43,7 @@ import org.dolphinemu.dolphinemu.features.infinitybase.ui.FigureSlotAdapter
 import org.dolphinemu.dolphinemu.features.input.model.ControllerInterface
 import org.dolphinemu.dolphinemu.features.input.model.DolphinSensorEventListener
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting
+import org.dolphinemu.dolphinemu.utils.ContentHandler
 import org.dolphinemu.dolphinemu.features.settings.model.IntSetting
 import org.dolphinemu.dolphinemu.features.settings.model.Settings
 import org.dolphinemu.dolphinemu.features.settings.model.StringSetting
@@ -104,17 +105,21 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
     }
 
     val requestSkylanderFile = registerForActivityResult(
-        ActivityResultContracts.GetContent()
+        ActivityResultContracts.OpenDocument()
     ) { uri: Uri? ->
         if (uri != null) {
             val slot = SkylanderConfig.loadSkylander(
                 skylanderSlots[skylanderSlot].portalSlot,
                 uri.toString()
-            )!!
-            clearSkylander(skylanderSlot)
-            skylanderSlots[skylanderSlot].portalSlot = slot.first!!
-            skylanderSlots[skylanderSlot].label = slot.second!!
-            skylandersBinding.figureManager.adapter!!.notifyItemChanged(skylanderSlot)
+            )
+            if (slot != null && slot.first != null && slot.second != null) {
+                clearSkylander(skylanderSlot)
+                skylanderSlots[skylanderSlot].portalSlot = slot.first!!
+                skylanderSlots[skylanderSlot].label = slot.second!!
+                skylandersBinding.figureManager.adapter?.notifyItemChanged(skylanderSlot)
+            } else {
+                Toast.makeText(this, R.string.skylander_load_failed, Toast.LENGTH_SHORT).show()
+            }
             skylanderSlot = -1
             skylanderData = Skylander.BLANK_SKYLANDER
         }
@@ -131,10 +136,12 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
                     uri.toString(),
                     skylanderSlots[skylanderSlot].portalSlot
                 )
-                clearSkylander(skylanderSlot)
-                skylanderSlots[skylanderSlot].portalSlot = slot.first
-                skylanderSlots[skylanderSlot].label = slot.second
-                skylandersBinding.figureManager.adapter?.notifyItemChanged(skylanderSlot)
+                if (slot.first != -1) {
+                    clearSkylander(skylanderSlot)
+                    skylanderSlots[skylanderSlot].portalSlot = slot.first
+                    skylanderSlots[skylanderSlot].label = slot.second
+                    skylandersBinding.figureManager.adapter?.notifyItemChanged(skylanderSlot)
+                }
                 skylanderSlot = -1
                 skylanderData = Skylander.BLANK_SKYLANDER
             }
@@ -142,7 +149,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
     }
 
     val requestInfinityFigureFile = registerForActivityResult(
-        ActivityResultContracts.GetContent()
+        ActivityResultContracts.OpenDocument()
     ) { uri: Uri? ->
         if (uri != null) {
             val label = InfinityConfig.loadFigure(infinityPosition, uri.toString())

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/infinitybase/ui/FigureSlotAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/infinitybase/ui/FigureSlotAdapter.kt
@@ -51,7 +51,7 @@ class FigureSlotAdapter(
 
         holder.binding.buttonLoadFigure.setOnClickListener {
             activity.setInfinityFigureData(0, "", figure.position, position)
-            activity.requestInfinityFigureFile.launch("*/*")
+            activity.requestInfinityFigureFile.launch(arrayOf("*/*"))
         }
 
         val inflater = LayoutInflater.from(activity)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/skylanders/ui/SkylanderSlotAdapter.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/skylanders/ui/SkylanderSlotAdapter.kt
@@ -47,7 +47,7 @@ class SkylanderSlotAdapter(
 
         holder.binding.buttonLoadFigure.setOnClickListener {
             activity.setSkylanderData(0, 0, "", position)
-            activity.requestSkylanderFile.launch("*/*")
+            activity.requestSkylanderFile.launch(arrayOf("*/*"))
         }
 
         val inflater = LayoutInflater.from(activity)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -956,6 +956,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="skylander_id">ID</string>
     <string name="skylander_variant">Variant</string>
     <string name="invalid_skylander">Invalid Skylander Selection</string>
+    <string name="skylander_load_failed">Failed to load Skylander figure</string>
 
     <string name="emulate_infinity_base">Infinity Base</string>
     <string name="infinity_manager">Infinity Manager</string>


### PR DESCRIPTION
Fixes [dolphin issue 13956](https://bugs.dolphin-emu.org/issues/13956).

The main problem was that skylanders files (also disney infinity figures) were being opened with a method that only granted read permission (_GetContent_).  Switching to _OpenDocument_ grants read and write permission for Dolphin over these files.

Additionally, added some null checks to show an error message when an skylanders fails to load, preventing the emulator from crashing.

*Note: The issue investigation and changes were made with the assistance of AI tools and verified by me, tested on a real android device.*