### PR TITLE
HW/EXI: Don’t dereference one item past end of array

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -136,7 +136,7 @@ void GeckoSockServer::ClientThread()
       {
         did_nothing = false;
 
-        recv_fifo.insert(recv_fifo.end(), buffer.data(), &buffer[got]);
+        recv_fifo.insert(recv_fifo.end(), buffer.data(), buffer.data() + got);
       }
 
       if (!send_fifo.empty())


### PR DESCRIPTION
Dolphin would previously crash while accessing `&buffer[got]`, as if we were trying to access that element instead of just obtaining a pointer to it.  The proper solution is to obtain a pointer to the first element, and only add the offset we want to get the range.

Here is the printed message:
```
/usr/include/c++/16/array:210: constexpr std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) [with _Tp = char; long unsigned int _Nm = 128; reference = char&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```

The stack trace originates from: [Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp:139](https://github.com/dolphin-emu/dolphin/blob/ca8c6ee45e419296226e4da8c2b2adaaf54e0299/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp#L139)