### PR TITLE
Flatpak: Fix Discord rich presence

### DIFF
--- a/Flatpak/dolphin-emu-wrapper
+++ b/Flatpak/dolphin-emu-wrapper
@@ -3,6 +3,11 @@
 # https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)#flatpak-applications
 for i in {0..9}; do
   test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+  # Do the same for Discord Canary as a fallback
+  # (will only stick if available during startup)
+  test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.DiscordCanary,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+  # Make any dangling links use the stable Discord though
+  test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
 dolphin-emu "$@"

--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -14,6 +14,8 @@ finish-args:
   # required for the emulated bluetooth adapter feature to work.
   - --allow=bluetooth
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  # also consider Discord Canary for rich presence
+  - --filesystem=xdg-run/app/com.discordapp.DiscordCanary:create
   - --filesystem=xdg-run/discord-ipc-0:create
   # required to disable the screensaver in various desktops
   - --talk-name=org.freedesktop.ScreenSaver

--- a/Flatpak/org.DolphinEmu.dolphin-emu.yml
+++ b/Flatpak/org.DolphinEmu.dolphin-emu.yml
@@ -16,7 +16,7 @@ finish-args:
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   # also consider Discord Canary for rich presence
   - --filesystem=xdg-run/app/com.discordapp.DiscordCanary:create
-  - --filesystem=xdg-run/discord-ipc-0:create
+  - --filesystem=xdg-run/discord-ipc-0
   # required to disable the screensaver in various desktops
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.xfce.ScreenSaver


### PR DESCRIPTION
The main goal of this PR is to support Flatpak install of the `beta` branch of Discord (Discord Canary) for rich presence. The way I propose it, a Discord Canary Flatpak running while Dolphin is started using the Dolphin wrapper should be picked up if no stable (or native) version of Discord is running at the same time.

The flow works as follows (if `$XDG_RUNTIME_DIR/discord-ipc-0` starts out as a regular file, directory, or is non-existent; assuming no symlinks exist inside the sandbox yet):
- If only the stable Discord Flatpak is running with, e.g., its `discord-ipc-0` socket exposed in `$XDG_RUNTIME_DIR/app/com.discordapp.Discord`, then the first `test ... || ln -sf ...` line will see that `$XDG_RUNTIME_DIR/discord-ipc-0` is not a socket and will thus make it point to `$XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-0`. The subsequent two lines would run the `test` and see that the file represented by `$XDG_RUNTIME_DIR/discord-ipc-0` is indeed now a socket, and will not change the symlink(s).
- If only the beta Discord Canary Flatpak is running with its  `discord-ipc-0` socket exposed in `$XDG_RUNTIME_DIR/app/com.discordapp.DiscordCanary`, then the first `test ... || ln -sf ...` line will see that `$XDG_RUNTIME_DIR/discord-ipc-0` is not a socket and will thus make it point to `$XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-0` (same as above). The second `test` line will test `$XDG_RUNTIME_DIR/discord-ipc-0` again, and see that it is not a socket due to being a broken symlink. The `ln -sf ...` part will now make `$XDG_RUNTIME_DIR/discord-ipc-0` point to `$XDG_RUNTIME_DIR/app/com.discordapp.DiscordCanary/discord-ipc-0`, which is the socket of Discord Canary. Thus, the third `test` line will return early and not change the symlink again.
- If both stable and beta Discord Flatpak versions are running, the stable version should take precedence as it is the first candidate symlink target.
- If none of the two Discord Flatpak versions are running, the third `test` line ensures that `$XDG_RUNTIME_DIR/discord-ipc-0` ends up pointing at `$XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-0` (the stable version's socket location) with a dangling symlink, prioritizing the stable installation. Since the entire `xdg-run/app/com.discordapp.Discord:create` directory is exposed, launching the stable Discord Flatpak at a later time should make the symlink point to its socket.

Now, while looking at this, I noticed that the other `--filesystem=xdg-run/discord-ipc-0:create` flag, which is intended to expose a non-Flatpak Discord socket, is wrong. Due to the `:create` suffix, if Discord is not running, a directory will be created rather than a socket, breaking rich presence. The path must not be treated as a directory, which is why the suffix was removed. It now behaves like this: If the socket file exists, it is exposed to the Dolphin Flatpak, and if it does not exist, a `0-byte` regular file is created inside Dolphin's sandbox, which can then be symlinked to point to something else by the wrapper. It should be noted that exposing the single native `discord-ipc-0` socket (out of up to 10 potential sockets) is not exactly the best solution for this, and also only gets correctly forwarded into the sandbox if Discord is already running (which is similar to the proposed Canary case).

Evidence of `:create` being a problem:
```
Error: listen EADDRINUSE: address already in use /run/user/1000/discord-ipc-0
```

Related PR: #14120