### PR TITLE
Jit: Optimize trampoline info allocation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -134,3 +134,7 @@
 	path = Externals/wil
 	url = https://github.com/microsoft/wil.git
 	shallow = true
+[submodule "Externals/sfl-library"]
+	path = Externals/sfl-library
+	url = https://github.com/slavenf/sfl-library/
+	shallow = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,8 @@ else()
   # gcc uses some optimizations which might break stuff without this flag
   check_and_add_flag(NO_STRICT_ALIASING -fno-strict-aliasing)
   check_and_add_flag(NO_EXCEPTIONS -fno-exceptions)
+  # sfl doesn't check for -fno-exceptions
+  add_compile_definitions(SFL_NO_EXCEPTIONS)
 
   check_and_add_flag(VISIBILITY_INLINES_HIDDEN -fvisibility-inlines-hidden)
   check_and_add_flag(VISIBILITY_HIDDEN -fvisibility=hidden)
@@ -363,10 +365,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   # Drop unreachable code and data.
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip,-dead_strip_dylibs")
 
-  # Set FMT_EXCEPTIONS = 0, for consistency with -fno-exceptions earlier.
+  # Set FMT_USE_EXCEPTIONS = 0, for consistency with -fno-exceptions earlier.
   # If we set only -fno-exceptions, fmt fails to compile when included from
   # Objective-C++ because fmt tries try to use throw because __EXCEPTIONS is defined.
-  add_definitions(-DFMT_EXCEPTIONS=0)
+  add_definitions(-DFMT_USE_EXCEPTIONS=0)
 
   find_library(APPKIT_LIBRARY AppKit)
   find_library(APPSERV_LIBRARY ApplicationServices)
@@ -748,6 +750,9 @@ include_directories(Externals/picojson)
 add_subdirectory(Externals/expr)
 
 add_subdirectory(Externals/FatFs)
+
+# TODO: Switch to dolphin_add_bundled_library after https://github.com/dolphin-emu/dolphin/pull/14793
+add_subdirectory(Externals/sfl-library)
 
 if (USE_RETRO_ACHIEVEMENTS)
   add_subdirectory(Externals/rcheevos)

--- a/Externals/licenses.md
+++ b/Externals/licenses.md
@@ -68,6 +68,8 @@ Dolphin includes or links code of the following third-party software projects:
    [LGPLv3 and other licenses](http://doc.qt.io/qt-5/licensing.html)
 - [SDL](https://www.libsdl.org/):
    [zlib license](http://hg.libsdl.org/SDL/file/tip/COPYING.txt)
+- [sfl-library](https://github.com/slavenf/sfl-library):
+   [zlib license](https://github.com/slavenf/sfl-library/blob/master/LICENSE.txt)
 - [SFML](http://www.sfml-dev.org/):
    [zlib license](http://www.sfml-dev.org/license.php)
 - [TAP-Windows](https://openvpn.net/):

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -184,6 +184,7 @@ PUBLIC
   fmt::fmt
   MbedTLS::mbedtls
   MINIZIP::minizip-ng
+  sfl
   sfml-network
 
 PRIVATE

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -659,6 +659,7 @@ if(_M_X86_64)
   )
 elseif(_M_ARM_64)
   target_sources(core PRIVATE
+    PowerPC/JitArm64/FastmemArea.h
     PowerPC/JitArm64/Jit.cpp
     PowerPC/JitArm64/Jit.h
     PowerPC/JitArm64/JitAsm.cpp

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -179,14 +179,6 @@ bool Jit64::BackPatch(SContext* ctx)
 
   TrampolineInfo& info = it->second;
 
-  u8* exceptionHandler = nullptr;
-  if (jo.memcheck)
-  {
-    auto it2 = m_exception_handler_at_loc.find(codePtr);
-    if (it2 != m_exception_handler_at_loc.end())
-      exceptionHandler = it2->second;
-  }
-
   // In the trampoline code, we jump back into the block at the beginning
   // of the next instruction. The next instruction comes immediately
   // after the backpatched operation, or BACKPATCH_SIZE bytes after the start
@@ -195,7 +187,7 @@ bool Jit64::BackPatch(SContext* ctx)
   // to insert the backpatch jump.)
 
   js.generatingTrampoline = true;
-  js.trampolineExceptionHandler = exceptionHandler;
+  js.trampolineExceptionHandler = info.exception_handler_at_loc;
   js.compilerPC = info.pc;
 
   // Generate the trampoline.
@@ -1203,12 +1195,11 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         SwitchToFarCode();
         if (!js.fastmemLoadStore)
         {
-          m_exception_handler_at_loc[js.fastmemLoadStore] = nullptr;
           SetJumpTarget(js.fixupExceptionHandler ? js.exceptionHandler : memException);
         }
         else
         {
-          m_exception_handler_at_loc[js.fastmemLoadStore] = GetWritableCodePtr();
+          m_back_patch_info.at(js.fastmemLoadStore).exception_handler_at_loc = GetWritableCodePtr();
         }
 
         RCForkGuard gpr_guard = gpr.Fork();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <sfl/compact_vector.hpp>
 
 // for the PROFILER stuff
 #ifdef _WIN32
@@ -170,14 +171,28 @@ bool Jit64::BackPatch(SContext* ctx)
   if (!IsInSpace(codePtr))
     return false;  // this will become a regular crash real soon after this
 
-  auto it = m_back_patch_info.find(codePtr);
-  if (it == m_back_patch_info.end())
+  // Find the block
+  auto block_it = m_back_patch_info.lower_bound(codePtr);
+  if (block_it == m_back_patch_info.end())
   {
-    PanicAlertFmt("BackPatch: no register use entry for address {}", fmt::ptr(codePtr));
+    PanicAlertFmt("BackPatch: no block returned for address {}", fmt::ptr(codePtr));
+    return false;
+  }
+  // Then find the entry
+  auto entry_it = std::ranges::find_if(
+      block_it->second, [codePtr](auto& entry) { return codePtr < entry.start + entry.len; });
+  if (entry_it == block_it->second.end())
+  {
+    PanicAlertFmt("BackPatch: entry for address {} not found in block", fmt::ptr(codePtr));
     return false;
   }
 
-  TrampolineInfo& info = it->second;
+  TrampolineInfo& info = *entry_it;
+  if (codePtr < info.start)
+  {
+    PanicAlertFmt("BackPatch: didn't find entry that overlaps with address {}", fmt::ptr(codePtr));
+    return false;
+  }
 
   // In the trampoline code, we jump back into the block at the beginning
   // of the next instruction. The next instruction comes immediately
@@ -195,10 +210,8 @@ bool Jit64::BackPatch(SContext* ctx)
   js.generatingTrampoline = false;
   js.trampolineExceptionHandler = nullptr;
 
-  u8* start = info.start;
-
   // Patch the original memory operation.
-  XEmitter emitter(start, start + info.len);
+  XEmitter emitter(info.start, info.start + info.len);
   emitter.JMP(trampoline);
   // NOPs become dead code
   const u8* end = info.start + info.len;
@@ -240,6 +253,11 @@ bool Jit64::BackPatch(SContext* ctx)
     *ptr = static_cast<u32>(*ptr - info.offset);
   }
 
+  // Delete the entry
+  block_it->second.erase(entry_it);
+  if (block_it->second.empty())
+    m_back_patch_info.erase(block_it);
+
   ctx->CTX_PC = reinterpret_cast<u64>(trampoline);
 
   return true;
@@ -255,7 +273,7 @@ void Jit64::Init()
 
   jo.optimizeGatherPipe = true;
   jo.accurateSinglePrecision = true;
-  js.fastmemLoadStore = nullptr;
+  js.fastmemLoadStore = false;
   js.compilerPC = 0;
 
   gpr.SetEmitter(this);
@@ -313,7 +331,13 @@ void Jit64::FreeRanges()
   // Check if any code blocks have been freed in the block cache and transfer this information to
   // the local rangesets to allow overwriting them with new code.
   for (const auto& [from, to] : blocks.GetRangesToFreeNear())
+  {
+    // Note that the erasure in m_back_patch_info isn't just a matter of memory usage: because
+    // lookups use lower_bound (from the current pc) to get the entries of the current block, it's
+    // imperative that erased blocks do not interfere.
+    m_back_patch_info.erase(from);
     m_free_ranges_near.insert(from, to);
+  }
   for (const auto& [from, to] : blocks.GetRangesToFreeFar())
     m_free_ranges_far.insert(from, to);
   blocks.ClearRangesToFree();
@@ -857,6 +881,14 @@ void Jit64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
       b->far_begin = far_start;
       b->far_end = far_end;
 
+      if (!js.back_patch_info_temp.empty())
+      {
+        // The copy from temp is intentional, to minimize allocations due to exceeded vector
+        // capacity.
+        m_back_patch_info.emplace(near_start, sfl::compact_vector<TrampolineInfo>(
+                                                  sfl::from_range_t(), js.back_patch_info_temp));
+      }
+
       blocks.FinalizeBlock(*b, jo.enableBlocklink, code_block, m_code_buffer);
 
 #ifdef JIT_LOG_GENERATED_CODE
@@ -914,6 +946,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   js.curBlock = b;
   js.numLoadStoreInst = 0;
   js.numFloatingPointInst = 0;
+  js.back_patch_info_temp.clear();
 
   // TODO: Test if this or AlignCode16 make a difference from GetCodePtr
   b->normalEntry = AlignCode4();
@@ -995,7 +1028,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
     js.instructionsLeft = (code_block.m_num_instructions - 1) - i;
     const GekkoOPInfo* opinfo = op.opinfo;
     js.downcountAmount += opinfo->num_cycles;
-    js.fastmemLoadStore = nullptr;
+    js.fastmemLoadStore = false;
     js.fixupExceptionHandler = false;
 
     if (i == (code_block.m_num_instructions - 1))
@@ -1199,7 +1232,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         }
         else
         {
-          m_back_patch_info.at(js.fastmemLoadStore).exception_handler_at_loc = GetWritableCodePtr();
+          js.back_patch_info_temp.back().exception_handler_at_loc = GetWritableCodePtr();
         }
 
         RCForkGuard gpr_guard = gpr.Fork();

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -1061,5 +1061,4 @@ void EmuCodeBlock::SetFPRF(Gen::X64Reg xmm, bool single)
 void EmuCodeBlock::Clear()
 {
   m_back_patch_info.clear();
-  m_exception_handler_at_loc.clear();
 }

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -336,27 +336,31 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
     MovInfo mov;
     bool offsetAddedToAddress =
         UnsafeLoadToReg(reg_value, opAddress, accessSize, offset, signExtend, &mov);
-    TrampolineInfo& info = m_back_patch_info[mov.address];
-    info.pc = js.compilerPC;
-    info.nonAtomicSwapStoreSrc = mov.nonAtomicSwapStore ? mov.nonAtomicSwapStoreSrc : INVALID_REG;
-    info.start = backpatchStart;
-    info.read = true;
-    info.op_reg = reg_value;
-    info.op_arg = opAddress;
-    info.offsetAddedToAddress = offsetAddedToAddress;
-    info.accessSize = accessSize >> 3;
-    info.offset = offset;
-    info.registersInUse = registersInUse;
-    info.flags = flags;
-    info.signExtend = signExtend;
+
     ptrdiff_t padding = BACKPATCH_SIZE - (GetCodePtr() - backpatchStart);
     if (padding > 0)
     {
       NOP(padding);
     }
-    info.len = static_cast<u16>(GetCodePtr() - info.start);
 
-    js.fastmemLoadStore = mov.address;
+    TrampolineInfo& info = js.back_patch_info_temp.emplace_back();
+    info = {
+        .start = backpatchStart,
+        .len = static_cast<u16>(GetCodePtr() - backpatchStart),
+        .flags = static_cast<u8>(flags),
+        .accessSize = static_cast<u8>(accessSize >> 3),
+        .read = true,
+        .signExtend = signExtend,
+        .offsetAddedToAddress = offsetAddedToAddress,
+        .pc = js.compilerPC,
+        .registersInUse = registersInUse,
+        .nonAtomicSwapStoreSrc = mov.nonAtomicSwapStore ? mov.nonAtomicSwapStoreSrc : INVALID_REG,
+        .offset = offset,
+        .op_reg = reg_value,
+        .op_arg = opAddress,
+    };
+
+    js.fastmemLoadStore = true;
     return;
   }
 
@@ -509,26 +513,30 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
     u8* backpatchStart = GetWritableCodePtr();
     MovInfo mov;
     UnsafeWriteRegToReg(reg_value, reg_addr, accessSize, offset, swap, &mov);
-    TrampolineInfo& info = m_back_patch_info[mov.address];
-    info.pc = js.compilerPC;
-    info.nonAtomicSwapStoreSrc = mov.nonAtomicSwapStore ? mov.nonAtomicSwapStoreSrc : INVALID_REG;
-    info.start = backpatchStart;
-    info.read = false;
-    info.op_arg = reg_value;
-    info.op_reg = reg_addr;
-    info.offsetAddedToAddress = false;
-    info.accessSize = accessSize >> 3;
-    info.offset = offset;
-    info.registersInUse = registersInUse;
-    info.flags = flags;
-    ptrdiff_t padding = BACKPATCH_SIZE - (GetCodePtr() - backpatchStart);
+
+    const ptrdiff_t padding = BACKPATCH_SIZE - (GetCodePtr() - backpatchStart);
     if (padding > 0)
     {
       NOP(padding);
     }
-    info.len = static_cast<u16>(GetCodePtr() - info.start);
 
-    js.fastmemLoadStore = mov.address;
+    TrampolineInfo& info = js.back_patch_info_temp.emplace_back();
+    info = {
+        .start = backpatchStart,
+        .len = static_cast<u16>(GetCodePtr() - backpatchStart),
+        .flags = static_cast<u8>(flags),
+        .accessSize = static_cast<u8>(accessSize >> 3),
+        .read = false,
+        .offsetAddedToAddress = false,
+        .pc = js.compilerPC,
+        .registersInUse = registersInUse,
+        .nonAtomicSwapStoreSrc = mov.nonAtomicSwapStore ? mov.nonAtomicSwapStoreSrc : INVALID_REG,
+        .offset = offset,
+        .op_reg = reg_addr,
+        .op_arg = reg_value,
+    };
+
+    js.fastmemLoadStore = true;
 
     return;
   }

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
-#include <unordered_map>
+#include <map>
+
+#include <sfl/compact_vector.hpp>
 
 #include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
@@ -140,6 +142,15 @@ protected:
   u8* m_near_code_end = nullptr;
   bool m_near_code_write_failed = false;
 
-  std::unordered_map<u8*, TrampolineInfo> m_back_patch_info;
-  std::unordered_map<u8*, u8*> m_exception_handler_at_loc;
+  // The keys store the entry point of a block. Lookups find the block through lower_bound (which is
+  // why the comparison is std::greater), and then linearly search the vector for the specific
+  // address. The total number of entries is in the 100s of thousands, and maps are inefficient, so
+  // this improves performance by reducing the stress of balancing and by allowing to batch insert
+  // all the info for each block. (Even a better ordered structure like b-tree maps would probably
+  // benefit.)
+  //
+  // Also note that this would need to be an ordered structure anyway in order to erase the entries
+  // when a block is destroyed.
+  std::map<const u8*, sfl::compact_vector<TrampolineInfo>, std::greater<const u8*>>
+      m_back_patch_info;
 };

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineInfo.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineInfo.h
@@ -8,7 +8,7 @@
 #include "Common/x64Emitter.h"
 
 // Stores information we need to batch-patch a MOV with a call to the slow read/write path after
-// it faults. There will be 10s of thousands of these structs live, so be wary of making this too
+// it faults. There will be 100s of thousands of these structs live, so be wary of making this too
 // big.
 struct TrampolineInfo final
 {
@@ -46,4 +46,8 @@ struct TrampolineInfo final
   s32 offset = 0;
   Gen::X64Reg op_reg{};
   Gen::OpArg op_arg{};
+
+  // Never set if memcheck is disabled. Otherwise, it's almost always set, so a separate map would
+  // be a waste.
+  u8* exception_handler_at_loc = nullptr;
 };

--- a/Source/Core/Core/PowerPC/JitArm64/FastmemArea.h
+++ b/Source/Core/Core/PowerPC/JitArm64/FastmemArea.h
@@ -1,0 +1,13 @@
+// Copyright 2026 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+
+struct FastmemArea
+{
+  u8* fast_access_start;
+  u8* fast_access_end;
+  const u8* slow_access_code;
+};

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <sfl/compact_vector.hpp>
 
 #include "Common/Arm64Emitter.h"
 #include "Common/CommonTypes.h"
@@ -207,12 +208,10 @@ void JitArm64::FreeRanges()
   // the local rangesets to allow overwriting them with new code.
   for (const auto& [from, to] : blocks.GetRangesToFreeNear())
   {
-    const auto first_fastmem_area = m_fault_to_handler.upper_bound(from);
-    auto last_fastmem_area = first_fastmem_area;
-    const auto end = m_fault_to_handler.end();
-    while (last_fastmem_area != end && last_fastmem_area->first <= to)
-      ++last_fastmem_area;
-    m_fault_to_handler.erase(first_fastmem_area, last_fastmem_area);
+    // Note that the erasure in m_fault_to_handler isn't just a matter of memory usage: because
+    // lookups use lower_bound (from the current pc) to get the entries of the current block, it's
+    // imperative that erased blocks do not interfere.
+    m_fault_to_handler.erase(from);
 
     if (from < m_near_code_0.GetCodeEnd())
       m_free_ranges_near_0.insert(from, to);
@@ -1057,6 +1056,14 @@ void JitArm64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
       b->far_begin = far_start;
       b->far_end = far_end;
 
+      if (!js.fault_to_handler_temp.empty())
+      {
+        // The copy from temp is intentional, to minimize allocations due to exceeded vector
+        // capacity.
+        m_fault_to_handler.emplace(near_start, sfl::compact_vector<FastmemArea>(
+                                                   sfl::from_range_t(), js.fault_to_handler_temp));
+      }
+
       blocks.FinalizeBlock(*b, jo.enableBlocklink, code_block, m_code_buffer);
 
 #ifdef JIT_LOG_GENERATED_CODE
@@ -1169,6 +1176,7 @@ bool JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   js.carryFlag = CarryFlag::InPPCState;
   js.numLoadStoreInst = 0;
   js.numFloatingPointInst = 0;
+  js.fault_to_handler_temp.clear();
 
   b->normalEntry = GetWritableCodePtr();
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -7,9 +7,12 @@
 #include <map>
 #include <optional>
 
+#include <sfl/compact_vector.hpp>
+
 #include "Common/Arm64Emitter.h"
 #include "Common/RangeSizeSet.h"
 
+#include "Core/PowerPC/JitArm64/FastmemArea.h"
 #include "Core/PowerPC/JitArm64/JitArm64Cache.h"
 #include "Core/PowerPC/JitArm64/JitArm64_RegCache.h"
 #include "Core/PowerPC/JitArmCommon/BackPatch.h"
@@ -191,12 +194,6 @@ public:
   void rlwinmx_internal(UGeckoInstruction inst, u32 sh);
 
 protected:
-  struct FastmemArea
-  {
-    const u8* fast_access_code;
-    const u8* slow_access_code;
-  };
-
   void SetBlockLinkingEnabled(bool enabled);
   void SetOptimizationEnabled(bool enabled);
 
@@ -389,8 +386,17 @@ protected:
   void SetFPRFIfNeeded(bool single, Arm64Gen::ARM64Reg reg);
   void Force25BitPrecision(Arm64Gen::ARM64Reg output, Arm64Gen::ARM64Reg input);
 
-  // <Fast path fault location, slow path handler location>
-  std::map<const u8*, FastmemArea> m_fault_to_handler{};
+  // The keys store the entry point of a block. Lookups find the block through lower_bound (which is
+  // why the comparison is std::greater), and then linearly search the vector for the specific
+  // address. The total number of entries is in the 100s of thousands, and maps are inefficient, so
+  // this improves performance by reducing the stress of balancing and by allowing to batch insert
+  // all the info for each block. (Even a better ordered structure like b-tree maps would probably
+  // benefit.)
+  //
+  // Also note that this would need to be an ordered structure anyway in order to erase the entries
+  // when a block is destroyed.
+  std::map<const u8*, sfl::compact_vector<FastmemArea>, std::greater<const u8*>>
+      m_fault_to_handler{};
   Arm64GPRCache gpr;
   Arm64FPRCache fpr;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -67,7 +67,7 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, MemAccessMode mode, ARM64Reg RS, 
   const bool emit_slow_access = mode != MemAccessMode::AlwaysFastAccess;
 
   bool in_far_code = false;
-  const u8* fast_access_start = GetCodePtr();
+  u8* fast_access_start = GetWritableCodePtr();
   std::optional<FixupBranch> slow_access_fixup;
 
   if (emit_fast_access)
@@ -148,7 +148,7 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, MemAccessMode mode, ARM64Reg RS, 
       ByteswapAfterLoad(this, &m_float_emit, RS, RS, flags, true, false);
     }
   }
-  const u8* fast_access_end = GetCodePtr();
+  u8* fast_access_end = GetWritableCodePtr();
 
   if (emit_slow_access)
   {
@@ -161,9 +161,12 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, MemAccessMode mode, ARM64Reg RS, 
 
       if (jo.fastmem && !emitting_routine)
       {
-        FastmemArea* fastmem_area = &m_fault_to_handler[fast_access_end];
-        fastmem_area->fast_access_code = fast_access_start;
-        fastmem_area->slow_access_code = GetCodePtr();
+        FastmemArea& fastmem_area = js.fault_to_handler_temp.emplace_back();
+        fastmem_area = {
+            .fast_access_start = fast_access_start,
+            .fast_access_end = fast_access_end,
+            .slow_access_code = GetCodePtr(),
+        };
       }
     }
 
@@ -330,28 +333,37 @@ void JitArm64::FlushPPCStateBeforeSlowAccess(ARM64Reg temp_gpr, ARM64Reg temp_fp
 bool JitArm64::HandleFastmemFault(SContext* ctx)
 {
   const u8* pc = reinterpret_cast<const u8*>(ctx->CTX_PC);
-  auto slow_handler_iter = m_fault_to_handler.upper_bound(pc);
 
-  // no fastmem area found
-  if (slow_handler_iter == m_fault_to_handler.end())
+  // Find the block
+  auto block_it = m_fault_to_handler.lower_bound(pc);
+  if (block_it == m_fault_to_handler.end())
     return false;
 
-  const u8* fastmem_area_start = slow_handler_iter->second.fast_access_code;
-  const u8* fastmem_area_end = slow_handler_iter->first;
+  // Then find the entry
+  auto entry_it = std::ranges::find_if(block_it->second,
+                                       [pc](auto& entry) { return pc < entry.fast_access_end; });
+  if (entry_it == block_it->second.end())
+    return false;
 
-  // no overlapping fastmem area found
+  u8* fastmem_area_start = entry_it->fast_access_start;
+  u8* fastmem_area_end = entry_it->fast_access_end;
+
+  // The found entry doesn't actually overlap
   if (pc < fastmem_area_start)
     return false;
 
   const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
-  ARM64XEmitter emitter(const_cast<u8*>(fastmem_area_start), const_cast<u8*>(fastmem_area_end));
+  ARM64XEmitter emitter(fastmem_area_start, fastmem_area_end);
 
-  emitter.BL(slow_handler_iter->second.slow_access_code);
+  emitter.BL(entry_it->slow_access_code);
 
   while (emitter.GetCodePtr() < fastmem_area_end)
     emitter.NOP();
 
-  m_fault_to_handler.erase(slow_handler_iter);
+  // Delete the entry
+  block_it->second.erase(entry_it);
+  if (block_it->second.empty())
+    m_fault_to_handler.erase(block_it);
 
   emitter.FlushIcache();
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -6,7 +6,6 @@
 #include <array>
 #include <cstddef>
 #include <iosfwd>
-#include <map>
 #include <string_view>
 #include <unordered_set>
 #include <utility>
@@ -20,6 +19,12 @@
 #include "Core/ConfigManager.h"
 #include "Core/MachineContext.h"
 #include "Core/PowerPC/CPUCoreBase.h"
+#ifdef _M_X86_64
+#include "Core/PowerPC/Jit64Common/TrampolineInfo.h"
+#endif
+#ifdef _M_ARM_64
+#include "Core/PowerPC/JitArm64/FastmemArea.h"
+#endif
 #include "Core/PowerPC/JitCommon/JitAsmCommon.h"
 #include "Core/PowerPC/JitCommon/JitCache.h"
 #include "Core/PowerPC/PPCAnalyst.h"
@@ -99,8 +104,8 @@ protected:
     u32 downcountAmount;
     u32 numLoadStoreInst;
     u32 numFloatingPointInst;
-    // If this is set, we need to generate an exception handler for the fastmem load.
-    u8* fastmemLoadStore;
+    // If this is true, we need to generate an exception handler for the fastmem load.
+    bool fastmemLoadStore;
     // If this is set, a load or store already prepared a jump to the exception handler for us,
     // so just fixup that branch instead of testing for a DSI again.
     bool fixupExceptionHandler;
@@ -131,6 +136,14 @@ protected:
     std::unordered_set<u32> fifoWriteAddresses;
     std::unordered_set<u32> pairedQuantizeAddresses;
     std::unordered_set<u32> noSpeculativeConstantsAddresses;
+
+    // Insert as a batch when finalizing the block, minimizing map accesses.
+#ifdef _M_X86_64
+    std::vector<TrampolineInfo> back_patch_info_temp;
+#endif
+#ifdef _M_ARM_64
+    std::vector<FastmemArea> fault_to_handler_temp;
+#endif
   };
 
   PPCAnalyst::CodeBlock code_block;


### PR DESCRIPTION
Tested pausing and unpausing repeatedly in NBA Live 2005.

Before:
<img width="1104" height="557" alt="JIT_before" src="https://github.com/user-attachments/assets/8fbc5d69-656c-4416-8b37-db4fa376de94" />

After:
<img width="1104" height="557" alt="JIT_after_trampoline_optimization" src="https://github.com/user-attachments/assets/51eab767-b079-47fd-a54f-9574f2a7d5ca" />

As you can see, the slowest function (allocating to the trampoline info map) is just gone from the profiling, and the improvement is noticeable.

ARM is untested.

This PR adds a dependency for a cursory feature. It's waiting for #14793 (which is why it's a draft). See discussion on #14852.