### PR TITLE
RetroAchievements - Fix Achievement Progress Toggle

### DIFF
--- a/Source/Core/Core/AchievementManager.cpp
+++ b/Source/Core/Core/AchievementManager.cpp
@@ -1261,6 +1261,9 @@ void AchievementManager::HandleAchievementProgressIndicatorShowEvent(
     const rc_client_event_t* client_event)
 {
   auto& instance = AchievementManager::GetInstance();
+  instance.update_event.Trigger(UpdatedItems{.achievements = {client_event->achievement->id}});
+  if (!Config::Get(Config::RA_PROGRESS_ENABLED))
+    return;
   auto current_time = std::chrono::steady_clock::now();
   const auto message_wait_time = std::chrono::milliseconds{OSD::Duration::SHORT};
   if (current_time - instance.m_last_progress_message < message_wait_time)
@@ -1270,7 +1273,6 @@ void AchievementManager::HandleAchievementProgressIndicatorShowEvent(
                   OSD::Duration::SHORT, OSD::Color::GREEN,
                   &instance.GetAchievementBadge(client_event->achievement->id, false));
   instance.m_last_progress_message = current_time;
-  instance.update_event.Trigger(UpdatedItems{.achievements = {client_event->achievement->id}});
 }
 
 void AchievementManager::HandleGameCompletedEvent(const rc_client_event_t* client_event,


### PR DESCRIPTION
The RA_PROGRESS_ENABLED flag was added but not currently being invoked, this makes sure it is checked before popping up progress messages.