### PR TITLE
SDLGamepad: Add Misc 2 through 6

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDLGamepad.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDLGamepad.cpp
@@ -327,6 +327,9 @@ bool Gamepad::Button::IsMatchingName(std::string_view name) const
     return true;
 
   // Match the old "Button 0"-like names.
+  if (m_binding.output_type == SDL_GAMEPAD_BINDTYPE_BUTTON)
+    return name == GetLegacyButtonName(m_binding.output.button);
+
   switch (m_binding.input_type)
   {
   case SDL_GAMEPAD_BINDTYPE_BUTTON:

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDLGamepad.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDLGamepad.h
@@ -380,7 +380,7 @@ struct SDLMotionAxis
 };
 using SDLMotionAxisList = std::array<SDLMotionAxis, 6>;
 
-static constexpr std::array<const char*, 21> s_sdl_button_names = {
+static constexpr std::array<const char*, 26> s_sdl_button_names = {
     "Button S",    // SDL_GAMEPAD_BUTTON_SOUTH
     "Button E",    // SDL_GAMEPAD_BUTTON_EAST
     "Button W",    // SDL_GAMEPAD_BUTTON_WEST
@@ -402,6 +402,11 @@ static constexpr std::array<const char*, 21> s_sdl_button_names = {
     "Paddle 3",    // SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2
     "Paddle 4",    // SDL_GAMEPAD_BUTTON_LEFT_PADDLE2
     "Touchpad",    // SDL_GAMEPAD_BUTTON_TOUCHPAD
+    "Misc 2",      // SDL_GAMEPAD_BUTTON_MISC2
+    "Misc 3",      // SDL_GAMEPAD_BUTTON_MISC3
+    "Misc 4",      // SDL_GAMEPAD_BUTTON_MISC4
+    "Misc 5",      // SDL_GAMEPAD_BUTTON_MISC5
+    "Misc 6"       // SDL_GAMEPAD_BUTTON_MISC6
 };
 static constexpr std::array<const char*, 6> s_sdl_axis_names = {
     "Left X",     // SDL_GAMEPAD_AXIS_LEFTX


### PR DESCRIPTION
Misc 2-6 are currently unnamed generic buttons in Dolphin. SDL3 has added more misc buttons for "additional controller buttons" (e.g. left/right trigger clicks on a GameCube controller, or for the second touchpad click on the Steam Controller) which map to these additional named Misc buttons. The names Misc 2-6 are taken from [SDL_GamepadButton](https://wiki.libsdl.org/SDL3/SDL_GamepadButton).

This change is backwards compatible with old configs, as seen in this screenshot where I only press Misc 2:
<img width="228" height="113" alt="image" src="https://github.com/user-attachments/assets/717952d4-68b3-4b1f-9c0a-aca3be441bc8" />
