### PR TITLE
VideoCommon: Prefer Vulkan over OpenGL on Linux

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -208,16 +208,16 @@ const std::vector<std::unique_ptr<VideoBackendBase>>& VideoBackendBase::GetAvail
     backends.push_back(std::make_unique<DX11::VideoBackend>());
     backends.push_back(std::make_unique<DX12::VideoBackend>());
 #endif
-#ifdef HAS_OPENGL
-    backends.push_back(std::make_unique<OGL::VideoBackend>());
-#endif
 #ifdef HAS_VULKAN
-#ifdef __APPLE__
-    // Emplace the Vulkan backend at the beginning so it takes precedence over OpenGL.
-    // On macOS, we prefer Vulkan over OpenGL due to OpenGL support being deprecated by Apple.
-    backends.emplace(backends.begin(), std::make_unique<Vulkan::VideoBackend>());
-#else
     backends.push_back(std::make_unique<Vulkan::VideoBackend>());
+#endif
+#ifdef HAS_OPENGL
+#ifdef ANDROID
+    // Emplace the OpenGL backend at the beginning so it takes precedence over Vulkan.
+    // On Android, we prefer OpenGL over Vulkan due to OpenGL supporting more features.
+    backends.emplace(backends.begin(), std::make_unique<OGL::VideoBackend>());
+#else
+    backends.push_back(std::make_unique<OGL::VideoBackend>());
 #endif
 #endif
 #ifdef __APPLE__


### PR DESCRIPTION
With the current state of hardware support and the benefits over the OpenGL backend, I believe Vulkan is a saner default on Desktop platforms other than Windows (which still defaults to DX11.)