### PR TITLE
cmake: Try newer glslang versions first.

### DIFF
--- a/CMake/DolphinLibraryTools.cmake
+++ b/CMake/DolphinLibraryTools.cmake
@@ -88,7 +88,8 @@ function(dolphin_find_optional_system_library library bundled_path)
           break()
         endif()
       endwhile()
-      # Quietly check all the listed versions
+      # Quietly check all the listed versions, from newest to oldest.
+      list(SORT version_list COMPARE NATURAL ORDER DESCENDING)
       foreach(version IN LISTS version_list)
         find_package(${library} ${version} ${ARGN} QUIET)
         if(${library}_FOUND)


### PR DESCRIPTION
New is usually better; currently the newest version is also the one that is
shown when the search fails.

* CMakeLists.txt <glslang>: Search version 16 before 15.
