### PR TITLE
Android: Add reset item to emulation menu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.kt
@@ -367,6 +367,9 @@ object NativeLibrary {
     external fun PauseEmulation(overrideAchievementRestrictions: Boolean)
 
     @JvmStatic
+    external fun ResetEmulation()
+
+    @JvmStatic
     external fun StopEmulation()
 
   /**

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.kt
@@ -525,6 +525,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
             MENU_ACTION_SKYLANDERS -> showSkylanderPortalSettings()
             MENU_ACTION_INFINITY_BASE -> showInfinityBaseSettings()
             MENU_ACTION_EXIT -> emulationFragment!!.stopEmulation()
+            MENU_ACTION_RESET -> emulationFragment!!.resetEmulation()
         }
     }
 
@@ -1084,6 +1085,7 @@ class EmulationActivity : AppCompatActivity(), ThemeProvider {
         const val MENU_ACTION_SKYLANDERS = 36
         const val MENU_ACTION_INFINITY_BASE = 37
         const val MENU_ACTION_LATCHING_CONTROLS = 38
+        const val MENU_ACTION_RESET = 39;
 
         init {
             buttonsActionsMap.apply {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.kt
@@ -165,6 +165,11 @@ class EmulationFragment : Fragment(), SurfaceHolder.Callback {
         runWhenSurfaceIsValid = true
     }
 
+    fun resetEmulation() {
+        Log.debug("[EmulationFragment] Resetting emulation.")
+        NativeLibrary.ResetEmulation()
+    }
+
     fun stopEmulation() {
         Log.debug("[EmulationFragment] Stopping emulation.")
         NativeLibrary.StopEmulation()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.kt
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.kt
@@ -76,6 +76,7 @@ class MenuFragment : Fragment(), View.OnClickListener {
             button.setOnClickListener(this)
         }
 
+        binding.menuReset.setOnClickListener(this)
         binding.menuExit.setOnClickListener(this)
 
         val title = requireArguments().getString(KEY_TITLE, null)
@@ -199,6 +200,7 @@ class MenuFragment : Fragment(), View.OnClickListener {
                 EmulationActivity.MENU_ACTION_CHANGE_DISC
             )
             buttonsActionsMap.append(R.id.menu_exit, EmulationActivity.MENU_ACTION_EXIT)
+            buttonsActionsMap.append(R.id.menu_reset, EmulationActivity.MENU_ACTION_RESET)
             buttonsActionsMap.append(R.id.menu_settings, EmulationActivity.MENU_ACTION_SETTINGS)
             buttonsActionsMap.append(R.id.menu_skylanders, EmulationActivity.MENU_ACTION_SKYLANDERS)
             buttonsActionsMap.append(

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -111,6 +111,11 @@
                 android:text="@string/emulate_infinity_base"
                 style="@style/InGameMenuOption" />
 
+            <Button
+                android:id="@+id/menu_reset"
+                style="@style/InGameMenuOption"
+                android:text="@string/emulation_reset" />
+
         </LinearLayout>
 
     </ScrollView>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -630,6 +630,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_screenshot">Take Screenshot</string>
     <string name="emulation_savestate">Save State</string>
     <string name="emulation_loadstate">Load State</string>
+    <string name="emulation_reset">Reset Emulation</string>
     <string name="emulation_exit">Exit Emulation</string>
     <string name="emulation_state_slot">Slot %1$d\n\n%2$s</string>
     <string name="emulation_state_slot_empty">Slot %1$d\n\nEmpty</string>

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -42,6 +42,7 @@
 #include "Core/Core.h"
 #include "Core/DolphinAnalytics.h"
 #include "Core/HW/DVD/DVDInterface.h"
+#include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/Host.h"
@@ -249,6 +250,11 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulati
 {
   Core::SetState(Core::System::GetInstance(), Core::State::Paused, true,
                  override_achievement_restrictions);
+}
+
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ResetEmulation(JNIEnv*, jclass)
+{
+  Core::System::GetInstance().GetProcessorInterface().ResetButton_Tap();
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulation(JNIEnv*, jclass)


### PR DESCRIPTION
Just adds the reset action to the Android app.

Demo:

[reset-demo.webm](https://github.com/user-attachments/assets/8852c43b-2733-4f80-a0bb-d6d19bf3f391)
